### PR TITLE
Implement the `eth_estimateGas` JSON-RPC endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -504,7 +504,7 @@ func (b *BlockChainAPI) EstimateGas(
 		data = *args.Input
 	}
 
-	eoa := newEOATestAccount()
+	eoa := newEOATestAccount(b.config.COAKey.String()[2:])
 	txData := eoa.PrepareSignAndEncodeTx(
 		args.To,
 		data,

--- a/api/eoa_test_account.go
+++ b/api/eoa_test_account.go
@@ -12,9 +12,6 @@ import (
 	"github.com/onflow/flow-go/fvm/evm/emulator"
 )
 
-// address:  658bdf435d810c91414ec09147daa6db62406379
-const eoaTestAccount1KeyHex = "9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
-
 type eoaTestAccount struct {
 	address gethCommon.Address
 	key     *ecdsa.PrivateKey
@@ -65,8 +62,8 @@ func (a *eoaTestAccount) prepareAndSignTx(
 	return tx
 }
 
-func newEOATestAccount() *eoaTestAccount {
-	key, _ := gethCrypto.HexToECDSA(eoaTestAccount1KeyHex)
+func newEOATestAccount(keyHex string) *eoaTestAccount {
+	key, _ := gethCrypto.HexToECDSA(keyHex)
 	address := gethCrypto.PubkeyToAddress(key.PublicKey)
 	signer := emulator.GetDefaultSigner()
 

--- a/api/eoa_test_account.go
+++ b/api/eoa_test_account.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"io"
+	"math/big"
+
+	gethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	gethCrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/onflow/flow-go/fvm/evm/emulator"
+)
+
+// address:  658bdf435d810c91414ec09147daa6db62406379
+const eoaTestAccount1KeyHex = "9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
+
+type eoaTestAccount struct {
+	address gethCommon.Address
+	key     *ecdsa.PrivateKey
+	signer  types.Signer
+}
+
+func (a *eoaTestAccount) PrepareSignAndEncodeTx(
+	to *gethCommon.Address,
+	data []byte,
+	amount *big.Int,
+	gasLimit uint64,
+	gasPrice *big.Int,
+) []byte {
+	tx := a.prepareAndSignTx(to, data, amount, gasLimit, gasPrice)
+
+	var b bytes.Buffer
+	writer := io.Writer(&b)
+	err := tx.EncodeRLP(writer)
+	if err != nil {
+		panic(err)
+	}
+
+	return b.Bytes()
+}
+
+func (a *eoaTestAccount) prepareAndSignTx(
+	to *gethCommon.Address,
+	data []byte,
+	amount *big.Int,
+	gasLimit uint64,
+	gasPrice *big.Int,
+) *types.Transaction {
+	tx := types.NewTx(
+		&types.LegacyTx{
+			Nonce:    0,
+			To:       to,
+			Value:    amount,
+			Gas:      gasLimit,
+			GasPrice: gasPrice,
+			Data:     data,
+		},
+	)
+	tx, err := types.SignTx(tx, a.signer, a.key)
+	if err != nil {
+		panic(err)
+	}
+
+	return tx
+}
+
+func newEOATestAccount() *eoaTestAccount {
+	key, _ := gethCrypto.HexToECDSA(eoaTestAccount1KeyHex)
+	address := gethCrypto.PubkeyToAddress(key.PublicKey)
+	signer := emulator.GetDefaultSigner()
+
+	return &eoaTestAccount{
+		address: address,
+		key:     key,
+		signer:  signer,
+	}
+}

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/onflow/flow-evm-gateway/bootstrap"
 	"github.com/onflow/flow-evm-gateway/config"
@@ -458,6 +459,16 @@ func TestIntegration_API_DeployEvents(t *testing.T) {
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)
+
+	// estimate gas
+	gasUsed, err := rpcTester.estimateGas(fundEOAAddress, deployData, 200_000)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "contract creation code storage out of gas")
+	assert.Equal(t, hexutil.Uint64(0), gasUsed)
+
+	gasUsed, err = rpcTester.estimateGas(fundEOAAddress, deployData, 250_000)
+	require.NoError(t, err)
+	assert.Equal(t, hexutil.Uint64(215_324), gasUsed)
 
 	// check balance
 	balance, err := rpcTester.getBalance(fundEOAAddress)

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -534,6 +534,33 @@ func (r *rpcTest) getBalance(address common.Address) (*hexutil.Big, error) {
 	return &u, nil
 }
 
+func (r *rpcTest) estimateGas(
+	from common.Address,
+	data []byte,
+	gas uint64,
+) (hexutil.Uint64, error) {
+	rpcRes, err := r.request(
+		"eth_estimateGas",
+		fmt.Sprintf(
+			`[{"from":"%s","data":"0x%s","gas":"%s"}]`,
+			from.Hex(),
+			hex.EncodeToString(data),
+			hexutil.Uint64(gas),
+		),
+	)
+	if err != nil {
+		return hexutil.Uint64(0), err
+	}
+
+	var gasUsed hexutil.Uint64
+	err = json.Unmarshal(rpcRes, &gasUsed)
+	if err != nil {
+		return hexutil.Uint64(0), err
+	}
+
+	return gasUsed, nil
+}
+
 func uintHex(x uint64) string {
 	return fmt.Sprintf("0x%x", x)
 }

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -537,7 +537,7 @@ func (r *rpcTest) getBalance(address common.Address) (*hexutil.Big, error) {
 func (r *rpcTest) estimateGas(
 	from common.Address,
 	data []byte,
-	gas uint64,
+	gasLimit uint64,
 ) (hexutil.Uint64, error) {
 	rpcRes, err := r.request(
 		"eth_estimateGas",
@@ -545,7 +545,7 @@ func (r *rpcTest) estimateGas(
 			`[{"from":"%s","data":"0x%s","gas":"%s"}]`,
 			from.Hex(),
 			hex.EncodeToString(data),
-			hexutil.Uint64(gas),
+			hexutil.Uint64(gasLimit),
 		),
 	)
 	if err != nil {

--- a/services/requester/cadence/estimate_gas.cdc
+++ b/services/requester/cadence/estimate_gas.cdc
@@ -1,0 +1,11 @@
+import EVM
+
+access(all)
+fun main(encodedTx: [UInt8]): [UInt64; 2] {
+    let coa <- EVM.createCadenceOwnedAccount()
+    let txResult = EVM.run(tx: encodedTx, coinbase: coa.address())
+
+    destroy <- coa
+
+    return [txResult.errorCode, txResult.gasUsed]
+}

--- a/services/requester/cadence/estimate_gas.cdc
+++ b/services/requester/cadence/estimate_gas.cdc
@@ -2,10 +2,12 @@ import EVM
 
 access(all)
 fun main(encodedTx: [UInt8]): [UInt64; 2] {
-    let coa <- EVM.createCadenceOwnedAccount()
-    let txResult = EVM.run(tx: encodedTx, coinbase: coa.address())
+    let account = getAuthAccount<auth(Storage) &Account>(Address(0xCOA))
 
-    destroy <- coa
+    let coa = account.storage.borrow<&EVM.CadenceOwnedAccount>(
+        from: /storage/evm
+    ) ?? panic("Could not borrow reference to the COA!")
+    let txResult = EVM.run(tx: encodedTx, coinbase: coa.address())
 
     return [txResult.errorCode, txResult.gasUsed]
 }

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -280,6 +280,8 @@ func (e *EVM) EstimateGas(ctx context.Context, data []byte) (uint64, error) {
 	}
 
 	// sanity check, should never occur
+	// TODO(m-Peter): Consider adding a decoder for EVM.Result struct
+	// to a Go value/type.
 	if _, ok := value.(cadence.Array); !ok {
 		e.logger.Panic().Msg(fmt.Sprintf("failed to convert value to array: %v", value))
 	}
@@ -367,6 +369,7 @@ func bytesFromCadenceArray(value cadence.Value) ([]byte, error) {
 	return res, nil
 }
 
+// TODO(m-Peter): Consider moving this to flow-go repository
 func getErrorForCode(errorCode uint64) error {
 	switch evmTypes.ErrorCode(errorCode) {
 	case evmTypes.ValidationErrCodeInvalidBalance:

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -128,6 +128,9 @@ func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash,
 			uint64(len(data)),
 		),
 	)
+	if err != nil {
+		return common.Hash{}, err
+	}
 
 	// todo make sure the gas price is not bellow the configured gas price
 	flowID, err := e.signAndSend(


### PR DESCRIPTION
Residual from: https://github.com/onflow/flow-evm-gateway/issues/9

## Description

Utilizes the new interface of `EVM.run` inside a Cadence script, to run an EVM transaction in order to retrieve the gas consumption and any possible failures. No state change occurs.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 