### PR TITLE
Implement the `eth_sendRawTransaction` JSON-RPC endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -7,18 +7,21 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-evm-gateway/storage"
+	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/access"
+
+	sdkCrypto "github.com/onflow/flow-go-sdk/crypto"
 )
 
 const EthNamespace = "eth"
@@ -32,6 +35,9 @@ var (
 
 //go:embed cadence/scripts/bridged_account_call.cdc
 var bridgedAccountCall []byte
+
+//go:embed cadence/transactions/evm_run.cdc
+var evmRunTx []byte
 
 func SupportedAPIs(blockChainAPI *BlockChainAPI) []rpc.API {
 	return []rpc.API{
@@ -101,7 +107,69 @@ func (api *BlockChainAPI) SendRawTransaction(
 	ctx context.Context,
 	input hexutil.Bytes,
 ) (common.Hash, error) {
-	return crypto.Keccak256Hash([]byte("hello world")), nil
+	gethTx := &types.Transaction{}
+	encodedLen := uint(len(input))
+	err := gethTx.DecodeRLP(
+		rlp.NewStream(
+			bytes.NewReader(input),
+			uint64(encodedLen),
+		),
+	)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	block, err := api.FlowClient.GetLatestBlock(context.Background(), true)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	privateKey, err := sdkCrypto.DecodePrivateKeyHex(sdkCrypto.ECDSA_P256, strings.Replace("2619878f0e2ff438d17835c2a4561cb87b4d24d72d12ec34569acd0dd4af7c21", "0x", "", 1))
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	account, err := api.FlowClient.GetAccount(context.Background(), flow.HexToAddress("0xf8d6e0586b0a20c7"))
+	if err != nil {
+		return common.Hash{}, err
+	}
+	accountKey := account.Keys[0]
+	signer, err := sdkCrypto.NewInMemorySigner(privateKey, accountKey.HashAlgo)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	tx := flow.NewTransaction().
+		SetScript(evmRunTx).
+		SetProposalKey(account.Address, accountKey.Index, accountKey.SequenceNumber).
+		SetReferenceBlockID(block.ID).
+		SetPayer(account.Address).
+		AddAuthorizer(account.Address)
+
+	decodedTx, err := hex.DecodeString(input.String()[2:])
+	if err != nil {
+		return common.Hash{}, err
+	}
+	cdcBytes := make([]cadence.Value, 0)
+	for _, bt := range decodedTx {
+		cdcBytes = append(cdcBytes, cadence.UInt8(bt))
+	}
+	encodedTx := cadence.NewArray(
+		cdcBytes,
+	).WithType(cadence.NewVariableSizedArrayType(cadence.TheUInt8Type))
+	tx.AddArgument(encodedTx)
+
+	err = tx.SignEnvelope(account.Address, accountKey.Index, signer)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	err = api.FlowClient.SendTransaction(ctx, *tx)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return gethTx.Hash(), nil
 }
 
 // eth_createAccessList

--- a/api/api.go
+++ b/api/api.go
@@ -124,11 +124,13 @@ func (api *BlockChainAPI) SendRawTransaction(
 		return common.Hash{}, err
 	}
 
+	// TODO(m-Peter): Fetch the private key from a dedicated flow.json config file
 	privateKey, err := sdkCrypto.DecodePrivateKeyHex(sdkCrypto.ECDSA_P256, strings.Replace("2619878f0e2ff438d17835c2a4561cb87b4d24d72d12ec34569acd0dd4af7c21", "0x", "", 1))
 	if err != nil {
 		return common.Hash{}, err
 	}
 
+	// // TODO(m-Peter): Fetch the address from a dedicated flow.json config file
 	account, err := api.FlowClient.GetAccount(context.Background(), flow.HexToAddress("0xf8d6e0586b0a20c7"))
 	if err != nil {
 		return common.Hash{}, err

--- a/api/cadence/transactions/evm_run.cdc
+++ b/api/cadence/transactions/evm_run.cdc
@@ -1,0 +1,16 @@
+// TODO(m-Peter): Use proper address for each network
+import EVM from 0xf8d6e0586b0a20c7
+
+transaction(encodedTx: [UInt8]) {
+    let bridgedAccount: &EVM.BridgedAccount
+
+    prepare(signer: auth(Storage) &Account) {
+        self.bridgedAccount = signer.storage.borrow<&EVM.BridgedAccount>(
+            from: /storage/evm
+        ) ?? panic("Could not borrow reference to the bridged account!")
+    }
+
+    execute {
+        EVM.run(tx: encodedTx, coinbase: self.bridgedAccount.address())
+    }
+}

--- a/api/fixtures/eth_json_rpc_requests.json
+++ b/api/fixtures/eth_json_rpc_requests.json
@@ -1,7 +1,6 @@
 {"jsonrpc":"2.0","id":1,"method":"eth_chainId","params": []}
 {"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params": []}
 {"jsonrpc":"2.0","id":1,"method":"eth_syncing","params": []}
-{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"]}
 {"jsonrpc":"2.0","id":1,"method":"eth_gasPrice","params":[]}
 {"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x407d73d8a49eeb85d32cf465507dd71d507100c1","latest"]}
 {"jsonrpc":"2.0","id":1,"method":"eth_getCode","params":["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b","0x2"]}

--- a/api/fixtures/eth_json_rpc_responses.json
+++ b/api/fixtures/eth_json_rpc_responses.json
@@ -1,7 +1,6 @@
 {"jsonrpc":"2.0","id":1,"result":"0x29a"}
 {"jsonrpc":"2.0","id":1,"result":"0x0"}
 {"jsonrpc":"2.0","id":1,"result":false}
-{"jsonrpc":"2.0","id":1,"result":"0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad"}
 {"jsonrpc":"2.0","id":1,"result":"0x1dfd14000"}
 {"jsonrpc":"2.0","id":1,"result":"0x65"}
 {"jsonrpc":"2.0","id":1,"result":"0x600160008035811a818181146012578301005b601b6001356025565b8060005260206000f25b600060078202905091905056"}


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/2

## Description

Functionality to send raw EVM transactions.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 