### PR TITLE
Fixes to log output lines and log setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ The application can be configured using the following flags at runtime:
 | `--coa-key`               | (required)       | *WARNING*: Do not use this flag in production! Private key value for the COA address used for submitting transactions. |
 | `--coa-resource-create`   | `false`          | Auto-create the COA resource in the Flow COA account provided if one doesn't exist.                                    |
 | `--log-level`             | `debug`          | Define verbosity of the log output ('debug', 'info', 'error')                                                          |
-| `--log-writer`            | `stdout`         | Log writer used for output ('stdout', 'console')                                                                       |
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The application can be configured using the following flags at runtime:
 | `--coa-key`               | (required)       | *WARNING*: Do not use this flag in production! Private key value for the COA address used for submitting transactions. |
 | `--coa-resource-create`   | `false`          | Auto-create the COA resource in the Flow COA account provided if one doesn't exist.                                    |
 | `--log-level`             | `debug`          | Define verbosity of the log output ('debug', 'info', 'error')                                                          |
-| `--log-writer`            | `stderr`         | Log writer used for output ('stderr', 'console')                                                                       |
+| `--log-writer`            | `stdout`         | Log writer used for output ('stdout', 'console')                                                                       |
 
 ## Getting Started
 

--- a/api/server.go
+++ b/api/server.go
@@ -221,7 +221,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Str("url", r.URL.String()).
 			Uint64("id", body["id"].(uint64)).
 			Fields(body["method"]).
-			Fields(body["params"]).
+			Interface("list", body["params"]).
 			Bool("is-ws", isWebSocket(r)).
 			Msg("API request")
 

--- a/api/server.go
+++ b/api/server.go
@@ -221,7 +221,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Str("url", r.URL.String()).
 			Uint64("id", body["id"].(uint64)).
 			Fields(body["method"]).
-			Interface("list", body["params"]).
+			Interface("params", body["params"]).
 			Bool("is-ws", isWebSocket(r)).
 			Msg("API request")
 

--- a/api/server.go
+++ b/api/server.go
@@ -219,9 +219,9 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		h.logger.Debug().
 			Str("url", r.URL.String()).
-			Str("id", fmt.Sprintf("%v", body["id"])).
-			Str("method", fmt.Sprintf("%s", body["method"])).
-			Str("params", fmt.Sprintf("%v", body["params"])).
+			Uint64("id", body["id"].(uint64)).
+			Fields(body["method"]).
+			Fields(body["params"]).
 			Bool("is-ws", isWebSocket(r)).
 			Msg("API request")
 
