### PR TITLE
Make value returned by `eth_gasPrice` configurable

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -25,7 +25,7 @@ import (
 )
 
 const EthNamespace = "eth"
-const defaultGasPrice = 8049999872
+const DefaultGasPrice = 8049999872
 
 // TODO: Fetch these from flow-go/fvm/evm/emulator/config.go
 var (
@@ -211,7 +211,7 @@ func (s *BlockChainAPI) FeeHistory(
 // eth_gasPrice (returns the gas price)
 // GasPrice returns a suggestion for a gas price for legacy transactions.
 func (s *BlockChainAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
-	return (*hexutil.Big)(big.NewInt(defaultGasPrice)), nil
+	return (*hexutil.Big)(s.config.GasPrice), nil
 }
 
 // eth_maxPriorityFeePerGas

--- a/api/api.go
+++ b/api/api.go
@@ -25,7 +25,6 @@ import (
 )
 
 const EthNamespace = "eth"
-const DefaultGasPrice = 8049999872
 
 // TODO: Fetch these from flow-go/fvm/evm/emulator/config.go
 var (

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -177,10 +177,17 @@ func TestBlockChainAPI(t *testing.T) {
 	})
 
 	t.Run("GasPrice", func(t *testing.T) {
+		config := &api.Config{
+			ChainID:  api.FlowEVMTestnetChainID,
+			Coinbase: common.HexToAddress("0xf02c1c8e6114b1dbe8937a39260b5b0a374432bb"),
+			GasPrice: big.NewInt(5049999872),
+		}
+		blockchainAPI := api.NewBlockChainAPI(config, store, flowClient)
+
 		gasPrice, err := blockchainAPI.GasPrice(context.Background())
 		require.NoError(t, err)
 
-		assert.Equal(t, gasPrice, (*hexutil.Big)(big.NewInt(8049999872)))
+		assert.Equal(t, gasPrice, (*hexutil.Big)(big.NewInt(5049999872)))
 	})
 
 	t.Run("MaxPriorityFeePerGas", func(t *testing.T) {

--- a/api/config.go
+++ b/api/config.go
@@ -6,6 +6,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+var DefaultGasPrice = big.NewInt(8049999872)
+
 // TODO(m-Peter) Add more config options, such as:
 // - host
 // - port

--- a/api/config.go
+++ b/api/config.go
@@ -15,4 +15,5 @@ import (
 type Config struct {
 	ChainID  *big.Int
 	Coinbase common.Address
+	GasPrice *big.Int
 }

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"io"
-	"math/big"
 	"net/http"
 	"strings"
 	"testing"
@@ -41,7 +40,7 @@ func TestServerJSONRPCOveHTTPHandler(t *testing.T) {
 	config := &api.Config{
 		ChainID:  api.FlowEVMTestnetChainID,
 		Coinbase: common.HexToAddress("0xf02c1c8e6114b1dbe8937a39260b5b0a374432bb"),
-		GasPrice: big.NewInt(api.DefaultGasPrice),
+		GasPrice: api.DefaultGasPrice,
 	}
 	blockchainAPI := api.NewBlockChainAPI(config, store, mockFlowClient)
 	supportedAPIs := api.SupportedAPIs(blockchainAPI)
@@ -232,7 +231,7 @@ func TestServerJSONRPCOveWebSocketHandler(t *testing.T) {
 	config := &api.Config{
 		ChainID:  api.FlowEVMTestnetChainID,
 		Coinbase: common.HexToAddress("0xf02c1c8e6114b1dbe8937a39260b5b0a374432bb"),
-		GasPrice: big.NewInt(api.DefaultGasPrice),
+		GasPrice: api.DefaultGasPrice,
 	}
 	flowClient, err := api.NewFlowClient(grpc.EmulatorHost)
 	require.NoError(t, err)

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"io"
+	"math/big"
 	"net/http"
 	"strings"
 	"testing"
@@ -40,6 +41,7 @@ func TestServerJSONRPCOveHTTPHandler(t *testing.T) {
 	config := &api.Config{
 		ChainID:  api.FlowEVMTestnetChainID,
 		Coinbase: common.HexToAddress("0xf02c1c8e6114b1dbe8937a39260b5b0a374432bb"),
+		GasPrice: big.NewInt(api.DefaultGasPrice),
 	}
 	blockchainAPI := api.NewBlockChainAPI(config, store, mockFlowClient)
 	supportedAPIs := api.SupportedAPIs(blockchainAPI)
@@ -230,6 +232,7 @@ func TestServerJSONRPCOveWebSocketHandler(t *testing.T) {
 	config := &api.Config{
 		ChainID:  api.FlowEVMTestnetChainID,
 		Coinbase: common.HexToAddress("0xf02c1c8e6114b1dbe8937a39260b5b0a374432bb"),
+		GasPrice: big.NewInt(api.DefaultGasPrice),
 	}
 	flowClient, err := api.NewFlowClient(grpc.EmulatorHost)
 	require.NoError(t, err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	flag.StringVar(&network, "network", "testnet", "network to connect the gateway to")
 	flag.StringVar(&coinbase, "coinbase", coinbaseAddr, "coinbase address to use for fee collection")
-	flag.Int64Var(&gasPrice, "gasPrice", api.DefaultGasPrice, "gas price for transactions")
+	flag.Int64Var(&gasPrice, "gasPrice", api.DefaultGasPrice.Int64(), "gas price for transactions")
 	flag.Parse()
 
 	config := &api.Config{

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math/big"
 	"runtime"
 	"time"
 
@@ -33,13 +34,17 @@ var evmEventTypes = []string{
 
 func main() {
 	var network, coinbase string
+	var gasPrice int64
 
 	flag.StringVar(&network, "network", "testnet", "network to connect the gateway to")
 	flag.StringVar(&coinbase, "coinbase", coinbaseAddr, "coinbase address to use for fee collection")
+	flag.Int64Var(&gasPrice, "gasPrice", api.DefaultGasPrice, "gas price for transactions")
 	flag.Parse()
 
-	config := &api.Config{}
-	config.Coinbase = common.HexToAddress(coinbase)
+	config := &api.Config{
+		Coinbase: common.HexToAddress(coinbase),
+		GasPrice: big.NewInt(gasPrice),
+	}
 	if network == "testnet" {
 		config.ChainID = api.FlowEVMTestnetChainID
 	} else if network == "mainnet" {


### PR DESCRIPTION
Work towards: https://github.com/onflow/flow-evm-gateway/issues/2

## Description

Allow configuration of value returned by the `eth_gasPrice` JSON-RPC endpoint.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 