### PR TITLE
Support empty `To` address in `eth_call` endpoint

### DIFF
--- a/api/sign_transaction.go
+++ b/api/sign_transaction.go
@@ -10,8 +10,51 @@ import (
 	"github.com/onflow/flow-go/fvm/evm/emulator"
 )
 
+const defaultGasLimit uint64 = 15_000_000
+
 var key, _ = gethCrypto.HexToECDSA("45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8")
 var signer = emulator.GetDefaultSigner()
+
+// signTxFromArgs will create a transaction from the given arguments and sign it
+// with a test account. The resulting signed transaction is only supposed to be
+// used through `EVM.run` inside Cadence scripts, meaning that no state change
+// will occur. This is only useful for `eth_estimateGas` and `eth_call` endpoints.
+func signTxFromArgs(args TransactionArgs) ([]byte, error) {
+	var data []byte
+	if args.Data != nil {
+		data = *args.Data
+	} else if args.Input != nil {
+		data = *args.Input
+	}
+
+	// provide a high enough gas for the tx to be able to execute
+	gasLimit := defaultGasLimit
+	if args.Gas != nil {
+		gasLimit = uint64(*args.Gas)
+	}
+	value := big.NewInt(0)
+	if args.Value != nil {
+		value = args.Value.ToInt()
+	}
+
+	tx := types.NewTx(
+		&types.LegacyTx{
+			Nonce:    0,
+			To:       args.To,
+			Value:    value,
+			Gas:      gasLimit,
+			GasPrice: big.NewInt(0),
+			Data:     data,
+		},
+	)
+
+	tx, err := types.SignTx(tx, signer, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign tx from args: %w", err)
+	}
+
+	return tx.MarshalBinary()
+}
 
 // signGasEstimationTx will create a transaction and sign it with a test account
 // used only for gas estimation, since gas estimation is run inside a script

--- a/services/requester/cadence/call.cdc
+++ b/services/requester/cadence/call.cdc
@@ -4,7 +4,7 @@ access(all)
 fun main(hexEncodedTx: String): String {
     let account = getAuthAccount<auth(Storage) &Account>(Address(0xCOA))
 
-    let coa = account.storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(
+    let coa = account.storage.borrow<&EVM.CadenceOwnedAccount>(
         from: /storage/evm
     ) ?? panic("Could not borrow reference to the COA!")
     let txResult = EVM.run(tx: hexEncodedTx.decodeHex(), coinbase: coa.address())

--- a/services/requester/cadence/call.cdc
+++ b/services/requester/cadence/call.cdc
@@ -1,20 +1,13 @@
 import EVM
 
 access(all)
-fun main(hexEncodedData: String, hexEncodedAddress: String): String {
+fun main(hexEncodedTx: String): String {
     let account = getAuthAccount<auth(Storage) &Account>(Address(0xCOA))
 
     let coa = account.storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(
         from: /storage/evm
     ) ?? panic("Could not borrow reference to the COA!")
-    let addressBytes = hexEncodedAddress.decodeHex().toConstantSized<[UInt8; 20]>()!
+    let txResult = EVM.run(tx: hexEncodedTx.decodeHex(), coinbase: coa.address())
 
-    let callResult = coa.call(
-        to: EVM.EVMAddress(bytes: addressBytes),
-        data: hexEncodedData.decodeHex(),
-        gasLimit: 15000000, // todo make it configurable, max for now
-        value: EVM.Balance(attoflow: 0)
-    )
-
-    return String.encodeHex(callResult.data)
+    return String.encodeHex(txResult.data)
 }


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/113

## Description

This will allow us to simulate contract deployments by using the `eth_call` JSON-RPC endpoint. Later on, we can consolidate the logic for `eth_estimateGas` and `eth_call`, as they are actually quite similar in nature.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 