### PR TITLE
Add `net` and `web3` namespaces

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -22,7 +22,11 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 )
 
-const EthNamespace = "eth"
+const (
+	EthNamespace  = "eth"
+	Web3Namespace = "web3"
+	NetNamespace  = "net"
+)
 
 // TODO: Fetch these from flow-go/fvm/evm/emulator/config.go
 var (
@@ -44,6 +48,14 @@ func SupportedAPIs(blockChainAPI *BlockChainAPI) []rpc.API {
 		{
 			Namespace: EthNamespace,
 			Service:   blockChainAPI,
+		},
+		{
+			Namespace: Web3Namespace,
+			Service:   &Web3API{},
+		},
+		{
+			Namespace: NetNamespace,
+			Service:   &NetAPI{},
 		},
 	}
 }

--- a/api/net_api.go
+++ b/api/net_api.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// NetAPI offers network related RPC methods
+type NetAPI struct{}
+
+// Listening returns an indication if the node is
+// listening for network connections.
+func (s *NetAPI) Listening() bool {
+	return true // always listening
+}
+
+// PeerCount returns the number of connected peers
+func (s *NetAPI) PeerCount() hexutil.Uint {
+	return 1
+}
+
+// Version returns the current ethereum protocol version.
+func (s *NetAPI) Version() string {
+	return fmt.Sprintf("%d", 666)
+}

--- a/api/server.go
+++ b/api/server.go
@@ -24,7 +24,7 @@ type rpcHandler struct {
 }
 
 type httpServer struct {
-	log      zerolog.Logger
+	logger   zerolog.Logger
 	timeouts rpc.HTTPTimeouts
 
 	server   *http.Server
@@ -46,9 +46,9 @@ const (
 	shutdownTimeout = 5 * time.Second
 )
 
-func NewHTTPServer(log zerolog.Logger, timeouts rpc.HTTPTimeouts) *httpServer {
+func NewHTTPServer(logger zerolog.Logger, timeouts rpc.HTTPTimeouts) *httpServer {
 	return &httpServer{
-		log:      log,
+		logger:   logger,
 		timeouts: timeouts,
 	}
 }
@@ -153,7 +153,7 @@ func (h *httpServer) Start() error {
 	// Initialize the server.
 	h.server = &http.Server{Handler: h}
 	if h.timeouts != (rpc.HTTPTimeouts{}) {
-		CheckTimeouts(h.log, &h.timeouts)
+		CheckTimeouts(h.logger, &h.timeouts)
 		h.server.ReadTimeout = h.timeouts.ReadTimeout
 		h.server.ReadHeaderTimeout = h.timeouts.ReadHeaderTimeout
 		h.server.WriteTimeout = h.timeouts.WriteTimeout
@@ -174,12 +174,11 @@ func (h *httpServer) Start() error {
 	go h.server.Serve(listener)
 
 	if h.rpcAllowed() {
-		log.Info().Msg(fmt.Sprintf("JSON-RPC over HTTP enabled: %v/rpc", listener.Addr()))
+		h.logger.Info().Msgf("JSON-RPC over HTTP enabled: %s", listener.Addr())
 	}
 
 	if h.wsAllowed() {
-		url := fmt.Sprintf("ws://%v/ws", listener.Addr())
-		log.Info().Msg(fmt.Sprint("JSON-RPC over WebSocket enabled: ", url))
+		h.logger.Info().Msgf("JSON-RPC over WebSocket enabled: %s", listener.Addr())
 	}
 
 	return nil
@@ -200,7 +199,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Check if WebSocket request and serve if JSON-RPC over WebSocket is enabled
 	ws := h.wsHandler
 	if ws != nil && isWebSocket(r) {
-		if checkPath(r, "/ws") {
+		if checkPath(r, "") {
 			ws.ServeHTTP(w, r)
 			return
 		}
@@ -209,7 +208,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// If JSON-RPC over HTTP is enabled, try to serve the request
 	rpc := h.httpHandler
 	if rpc != nil {
-		if checkPath(r, "/rpc") {
+		if checkPath(r, "") {
 			rpc.ServeHTTP(w, r)
 			return
 		}

--- a/api/web3_api.go
+++ b/api/web3_api.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Web3API offers helper utils
+type Web3API struct{}
+
+// ClientVersion returns the node name
+func (s *Web3API) ClientVersion() string {
+	return "flow-evm-gateway@v1.13.5"
+}
+
+// Sha3 applies the ethereum sha3 implementation on the input.
+// It assumes the input is hex encoded.
+func (s *Web3API) Sha3(input hexutil.Bytes) hexutil.Bytes {
+	return crypto.Keccak256(input)
+}


### PR DESCRIPTION
## Description

Adds the following JSON-RPC endpoints:
- `net_listening`
- `net_peerCount`
- `net_version`
- `web3_clientVersion`
- `web3_sha3`

`web3.js` makes use of some of the above.

Documentation with instructions on running the gateway locally as added, as well as a list of ready JSON-RPC calls to executed.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 