@@ -410,8 +410,8 @@ func (w *loggingResponseWriter) Write(data []byte) (int, error) {
 
 	w.logger.
 		Debug().
-		Str("id", fmt.Sprintf("%v", body["id"])).
-		Str("result", fmt.Sprintf("%v", body["result"])).
+		Uint64("id", body["id"].(uint64)).
+		Fields(body["result"]).
 		Msg("API response")
 
 	return w.ResponseWriter.Write(data)

--- a/api/server.go
+++ b/api/server.go
@@ -406,7 +406,6 @@ type loggingResponseWriter struct {
 }
 
 func (w *loggingResponseWriter) Write(data []byte) (int, error) {
-	fmt.Println("<-----", string(data))
 	body := make(map[string]any)
 	_ = json.Unmarshal(data, &body)
 

--- a/api/server.go
+++ b/api/server.go
@@ -215,7 +215,6 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Check if WebSocket request and serve if JSON-RPC over WebSocket is enabled
 	if b, err := io.ReadAll(r.Body); err == nil {
 		body := make(map[string]any)
-		fmt.Println("----->", string(b))
 		_ = json.Unmarshal(b, &body)
 
 		h.logger.Debug().

--- a/config/config.go
+++ b/config/config.go
@@ -152,11 +152,7 @@ func FromFlags() (*Config, error) {
 		cfg.LogLevel = zerolog.ErrorLevel
 	}
 
-	if logWriter == "stdout" {
-		cfg.LogWriter = os.Stdout
-	} else {
-		cfg.LogWriter = zerolog.NewConsoleWriter()
-	}
+	cfg.LogWriter = zerolog.NewConsoleWriter()
 
 	// todo validate Config values
 	return cfg, nil

--- a/config/config.go
+++ b/config/config.go
@@ -152,7 +152,11 @@ func FromFlags() (*Config, error) {
 		cfg.LogLevel = zerolog.ErrorLevel
 	}
 
-	cfg.LogWriter = zerolog.NewConsoleWriter()
+	if logWriter == "stdout" {
+		cfg.LogWriter = os.Stdout
+	} else {
+		cfg.LogWriter = zerolog.NewConsoleWriter()
+	}
 
 	// todo validate Config values
 	return cfg, nil

--- a/config/config.go
+++ b/config/config.go
@@ -152,11 +152,7 @@ func FromFlags() (*Config, error) {
 		cfg.LogLevel = zerolog.ErrorLevel
 	}
 
-	if logWriter == "stderr" {
-		cfg.LogWriter = os.Stderr
-	} else {
-		cfg.LogWriter = zerolog.NewConsoleWriter()
-	}
+	cfg.LogWriter = zerolog.NewConsoleWriter()
 
 	// todo validate Config values
 	return cfg, nil

--- a/services/ingestion/engine.go
+++ b/services/ingestion/engine.go
@@ -119,7 +119,7 @@ func (e *Engine) Run(ctx context.Context) error {
 func (e *Engine) processEvents(events flow.BlockEvents) error {
 	e.log.Debug().
 		Uint64("cadence-height", events.Height).
-		Int("cadence-event-length", len(events.Events)).
+		Interface("cadence-events", events.Events).
 		Msg("received new cadence evm events")
 
 	blockEvent := false

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -141,7 +141,7 @@ func NewEVM(
 
 func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash, error) {
 	e.logger.Debug().
-		Str("data", fmt.Sprintf("%x", data)).
+		Bytes("byteData", data).
 		Msg("send raw transaction")
 
 	tx := &types.Transaction{}
@@ -240,7 +240,7 @@ func (e *EVM) signAndSend(ctx context.Context, script []byte, args ...cadence.Va
 
 			e.logger.Debug().
 				Str("flow-id", id.String()).
-				Str("events", fmt.Sprintf("%v", res.Events)).
+				Interface("events", res.Events).
 				Msg("flow transaction executed successfully")
 		}(flowTx.ID())
 	}
@@ -313,7 +313,7 @@ func (e *EVM) Call(ctx context.Context, address common.Address, data []byte) ([]
 
 	e.logger.Debug().
 		Str("address", address.Hex()).
-		Str("data", fmt.Sprintf("%x", data)).
+		Interface("data", data).
 		Msg("call")
 
 	scriptResult, err := e.client.ExecuteScriptAtLatestBlock(
@@ -332,7 +332,7 @@ func (e *EVM) Call(ctx context.Context, address common.Address, data []byte) ([]
 
 	e.logger.Info().
 		Str("address", address.Hex()).
-		Str("data", fmt.Sprintf("%x", data)).
+		Interface("data", data).
 		Str("result", hex.EncodeToString(output)).
 		Msg("call executed")
 
@@ -341,7 +341,7 @@ func (e *EVM) Call(ctx context.Context, address common.Address, data []byte) ([]
 
 func (e *EVM) EstimateGas(ctx context.Context, data []byte) (uint64, error) {
 	e.logger.Debug().
-		Str("data", fmt.Sprintf("%x", data)).
+		Interface("data", data).
 		Msg("estimate gas")
 
 	hexEncodedTx, err := cadence.NewString(hex.EncodeToString(data))
@@ -382,8 +382,8 @@ func (e *EVM) GetCode(
 	height uint64,
 ) ([]byte, error) {
 	e.logger.Debug().
-		Str("addess", address.Hex()).
-		Str("height", fmt.Sprintf("%d", height)).
+		Str("address", address.Hex()).
+		Uint64("height", height).
 		Msg("get code")
 
 	hexEncodedAddress, err := addressToCadenceString(address)


### PR DESCRIPTION
Log lines were not being output to JSON the same way as they were being output to stdout so needed to adjust the way logged values were being stringified. 

Also removed the --log-output option to always use stdout since it gets confusing when looking at server logs in grafana which show both stdout and stderr; want to keep clean separation between them