### PR TITLE
Add support for returning full transactions

### DIFF
--- a/api/models.go
+++ b/api/models.go
@@ -138,6 +138,6 @@ type Block struct {
 	Number       hexutil.Uint64 `json:"number"`
 	ParentHash   common.Hash    `json:"parentHash"`
 	ReceiptsRoot common.Hash    `json:"receiptsRoot"`
-	Transactions []common.Hash  `json:"transactions"`
+	Transactions interface{}    `json:"transactions"`
 	// todo add more fields needed
 }

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -543,14 +543,14 @@ func TestE2E_API_DeployEvents(t *testing.T) {
 	latestBlockNumber, err := rpcTester.blockNumber()
 	require.NoError(t, err)
 
-	blkRpc, err := rpcTester.getBlock(latestBlockNumber)
+	blkRpc, err := rpcTester.getBlock(latestBlockNumber, false)
 	require.NoError(t, err)
 
 	require.Len(t, blkRpc.Transactions, 1)
 	assert.Equal(t, uintHex(4), blkRpc.Number)
 
 	// check the deployment transaction and receipt
-	deployHash := blkRpc.Transactions[0]
+	deployHash := blkRpc.TransactionHashes()[0]
 	require.Equal(t, hash.String(), deployHash)
 
 	txRpc, err := rpcTester.getTx(deployHash)
@@ -605,12 +605,12 @@ func TestE2E_API_DeployEvents(t *testing.T) {
 	latestBlockNumber, err = rpcTester.blockNumber()
 	require.NoError(t, err)
 
-	blkRpc, err = rpcTester.getBlock(latestBlockNumber)
+	blkRpc, err = rpcTester.getBlock(latestBlockNumber, false)
 	require.NoError(t, err)
 	assert.Equal(t, uintHex(5), blkRpc.Number)
 	require.Len(t, blkRpc.Transactions, 1)
 
-	interactHash := blkRpc.Transactions[0]
+	interactHash := blkRpc.TransactionHashes()[0]
 	assert.Equal(t, signedHash.String(), interactHash)
 
 	txRpc, err = rpcTester.getTx(interactHash)
@@ -659,12 +659,12 @@ func TestE2E_API_DeployEvents(t *testing.T) {
 	latestBlockNumber, err = rpcTester.blockNumber()
 	require.NoError(t, err)
 
-	blkRpc, err = rpcTester.getBlock(latestBlockNumber)
+	blkRpc, err = rpcTester.getBlock(latestBlockNumber, false)
 	require.NoError(t, err)
 	assert.Equal(t, uintHex(6), blkRpc.Number)
 	require.Len(t, blkRpc.Transactions, 1)
 
-	interactHash = blkRpc.Transactions[0]
+	interactHash = blkRpc.TransactionHashes()[0]
 	assert.Equal(t, signedHash.String(), interactHash)
 
 	txRpc, err = rpcTester.getTx(interactHash)
@@ -699,11 +699,11 @@ func TestE2E_API_DeployEvents(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// block is produced by above call to the sum that emits sdkEvent
-		blkRpc, err = rpcTester.getBlock(latestBlockNumber + 1 + uint64(i))
+		blkRpc, err = rpcTester.getBlock(latestBlockNumber+1+uint64(i), false)
 		require.NoError(t, err)
 		require.Len(t, blkRpc.Transactions, 1)
 
-		sumHash := blkRpc.Transactions[0]
+		sumHash := blkRpc.TransactionHashes()[0]
 		assert.Equal(t, signedHash.String(), sumHash)
 
 		_, err = rpcTester.getTx(sumHash)
@@ -732,7 +732,7 @@ func TestE2E_API_DeployEvents(t *testing.T) {
 
 	// successfully filter by block id with found single match for each block
 	for i := 0; i < 4; i++ {
-		blkRpc, err = rpcTester.getBlock(latestBlockNumber + 1 + uint64(i))
+		blkRpc, err = rpcTester.getBlock(latestBlockNumber+1+uint64(i), false)
 		require.NoError(t, err)
 
 		blkID := common.HexToHash(blkRpc.Hash)
@@ -757,7 +757,7 @@ func TestE2E_API_DeployEvents(t *testing.T) {
 	}
 
 	// invalid filter by block id with wrong topic value
-	blkRpc, err = rpcTester.getBlock(latestBlockNumber + 1)
+	blkRpc, err = rpcTester.getBlock(latestBlockNumber+1, false)
 	require.NoError(t, err)
 	blkID := common.HexToHash(blkRpc.Hash)
 	require.NoError(t, err)
@@ -914,6 +914,126 @@ func TestE2E_ConcurrentTransactionSubmission(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, uint64(1), rcp.Status)
 	}
+}
+
+func TestE2E_API_GetBlocksWithFullTransactions(t *testing.T) {
+	srv, err := startEmulator()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		srv.Stop()
+	}()
+
+	emu := srv.Emulator()
+	dbDir := t.TempDir()
+	gwAcc := emu.ServiceKey()
+	gwKey := gwAcc.PrivateKey
+	gwAddress := gwAcc.Address
+
+	cfg := &config.Config{
+		DatabaseDir:        dbDir,
+		AccessNodeGRPCHost: "localhost:3569", // emulator
+		RPCPort:            8545,
+		RPCHost:            "127.0.0.1",
+		FlowNetworkID:      "flow-emulator",
+		EVMNetworkID:       types.FlowEVMTestnetChainID,
+		Coinbase:           fundEOAAddress,
+		COAAddress:         gwAddress,
+		COAKey:             gwKey,
+		CreateCOAResource:  true,
+		GasPrice:           new(big.Int).SetUint64(1),
+	}
+
+	rpcTester := &rpcTest{
+		url: fmt.Sprintf("http://%s:%d", cfg.RPCHost, cfg.RPCPort),
+	}
+
+	go func() {
+		err = bootstrap.Start(ctx, cfg)
+		require.NoError(t, err)
+	}()
+
+	time.Sleep(500 * time.Millisecond) // some time to startup
+
+	flowAmount, _ := cadence.NewUFix64("5.0")
+
+	// Steps 1, 2 and 3. - create COA and fund it - setup phase
+	res, err := fundEOA(emu, flowAmount, fundEOAAddress)
+	require.NoError(t, err)
+	require.NoError(t, res.Error)
+	assert.Len(t, res.Events, 8)
+
+	// Step 4. - deploy contract
+	deployData, err := hex.DecodeString(testContractBinary)
+	require.NoError(t, err)
+	nonce := uint64(0)
+	gasLimit := uint64(4700000) // arbitrarily big
+	eoaKey, err := crypto.HexToECDSA(fundEOARawKey)
+	require.NoError(t, err)
+
+	signed, _, err := evmSign(nil, gasLimit, eoaKey, nonce, nil, deployData)
+	nonce++
+	hash, err := rpcTester.sendRawTx(signed)
+	require.NoError(t, err)
+	require.NotNil(t, hash)
+
+	time.Sleep(1 * time.Second)
+
+	latestBlockNumber, err := rpcTester.blockNumber()
+	require.NoError(t, err)
+
+	t.Run("eth_getBlockByNumber", func(t *testing.T) {
+		blkRpc, err := rpcTester.getBlock(latestBlockNumber, true)
+		require.NoError(t, err)
+		require.Len(t, blkRpc.FullTransactions(), 1)
+
+		fullTx := blkRpc.FullTransactions()[0]
+
+		assert.Equal(t, blkRpc.Hash, fullTx["blockHash"])
+		assert.Equal(t, blkRpc.Number, fullTx["blockNumber"])
+		assert.Equal(t, "0xfacf71692421039876a5bb4f10ef7a439d8ef61e", fullTx["from"])
+		assert.Equal(t, "0x3491c", fullTx["gas"])
+		assert.Equal(t, "0x0", fullTx["gasPrice"])
+		assert.Equal(t, "0x4ffb5f4e10812d9a2580e284056b9104804818f324382a41884c73fc12993369", fullTx["hash"])
+		assert.Equal(t, fmt.Sprintf("0x%s", testContractBinary), fullTx["input"])
+		assert.Equal(t, "0x0", fullTx["nonce"])
+		assert.Equal(t, "0x18022960774dfbac5ebbfdbec9a96cc130c13cde7bea0c42fc76525ca7570e57", fullTx["r"])
+		assert.Equal(t, "0x36326758c61a14daf2d4d106bcd540755b31937c0f4f3ba24a8d7361c085993", fullTx["s"])
+		assert.Nil(t, fullTx["to"])
+		assert.Equal(t, "0x0", fullTx["transactionIndex"])
+		assert.Equal(t, "0x0", fullTx["type"])
+		assert.Equal(t, "0x530", fullTx["v"])
+		assert.Equal(t, "0x0", fullTx["value"])
+	})
+
+	t.Run("eth_getBlockByHash", func(t *testing.T) {
+		blkRpc, err := rpcTester.getBlock(latestBlockNumber, false)
+		require.NoError(t, err)
+
+		blkRpc, err = rpcTester.getBlockByHash(blkRpc.Hash, true)
+		require.NoError(t, err)
+		require.Len(t, blkRpc.FullTransactions(), 1)
+
+		fullTx := blkRpc.FullTransactions()[0]
+
+		assert.Equal(t, blkRpc.Hash, fullTx["blockHash"])
+		assert.Equal(t, blkRpc.Number, fullTx["blockNumber"])
+		assert.Equal(t, "0xfacf71692421039876a5bb4f10ef7a439d8ef61e", fullTx["from"])
+		assert.Equal(t, "0x3491c", fullTx["gas"])
+		assert.Equal(t, "0x0", fullTx["gasPrice"])
+		assert.Equal(t, "0x4ffb5f4e10812d9a2580e284056b9104804818f324382a41884c73fc12993369", fullTx["hash"])
+		assert.Equal(t, fmt.Sprintf("0x%s", testContractBinary), fullTx["input"])
+		assert.Equal(t, "0x0", fullTx["nonce"])
+		assert.Equal(t, "0x18022960774dfbac5ebbfdbec9a96cc130c13cde7bea0c42fc76525ca7570e57", fullTx["r"])
+		assert.Equal(t, "0x36326758c61a14daf2d4d106bcd540755b31937c0f4f3ba24a8d7361c085993", fullTx["s"])
+		assert.Nil(t, fullTx["to"])
+		assert.Equal(t, "0x0", fullTx["transactionIndex"])
+		assert.Equal(t, "0x0", fullTx["type"])
+		assert.Equal(t, "0x530", fullTx["v"])
+		assert.Equal(t, "0x0", fullTx["value"])
+	})
 }
 
 // checkSumLogValue makes sure the match is correct by checking sum value

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -453,8 +453,29 @@ func (r *rpcTest) getLogs(
 	return lg, nil
 }
 
-func (r *rpcTest) getBlock(height uint64) (*rpcBlock, error) {
-	rpcRes, err := r.request("eth_getBlockByNumber", fmt.Sprintf(`["%s",false]`, uintHex(height)))
+func (r *rpcTest) getBlock(height uint64, fullTx bool) (*rpcBlock, error) {
+	rpcRes, err := r.request(
+		"eth_getBlockByNumber",
+		fmt.Sprintf(`["%s",%t]`, uintHex(height), fullTx),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var blkRpc rpcBlock
+	err = json.Unmarshal(rpcRes, &blkRpc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &blkRpc, nil
+}
+
+func (r *rpcTest) getBlockByHash(hash string, fullTx bool) (*rpcBlock, error) {
+	rpcRes, err := r.request(
+		"eth_getBlockByHash",
+		fmt.Sprintf(`["%s",%t]`, hash, fullTx),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -639,5 +660,36 @@ type rpcBlock struct {
 	Hash         string
 	Number       string
 	ParentHash   string
-	Transactions []string
+	Transactions interface{}
+}
+
+func (b *rpcBlock) TransactionHashes() []string {
+	txHashes := make([]string, 0)
+	switch value := b.Transactions.(type) {
+	case []interface{}:
+		for _, val := range value {
+			switch element := val.(type) {
+			case string:
+				txHashes = append(txHashes, element)
+			case map[string]string:
+				txHashes = append(txHashes, element["hash"])
+			}
+		}
+	}
+	return txHashes
+}
+
+func (b *rpcBlock) FullTransactions() []map[string]interface{} {
+	transactions := make([]map[string]interface{}, 0)
+	switch value := b.Transactions.(type) {
+	case []interface{}:
+		for _, val := range value {
+			switch element := val.(type) {
+			case map[string]interface{}:
+				transactions = append(transactions, element)
+
+			}
+		}
+	}
+	return transactions
 }

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -671,8 +671,8 @@ func (b *rpcBlock) TransactionHashes() []string {
 			switch element := val.(type) {
 			case string:
 				txHashes = append(txHashes, element)
-			case map[string]string:
-				txHashes = append(txHashes, element["hash"])
+			case map[string]interface{}:
+				txHashes = append(txHashes, element["hash"].(string))
 			}
 		}
 	}


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/112

## Description

Add support for returning the full transaction info for `eth_getBlockByNumber` and `eth_getBlockByHash` endpoints

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 