### PR TITLE
Revert "[Indexer] Decoding of event values"

### DIFF
--- a/models/block.go
+++ b/models/block.go
@@ -1,0 +1,51 @@
+package models
+
+import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/onflow/cadence"
+	cdcCommon "github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/flow-go/fvm/evm/types"
+)
+
+var blockExecutedType = (types.EVMLocation{}).TypeID(nil, string(types.EventTypeBlockExecuted))
+
+type blockEventPayload struct {
+	Height            uint64           `cadence:"height"`
+	Hash              string           `cadence:"hash"`
+	TotalSupply       cadence.Int      `cadence:"totalSupply"`
+	ParentBlockHash   string           `cadence:"parentHash"`
+	ReceiptRoot       string           `cadence:"receiptRoot"`
+	TransactionHashes []cadence.String `cadence:"transactionHashes"`
+}
+
+// DecodeBlock takes a cadence event that contains executed block payload and
+// decodes it into the Block type.
+func DecodeBlock(event cadence.Event) (*types.Block, error) {
+	if cdcCommon.TypeID(event.EventType.ID()) != blockExecutedType {
+		return nil, fmt.Errorf(
+			"invalid event type for decoding into block, received %s expected %s",
+			event.Type().ID(),
+			types.EventTypeBlockExecuted,
+		)
+	}
+
+	var b blockEventPayload
+	err := cadence.DecodeFields(event, &b)
+	if err != nil {
+		return nil, err
+	}
+
+	hashes := make([]common.Hash, len(b.TransactionHashes))
+	for i, h := range b.TransactionHashes {
+		hashes[i] = common.HexToHash(h.ToGoValue().(string))
+	}
+
+	return &types.Block{
+		ParentBlockHash:   common.HexToHash(b.ParentBlockHash),
+		Height:            b.Height,
+		TotalSupply:       b.TotalSupply.Value,
+		ReceiptRoot:       common.HexToHash(b.ReceiptRoot),
+		TransactionHashes: hashes,
+	}, nil
+}

