### PR TITLE
Properly handle tx results from `EVM.run`

### DIFF
--- a/services/requester/cadence/run.cdc
+++ b/services/requester/cadence/run.cdc
@@ -10,10 +10,12 @@ transaction(hexEncodedTx: String) {
     }
 
     execute {
-        let txResult = EVM.run(tx: hexEncodedTx.decodeHex(), coinbase: self.coa.address())
-        // todo only temporary until we correctly handle failure events
+        let txResult = EVM.run(
+            tx: hexEncodedTx.decodeHex(),
+            coinbase: self.coa.address()
+        )
         assert(
-            txResult.status == EVM.Status.successful,
+            txResult.status == EVM.Status.failed || txResult.status == EVM.Status.successful,
             message: "failed to execute evm transaction: ".concat(txResult.errorCode.toString())
         )
     }


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/83

## Description

Change `assert` condition on `run.cdc` transaction, so that we allow block formation for EVM transactions with validation errors. This way, the Gateway will receive an `evm.TransactionExecuted` event, with the `VMError` field populated with the corresponding error.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 