### PR TITLE
Update to Cadence v1.0.0-preview.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/ethereum/go-ethereum v1.13.5
 	github.com/goccy/go-json v0.10.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
-	github.com/onflow/cadence v1.0.0-preview.12
-	github.com/onflow/flow-go v0.34.0-crescendo-preview.5.0.20240312025929-25d0a9f6e292
-	github.com/onflow/flow-go-sdk v1.0.0-preview.10
+	github.com/onflow/cadence v1.0.0-preview.13
+	github.com/onflow/flow-go v0.34.0-crescendo-preview.6.0.20240313030147-6c1b120ed2ac
+	github.com/onflow/flow-go-sdk v1.0.0-preview.11
 	github.com/rs/cors v1.8.0
 	github.com/rs/zerolog v1.31.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -1816,8 +1816,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2 h1:jJLDswfAVB0bHCu1y1FPdKukPcTNmN+jYEX9S9phbv0=
 github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.12 h1:1/6vY61ueMqORQAb2rqtjyBw1SCuWh4jM6sKZEn/ANk=
-github.com/onflow/cadence v1.0.0-preview.12/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
+github.com/onflow/cadence v1.0.0-preview.13 h1:marbyx9A9atx/0JVumnJudaM60kUabWSCvDddUNCWCM=
+github.com/onflow/cadence v1.0.0-preview.13/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
 github.com/onflow/crypto v0.24.9 h1:jYP1qdwid0qCineFzBFlxBchg710A7RuSWpTqxaOdog=
 github.com/onflow/crypto v0.24.9/go.mod h1:J/V7IEVaqjDajvF8K0B/SJPJDgAOP2G+LVLeb0hgmbg=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240305214031-d81e0c3b42f3 h1:UNLms46HthnzKTR3DVQmEoDerf4EtNUMfkombIeT3U8=
@@ -1828,11 +1828,11 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240305212555-29d91e18f0c1 
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240305212555-29d91e18f0c1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240305212555-29d91e18f0c1 h1:7BkqJ21EQAbYCZqLj2xCIqJvhrHNCXe9BfLTEiQqIx0=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240305212555-29d91e18f0c1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.34.0-crescendo-preview.5.0.20240312025929-25d0a9f6e292 h1:C/K1NUVPLSXfVNzy7HjcjBIt3ir0X0AjDo+VMpNl3Go=
-github.com/onflow/flow-go v0.34.0-crescendo-preview.5.0.20240312025929-25d0a9f6e292/go.mod h1:PPaV69Oq5jzPCw/HK7HcLKh5zX/RdAlh5B08I0QgbM4=
+github.com/onflow/flow-go v0.34.0-crescendo-preview.6.0.20240313030147-6c1b120ed2ac h1:ItszWlgO6I7EUq1n6HyymZJ9TymsZXyZTlinKCRBIbg=
+github.com/onflow/flow-go v0.34.0-crescendo-preview.6.0.20240313030147-6c1b120ed2ac/go.mod h1:wy09Wo00Svnf+esMpIYFijkwidhtVFdxUPm3ot4zLyA=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.10 h1:7AolYdUBQLCddIfVhD5DoFYUQ+F1xDG8gtzeinqBWcc=
-github.com/onflow/flow-go-sdk v1.0.0-preview.10/go.mod h1:jYAxpaRkLWleW61N5hsvyo8RaLo8WNVvHYg+QtcN1+A=
+github.com/onflow/flow-go-sdk v1.0.0-preview.11 h1:tAuKwee1GoO7H1GAFjUEGWIwMqQHIfJVBgDYYTJ99dg=
+github.com/onflow/flow-go-sdk v1.0.0-preview.11/go.mod h1:1SRp23tOfnzkbP5YY/KbfzwtKaW5Ikm3Sly+iJAzFnc=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240305213046-9026973838d7 h1:0/s3DzQp3JHWuuz3DpGwniFShtgEy3wq1uBB+4uOG1I=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240305213046-9026973838d7/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240305213046-9026973838d7 h1:VU294Tk/Ra/UuuJbArLILA+x+4qX5qGPTY/kokNKyA4=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.13](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.13)
- [onflow/flow-go-sdk v1.0.0-preview.11](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.11)
- [onflow/flow-go 6c1b120ed2ac](https://github.com/onflow/flow-go/commit/6c1b120ed2ac)

