### PR TITLE
Set `GasPrice` to `0` for gas estimation tx

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -530,26 +529,7 @@ func (b *BlockChainAPI) EstimateGas(
 	blockNumberOrHash *rpc.BlockNumberOrHash,
 	overrides *StateOverride,
 ) (hexutil.Uint64, error) {
-	var data []byte
-	if args.Data != nil {
-		data = *args.Data
-	} else if args.Input != nil {
-		data = *args.Input
-	}
-
-	// provide a high enough gas for the tx to be able to execute
-	defaultGasLimit := uint64(15_000_000)
-	if args.Gas != nil {
-		defaultGasLimit = uint64(*args.Gas)
-	}
-
-	txData, err := signGasEstimationTx(
-		args.To,
-		data,
-		(*big.Int)(args.Value),
-		defaultGasLimit,
-		(*big.Int)(args.GasPrice),
-	)
+	txData, err := signTxFromArgs(args)
 	if err != nil {
 		b.logger.Error().Err(err).Msg("failed to sign transaction for gas estimate")
 		return hexutil.Uint64(defaultGasLimit), nil // return default gas limit

--- a/api/sign_transaction.go
+++ b/api/sign_transaction.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"math/big"
 
-	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	gethCrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/onflow/flow-go/fvm/evm/emulator"
 )
 
 const defaultGasLimit uint64 = 15_000_000
 
-var key, _ = gethCrypto.HexToECDSA("45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8")
+var key, _ = crypto.HexToECDSA("45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8")
 var signer = emulator.GetDefaultSigner()
 
 // signTxFromArgs will create a transaction from the given arguments and sign it
@@ -27,11 +26,13 @@ func signTxFromArgs(args TransactionArgs) ([]byte, error) {
 		data = *args.Input
 	}
 
-	// provide a high enough gas for the tx to be able to execute
+	// provide a high enough gas for the tx to be able to execute,
+	// capped by the gas set in transaction args.
 	gasLimit := defaultGasLimit
 	if args.Gas != nil {
 		gasLimit = uint64(*args.Gas)
 	}
+
 	value := big.NewInt(0)
 	if args.Value != nil {
 		value = args.Value.ToInt()
@@ -51,34 +52,6 @@ func signTxFromArgs(args TransactionArgs) ([]byte, error) {
 	tx, err := types.SignTx(tx, signer, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign tx from args: %w", err)
-	}
-
-	return tx.MarshalBinary()
-}
-
-// signGasEstimationTx will create a transaction and sign it with a test account
-// used only for gas estimation, since gas estimation is run inside a script
-// and does not change the state this account is not important it just has to be valid.
-func signGasEstimationTx(
-	to *gethCommon.Address,
-	data []byte,
-	amount *big.Int,
-	gasLimit uint64,
-	gasPrice *big.Int,
-) ([]byte, error) {
-	tx := types.NewTx(
-		&types.LegacyTx{
-			Nonce:    0,
-			To:       to,
-			Value:    amount,
-			Gas:      gasLimit,
-			GasPrice: gasPrice,
-			Data:     data,
-		},
-	)
-	tx, err := types.SignTx(tx, signer, key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to sign tx for gas estimation: %w", err)
 	}
 
 	return tx.MarshalBinary()


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/161

## Description

The EOA test account used for signing the transaction that encapsulates the user's `TransactionArgs`, does not have any funds. This means that if `GasPrice` is greater than 0, we return:
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32000,
    "message": "insufficient funds for gas * price + value"
  }
}
```

By setting this argument to `0`, we now return the intrinsic gas, which is `0xcf08` (or `53000` in decimal). The gas is mainly affected by the length of the `data` / `input` field value.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 