### PR TITLE
Setup improvements for running the Flow EVM Gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,15 @@ generate:
 
 .PHONY: ci
 ci: check-tidy test
+
+.PHONY: start-emulator
+start-emulator:
+	./flow-x86_64-linux- emulator --evm-enabled
+
+.PHONY: setup-account
+setup-account:
+	./flow-x86_64-linux- transactions send api/cadence/transactions/create_bridged_account.cdc 1500.0 --network=emulator --signer=emulator-account
+
+.PHONY: start
+start:
+	go run ./cmd/server/main.go

--- a/api/cadence/transactions/create_bridged_account.cdc
+++ b/api/cadence/transactions/create_bridged_account.cdc
@@ -1,0 +1,26 @@
+import EVM from 0xf8d6e0586b0a20c7 // todo dynamically set
+import FungibleToken from 0xee82856bf20e2aa6
+import FlowToken from 0x0ae53cb6e3f42a79
+
+transaction(amount: UFix64) {
+    let sentVault: @FlowToken.Vault
+    let auth: auth(Storage) &Account
+
+    prepare(signer: auth(Storage) &Account) {
+        let vaultRef = signer.storage.borrow<auth(FungibleToken.Withdrawable) &FlowToken.Vault>(
+            from: /storage/flowTokenVault
+        ) ?? panic("Could not borrow reference to the owner's Vault!")
+
+        self.sentVault <- vaultRef.withdraw(amount: amount) as! @FlowToken.Vault
+        self.auth = signer
+    }
+
+    execute {
+        let account <- EVM.createBridgedAccount()
+        log(account.address())
+        account.deposit(from: <-self.sentVault)
+
+        log(account.balance().flow)
+        self.auth.storage.save<@EVM.BridgedAccount>(<-account, to: StoragePath(identifier: "evm")!)
+    }
+}

--- a/flow.json
+++ b/flow.json
@@ -1,0 +1,18 @@
+{
+  "contracts": {},
+  "networks": {
+    "emulator": "127.0.0.1:3569",
+    "testing": "127.0.0.1:3569"
+  },
+  "accounts": {
+    "emulator-account": {
+      "address": "0xf8d6e0586b0a20c7",
+      "key": "2619878f0e2ff438d17835c2a4561cb87b4d24d72d12ec34569acd0dd4af7c21"
+    }
+  },
+  "deployments": {
+    "emulator": {
+      "emulator-account": []
+    }
+  }
+}


### PR DESCRIPTION
## Description

- Adds a `make` recipe to setup the service account with a COA
- Adds a `make` recipe to start the emulator with the `--evm-enabled` feature flag
- Adds a `make` recipe to start the Flow EVM Gateway
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 