--- a/models/block_test.go
+++ b/models/block_test.go
@@ -1,0 +1,30 @@
+package models
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/onflow/flow-go/fvm/evm/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"testing"
+)
+
+func Test_DecodeBlockExecutedEvent(t *testing.T) {
+	block := &types.Block{
+		ParentBlockHash: common.HexToHash("0x1"),
+		Height:          100,
+		TotalSupply:     big.NewInt(100),
+		ReceiptRoot:     common.HexToHash("0x2"),
+		TransactionHashes: []common.Hash{
+			common.HexToHash("0xf1"),
+		},
+	}
+	ev := types.NewBlockExecutedEvent(block)
+
+	encEv, err := ev.Payload.CadenceEvent()
+	require.NoError(t, err)
+
+	decBlock, err := DecodeBlock(encEv)
+	require.NoError(t, err)
+	assert.Equal(t, block, decBlock)
+}

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -1,0 +1,106 @@
+package models
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/onflow/cadence"
+	cdcCommon "github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/flow-go/fvm/evm/types"
+	"math/big"
+)
+
+var txExecutedType = (types.EVMLocation{}).TypeID(nil, string(types.EventTypeTransactionExecuted))
+
+type txEventPayload struct {
+	BlockHeight             uint64 `cadence:"blockHeight"`
+	TransactionHash         string `cadence:"transactionHash"`
+	Transaction             string `cadence:"transaction"`
+	TransactionType         int    `cadence:"transactionType"`
+	Failed                  bool   `cadence:"failed"`
+	GasConsumed             uint64 `cadence:"gasConsumed"`
+	DeployedContractAddress string `cadence:"deployedContractAddress"`
+	ReturnedValue           string `cadence:"returnedValue"`
+	Logs                    string `cadence:"logs"`
+}
+
+// DecodeReceipt takes a cadence event for transaction executed and decodes it into the receipt.
+func DecodeReceipt(event cadence.Event) (*gethTypes.Receipt, error) {
+	if cdcCommon.TypeID(event.EventType.ID()) != txExecutedType {
+		return nil, fmt.Errorf(
+			"invalid event type for decoding into receipt, received %s expected %s",
+			event.Type().ID(),
+			types.EventTypeTransactionExecuted,
+		)
+	}
+
+	var tx txEventPayload
+	err := cadence.DecodeFields(event, &tx)
+	if err != nil {
+		return nil, err
+	}
+
+	encLogs, err := hex.DecodeString(tx.Logs)
+	if err != nil {
+		return nil, err
+	}
+
+	var logs []*gethTypes.Log
+	err = rlp.Decode(bytes.NewReader(encLogs), &logs)
+	if err != nil {
+		return nil, err
+	}
+
+	receipt := &gethTypes.Receipt{
+		Type:              0,              // todo check
+		Status:            0,              // todo check
+		CumulativeGasUsed: tx.GasConsumed, // todo check
+		Logs:              logs,
+		TxHash:            common.HexToHash(tx.TransactionHash),
+		ContractAddress:   common.HexToAddress(tx.DeployedContractAddress),
+		GasUsed:           tx.GasConsumed,
+		EffectiveGasPrice: nil,           // todo check
+		BlobGasUsed:       0,             // todo check
+		BlobGasPrice:      nil,           // todo check
+		BlockHash:         common.Hash{}, // todo check
+		BlockNumber:       big.NewInt(int64(tx.BlockHeight)),
+		TransactionIndex:  0, // todo check
+	}
+
+	receipt.Bloom = gethTypes.CreateBloom([]*gethTypes.Receipt{receipt})
+
+	return receipt, nil
+}
+
+// DecodeTransaction takes a cadence event for transaction executed and decodes it into the transaction.
+func DecodeTransaction(event cadence.Event) (*gethTypes.Transaction, error) {
+	if cdcCommon.TypeID(event.EventType.ID()) != txExecutedType {
+		return nil, fmt.Errorf(
+			"invalid event type for decoding into receipt, received %s expected %s",
+			event.Type().ID(),
+			types.EventTypeTransactionExecuted,
+		)
+	}
+
+	var t txEventPayload
+	err := cadence.DecodeFields(event, &t)
+	if err != nil {
+		return nil, err
+	}
+
+	encTx, err := hex.DecodeString(t.Transaction)
+	if err != nil {
+		return nil, err
+	}
+
+	tx := gethTypes.Transaction{}
+	err = tx.DecodeRLP(rlp.NewStream(bytes.NewReader(encTx), uint64(len(encTx))))
+	if err != nil {
+		return nil, err
+	}
+
+	return &tx, nil
+}

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -1,0 +1,81 @@
+package models
+
+import (
+	"bytes"
+	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/onflow/cadence"
+	"github.com/onflow/flow-go/fvm/evm/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"testing"
+)
+
+func createTestEvent(t *testing.T) (cadence.Event, *gethTypes.Transaction, *types.Result) {
+	res := &types.Result{
+		Failed:                  false,
+		TxType:                  1,
+		GasConsumed:             1337,
+		DeployedContractAddress: types.Address{0x5, 0x6, 0x7},
+		ReturnedValue:           []byte{0x55},
+		Logs: []*gethTypes.Log{{
+			Address: common.Address{0x1, 0x2},
+			Topics:  []common.Hash{{0x5, 0x6}, {0x7, 0x8}},
+		}, {
+			Address: common.Address{0x3, 0x5},
+			Topics:  []common.Hash{{0x2, 0x66}, {0x7, 0x1}},
+		}},
+	}
+
+	tx := gethTypes.NewTx(&gethTypes.AccessListTx{
+		ChainID:  big.NewInt(1),
+		Nonce:    1,
+		GasPrice: big.NewInt(24),
+		Gas:      1337,
+		To:       &common.Address{0x01},
+		Value:    big.NewInt(5),
+		Data:     []byte{0x2, 0x3},
+	})
+
+	var txEnc bytes.Buffer
+	err := tx.EncodeRLP(&txEnc)
+	require.NoError(t, err)
+
+	ev := types.NewTransactionExecutedEvent(1, txEnc.Bytes(), tx.Hash(), res)
+
+	cdcEv, err := ev.Payload.CadenceEvent()
+	require.NoError(t, err)
+
+	return cdcEv, tx, res
+}
+
+func Test_DecodeTransaction(t *testing.T) {
+	cdcEv, tx, _ := createTestEvent(t)
+
+	decTx, err := DecodeTransaction(cdcEv)
+	require.NoError(t, err)
+	assert.Equal(t, tx.Hash(), decTx.Hash())
+	assert.Equal(t, tx.Type(), decTx.Type())
+	assert.Equal(t, tx.To(), decTx.To())
+	assert.Equal(t, tx.Value(), decTx.Value())
+	assert.Equal(t, tx.Nonce(), decTx.Nonce())
+	assert.Equal(t, tx.Data(), decTx.Data())
+	assert.Equal(t, tx.GasPrice(), decTx.GasPrice())
+	assert.Equal(t, tx.BlobGas(), decTx.BlobGas())
+	assert.Equal(t, tx.Size(), decTx.Size())
+}
+
+func Test_DecodeReceipts(t *testing.T) {
+	cdcEv, _, rec := createTestEvent(t)
+
+	receipt, err := DecodeReceipt(cdcEv)
+	require.NoError(t, err)
+
+	for i, l := range rec.Logs {
+		assert.ObjectsAreEqualValues(l, receipt.Logs[i])
+		for j, tt := range l.Topics {
+			assert.EqualValues(t, tt, receipt.Logs[i].Topics[j])
+		}
+	}
+}


### PR DESCRIPTION
Reverts onflow/flow-evm-gateway#40Closes: https://github.com/onflow/flow-evm-gateway/issues/16

This is a revert of https://github.com/onflow/flow-evm-gateway/pull/36 due to an unintended merge.

The original PR implemented decoding of Flow EVM events into models we defined in evm-gateway.