### PR TITLE
Optimize format for EVM txs & data

### DIFF
--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -586,7 +586,7 @@ func TestE2E_API_DeployEvents(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(
 		t,
-		"0000000000000000000000000000000000000000000000000000000000000539",
+		"0000000000000000000000000000000000000000000000000000000000000539", // 1337 in ABI encoding
 		hex.EncodeToString(storedValue),
 	)
 

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -5,11 +5,12 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"fmt"
-	"github.com/onflow/flow-go-sdk/access/grpc"
-	"github.com/onflow/flow-go/fvm/evm/types"
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/onflow/flow-go-sdk/access/grpc"
+	"github.com/onflow/flow-go/fvm/evm/types"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/params"
@@ -579,6 +580,15 @@ func TestE2E_API_DeployEvents(t *testing.T) {
 	assert.Equal(t, signedHash.String(), hash.String())
 
 	time.Sleep(1 * time.Second)
+
+	// perform `eth_call` to read the stored value
+	storedValue, err := rpcTester.call(contractAddress, callRetrieve)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"0000000000000000000000000000000000000000000000000000000000000539",
+		hex.EncodeToString(storedValue),
+	)
 
 	// check if the sender account nonce has been indexed as increased
 	eoaNonce, err = rpcTester.getNonce(fundEOAAddress)

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -559,6 +559,31 @@ func (r *rpcTest) estimateGas(
 	return gasUsed, nil
 }
 
+func (r *rpcTest) call(
+	to common.Address,
+	data []byte,
+) ([]byte, error) {
+	rpcRes, err := r.request(
+		"eth_call",
+		fmt.Sprintf(
+			`[{"to":"%s","data":"0x%s"}]`,
+			to.Hex(),
+			hex.EncodeToString(data),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var result hexutil.Bytes
+	err = json.Unmarshal(rpcRes, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func uintHex(x uint64) string {
 	return fmt.Sprintf("0x%x", x)
 }

--- a/services/requester/cadence/call.cdc
+++ b/services/requester/cadence/call.cdc
@@ -1,15 +1,16 @@
 import EVM
 
 access(all)
-fun main(data: [UInt8], contractAddress: [UInt8; 20]): [UInt8] {
+fun main(hexEncodedData: String, contractAddress: [UInt8; 20]): [UInt8] {
     let account = getAuthAccount<auth(Storage) &Account>(Address(0xCOA))
 
-    let coa = account.storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(from: /storage/evm)
-        ?? panic("Could not borrow reference to the COA!")
+    let coa = account.storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(
+        from: /storage/evm
+    ) ?? panic("Could not borrow reference to the COA!")
 
     return coa.call(
         to: EVM.EVMAddress(bytes: contractAddress),
-        data: data,
+        data: hexEncodedData.decodeHex(),
         gasLimit: 15000000, // todo make it configurable, max for now
         value: EVM.Balance(attoflow: 0)
     ).data

--- a/services/requester/cadence/call.cdc
+++ b/services/requester/cadence/call.cdc
@@ -1,17 +1,20 @@
 import EVM
 
 access(all)
-fun main(hexEncodedData: String, contractAddress: [UInt8; 20]): [UInt8] {
+fun main(hexEncodedData: String, hexEncodedAddress: String): String {
     let account = getAuthAccount<auth(Storage) &Account>(Address(0xCOA))
 
     let coa = account.storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(
         from: /storage/evm
     ) ?? panic("Could not borrow reference to the COA!")
+    let addressBytes = hexEncodedAddress.decodeHex().toConstantSized<[UInt8; 20]>()!
 
-    return coa.call(
-        to: EVM.EVMAddress(bytes: contractAddress),
+    let callResult = coa.call(
+        to: EVM.EVMAddress(bytes: addressBytes),
         data: hexEncodedData.decodeHex(),
         gasLimit: 15000000, // todo make it configurable, max for now
         value: EVM.Balance(attoflow: 0)
-    ).data
+    )
+
+    return String.encodeHex(callResult.data)
 }

--- a/services/requester/cadence/estimate_gas.cdc
+++ b/services/requester/cadence/estimate_gas.cdc
@@ -1,13 +1,13 @@
 import EVM
 
 access(all)
-fun main(encodedTx: [UInt8]): [UInt64; 2] {
+fun main(hexEncodedTx: String): [UInt64; 2] {
     let account = getAuthAccount<auth(Storage) &Account>(Address(0xCOA))
 
     let coa = account.storage.borrow<&EVM.CadenceOwnedAccount>(
         from: /storage/evm
     ) ?? panic("Could not borrow reference to the COA!")
-    let txResult = EVM.run(tx: encodedTx, coinbase: coa.address())
+    let txResult = EVM.run(tx: hexEncodedTx.decodeHex(), coinbase: coa.address())
 
     return [txResult.errorCode, txResult.gasUsed]
 }

--- a/services/requester/cadence/get_balance.cdc
+++ b/services/requester/cadence/get_balance.cdc
@@ -1,7 +1,8 @@
 import EVM
 
 access(all)
-fun main(addressBytes: [UInt8; 20]): UInt {
+fun main(hexEncodedAddress: String): UInt {
+    let addressBytes = hexEncodedAddress.decodeHex().toConstantSized<[UInt8; 20]>()!
     let address = EVM.EVMAddress(bytes: addressBytes)
 
     return address.balance().inAttoFLOW()

--- a/services/requester/cadence/get_nonce.cdc
+++ b/services/requester/cadence/get_nonce.cdc
@@ -1,7 +1,8 @@
 import EVM
 
 access(all)
-fun main(addressBytes: [UInt8; 20]): UInt64 {
+fun main(hexEncodedAddress: String): UInt64 {
+    let addressBytes = hexEncodedAddress.decodeHex().toConstantSized<[UInt8; 20]>()!
     let address = EVM.EVMAddress(bytes: addressBytes)
 
     return address.nonce()

--- a/services/requester/cadence/run.cdc
+++ b/services/requester/cadence/run.cdc
@@ -1,19 +1,20 @@
 import EVM
 
-transaction(encodedTx: [UInt8]) {
+transaction(hexEncodedTx: String) {
     let coa: &EVM.CadenceOwnedAccount
 
     prepare(signer: auth(Storage) &Account) {
-        self.coa = signer.storage.borrow<&EVM.CadenceOwnedAccount>(from: /storage/evm)
-            ?? panic("Could not borrow reference to the bridged account!")
+        self.coa = signer.storage.borrow<&EVM.CadenceOwnedAccount>(
+            from: /storage/evm
+        ) ?? panic("Could not borrow reference to the COA!")
     }
 
     execute {
-        let result = EVM.run(tx: encodedTx, coinbase: self.coa.address())
+        let txResult = EVM.run(tx: hexEncodedTx.decodeHex(), coinbase: self.coa.address())
         // todo only temporary until we correctly handle failure events
         assert(
-            result.status == EVM.Status.successful,
-            message: "failed to execute evm transaction: ".concat(result.errorCode.toString())
+            txResult.status == EVM.Status.successful,
+            message: "failed to execute evm transaction: ".concat(txResult.errorCode.toString())
         )
     }
 }

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -242,7 +242,9 @@ func (e *EVM) signAndSend(ctx context.Context, script []byte, args ...cadence.Va
 
 func (e *EVM) GetBalance(ctx context.Context, address common.Address, height uint64) (*big.Int, error) {
 	// todo make sure provided height is used
-	hexEncodedAddress, err := cadence.NewString(address.Hex()[2:])
+	hexEncodedAddress, err := cadence.NewString(
+		strings.TrimPrefix(address.Hex(), "0x"),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +269,9 @@ func (e *EVM) GetBalance(ctx context.Context, address common.Address, height uin
 }
 
 func (e *EVM) GetNonce(ctx context.Context, address common.Address) (uint64, error) {
-	hexEncodedAddress, err := cadence.NewString(address.Hex()[2:])
+	hexEncodedAddress, err := cadence.NewString(
+		strings.TrimPrefix(address.Hex(), "0x"),
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -298,7 +302,9 @@ func (e *EVM) Call(ctx context.Context, address common.Address, data []byte) ([]
 	}
 
 	// todo make "to" address optional, this can be used for contract deployment simulations
-	hexEncodedAddress, err := cadence.NewString(address.Hex()[2:])
+	hexEncodedAddress, err := cadence.NewString(
+		strings.TrimPrefix(address.Hex(), "0x"),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -43,11 +43,6 @@ var (
 
 	//go:embed cadence/get_nonce.cdc
 	getNonceScript []byte
-
-	addressType = cadence.NewConstantSizedArrayType(
-		common.AddressLength,
-		cadence.UInt8Type,
-	)
 )
 
 const minFlowBalance = 2
@@ -247,12 +242,15 @@ func (e *EVM) signAndSend(ctx context.Context, script []byte, args ...cadence.Va
 
 func (e *EVM) GetBalance(ctx context.Context, address common.Address, height uint64) (*big.Int, error) {
 	// todo make sure provided height is used
-	addr := cadenceArrayFromBytes(address.Bytes()).WithType(addressType)
+	hexEncodedAddress, err := cadence.NewString(address.Hex()[2:])
+	if err != nil {
+		return nil, err
+	}
 
 	val, err := e.client.ExecuteScriptAtLatestBlock(
 		ctx,
 		e.replaceAddresses(getBalanceScript),
-		[]cadence.Value{addr},
+		[]cadence.Value{hexEncodedAddress},
 	)
 	if err != nil {
 		return nil, err
@@ -269,12 +267,15 @@ func (e *EVM) GetBalance(ctx context.Context, address common.Address, height uin
 }
 
 func (e *EVM) GetNonce(ctx context.Context, address common.Address) (uint64, error) {
-	addr := cadenceArrayFromBytes(address.Bytes()).WithType(addressType)
+	hexEncodedAddress, err := cadence.NewString(address.Hex()[2:])
+	if err != nil {
+		return 0, err
+	}
 
 	val, err := e.client.ExecuteScriptAtLatestBlock(
 		ctx,
 		e.replaceAddresses(getNonceScript),
-		[]cadence.Value{addr},
+		[]cadence.Value{hexEncodedAddress},
 	)
 	if err != nil {
 		return 0, err
@@ -295,30 +296,45 @@ func (e *EVM) Call(ctx context.Context, address common.Address, data []byte) ([]
 	if err != nil {
 		return nil, err
 	}
+
 	// todo make "to" address optional, this can be used for contract deployment simulations
-	toAddress := cadenceArrayFromBytes(address.Bytes()).WithType(addressType)
+	hexEncodedAddress, err := cadence.NewString(address.Hex()[2:])
+	if err != nil {
+		return nil, err
+	}
 
 	e.logger.Debug().
 		Str("address", address.Hex()).
 		Str("data", fmt.Sprintf("%x", data)).
 		Msg("call")
 
-	value, err := e.client.ExecuteScriptAtLatestBlock(
+	scriptResult, err := e.client.ExecuteScriptAtLatestBlock(
 		ctx,
 		e.replaceAddresses(callScript),
-		[]cadence.Value{hexEncodedData, toAddress},
+		[]cadence.Value{hexEncodedData, hexEncodedAddress},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute script: %w", err)
 	}
 
+	// sanity check, should never occur
+	if _, ok := scriptResult.(cadence.String); !ok {
+		e.logger.Panic().Msg(fmt.Sprintf("failed to convert script result %v to String", scriptResult))
+	}
+
+	output := scriptResult.(cadence.String).ToGoValue().(string)
+	byteOutput, err := hex.DecodeString(output)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert call output: %w", err)
+	}
+
 	e.logger.Info().
 		Str("address", address.Hex()).
 		Str("data", fmt.Sprintf("%x", data)).
-		Str("result", value.String()).
+		Str("result", output).
 		Msg("call executed")
 
-	return bytesFromCadenceArray(value)
+	return byteOutput, nil
 }
 
 func (e *EVM) EstimateGas(ctx context.Context, data []byte) (uint64, error) {
@@ -394,29 +410,6 @@ func (e *EVM) replaceAddresses(script []byte) []byte {
 	s = strings.ReplaceAll(s, "0xCOA", e.address.HexWithPrefix())
 
 	return []byte(s)
-}
-
-func cadenceArrayFromBytes(input []byte) cadence.Array {
-	values := make([]cadence.Value, 0)
-	for _, element := range input {
-		values = append(values, cadence.UInt8(element))
-	}
-
-	return cadence.NewArray(values)
-}
-
-func bytesFromCadenceArray(value cadence.Value) ([]byte, error) {
-	arr, ok := value.(cadence.Array)
-	if !ok {
-		return nil, fmt.Errorf("cadence value is not of array type, can not conver to byte array")
-	}
-
-	res := make([]byte, len(arr.Values))
-	for i, x := range arr.Values {
-		res[i] = x.ToGoValue().(byte)
-	}
-
-	return res, nil
 }
 
 // TODO(m-Peter): Consider moving this to flow-go repository


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/123

## Description

Update Cadence scripts & transactions to accept EVM tx & data as hex-encoded strings instead of Cadence byte arrays. This is far more effiecient with the current JSON-CDC encoder.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 