### PR TITLE
Update bash script to use `canarynet` instead of `canary`

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ "$FLOW_NETWORK" = "testnet" ] || [ "$FLOW_NETWORK" = "mainnet" ] || [ "$FLOW_NETWORK" = "canary" ] || [ "$FLOW_NETWORK" = "crescendo" ]; then
+if [ "$FLOW_NETWORK" = "testnet" ] || [ "$FLOW_NETWORK" = "mainnet" ] || [ "$FLOW_NETWORK" = "canarynet" ] || [ "$FLOW_NETWORK" = "crescendo" ]; then
   ./evm-gateway --network=$FLOW_NETWORK
 else 
   # Start the first process & redirect output to a temporary file


### PR DESCRIPTION
## Description

The CLI flag condition (https://github.com/onflow/flow-evm-gateway/blob/main/cmd/server/main.go#L60-L62) checks against a value of `canarynet` instead of `canary`.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 