### PR TITLE
Log improvements

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -214,9 +214,9 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Check if WebSocket request and serve if JSON-RPC over WebSocket is enabled
 	if b, err := io.ReadAll(r.Body); err == nil {
 		h.logger.Debug().
-			Str("body", string(b)).
+			RawJSON("body", b).
 			Str("url", r.URL.String()).
-			Bool("ws", isWebSocket(r)).
+			Bool("is-ws", isWebSocket(r)).
 			Msg("API request")
 
 		r.Body = io.NopCloser(bytes.NewBuffer(b))
@@ -399,7 +399,11 @@ type loggingResponseWriter struct {
 }
 
 func (w *loggingResponseWriter) Write(data []byte) (int, error) {
-	w.logger.Debug().Str("data", string(data)).Msg("API response")
+	w.logger.
+		Debug().
+		RawJSON("data", data).
+		Msg("API response")
+
 	return w.ResponseWriter.Write(data)
 }
 

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -1,7 +1,6 @@
 package requester
 
 import (
-	"bytes"
 	"context"
 	_ "embed"
 	"fmt"
@@ -9,7 +8,6 @@ import (
 	gethCore "github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	gethVM "github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/access"
@@ -144,13 +142,7 @@ func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash,
 		Msg("send raw transaction")
 
 	tx := &types.Transaction{}
-	err := tx.DecodeRLP(
-		rlp.NewStream(
-			bytes.NewReader(data),
-			uint64(len(data)),
-		),
-	)
-	if err != nil {
+	if err := tx.UnmarshalBinary(data); err != nil {
 		return common.Hash{}, err
 	}
 

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -169,10 +169,17 @@ func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash,
 	if tx.To() != nil {
 		to = tx.To().String()
 	}
+
+	from, err := types.Sender(types.LatestSignerForChainID(tx.ChainId()), tx)
+	if err != nil {
+		e.logger.Error().Err(err).Msg("failed to calculate sender")
+	}
+
 	e.logger.Info().
 		Str("evm-id", tx.Hash().Hex()).
 		Str("flow-id", flowID.Hex()).
 		Str("to", to).
+		Str("from", from.Hex()).
 		Str("value", tx.Value().String()).
 		Msg("raw transaction sent")
 


### PR DESCRIPTION
Show JSON in logs as JSON and not string. Also add sender address to the log output when sending new transaction, so we can know who sent it.