### PR TITLE
Return proper response in `eth_getTransactionReceipt`

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	errs "github.com/onflow/flow-evm-gateway/api/errors"
 	"github.com/onflow/flow-evm-gateway/config"
+	"github.com/onflow/flow-evm-gateway/models"
 	"github.com/onflow/flow-evm-gateway/services/logs"
 	"github.com/onflow/flow-evm-gateway/services/requester"
 	"github.com/onflow/flow-evm-gateway/storage"
@@ -243,18 +244,23 @@ func (b *BlockChainAPI) GetTransactionByBlockNumberAndIndex(
 func (b *BlockChainAPI) GetTransactionReceipt(
 	ctx context.Context,
 	hash common.Hash,
-) (*types.Receipt, error) {
-	_, err := b.transactions.Get(hash)
+) (map[string]interface{}, error) {
+	tx, err := b.transactions.Get(hash)
 	if err != nil {
-		return handleError[*types.Receipt](b.logger, err)
+		return handleError[map[string]interface{}](b.logger, err)
 	}
 
-	rcp, err := b.receipts.GetByTransactionID(hash)
+	receipt, err := b.receipts.GetByTransactionID(hash)
 	if err != nil {
-		return handleError[*types.Receipt](b.logger, err)
+		return handleError[map[string]interface{}](b.logger, err)
 	}
 
-	return rcp, nil
+	txReceipt, err := models.MarshalReceipt(receipt, tx)
+	if err != nil {
+		return handleError[map[string]interface{}](b.logger, err)
+	}
+
+	return txReceipt, nil
 }
 
 // Coinbase is the address that mining rewards will be sent to (alias for Etherbase).


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/160

## Description

The Ethereum JSON-API specification, requires also the following fields:
- `contractAddress` (present for contract creation),
- `from`,
- `to` (`null` for contract creation)

Examples:

**Contract creation:**

```bash
curl -XPOST 'localhost:8545' --header 'Content-Type: application/json' --data-raw '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0xe414f90fea2aebd75e8c0b3b6a4a0c9928e86c16ea724343d884f40bfe2c4c6b"],"id":8}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8,
  "result": {
    "blockHash": "0xcbad8c56cfd41509bbbe8c5750d8f550d6268cc3549abcf7ea78087e46c54f49",
    "blockNumber": "0x3",
    "contractAddress": "0x99466ed2e37b892a2ee3e9cd55a98b68f5735db2",
    "cumulativeGasUsed": "0x195b0",
    "effectiveGasPrice": "0x0",
    "from": "0x658bdf435d810c91414ec09147daa6db62406379",
    "gasUsed": "0x195b0",
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "status": "0x1",
    "to": null,
    "transactionHash": "0xe414f90fea2aebd75e8c0b3b6a4a0c9928e86c16ea724343d884f40bfe2c4c6b",
    "transactionIndex": "0x0",
    "type": "0x0"
  }
}
```

**Contract call:**

```bash
curl -XPOST 'localhost:8545' --header 'Content-Type: application/json' --data-raw '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x9da005357b95da4b5c485c08f2ac41ecfe868ead4e6856b909a45dc27a6fcf7d"],"id":8}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8,
  "result": {
    "blockHash": "0x019fdff559b2bf0d3f0f4d3e951875c22d84065a041636179c0a22f5f51a7373",
    "blockNumber": "0x4",
    "contractAddress": null,
    "cumulativeGasUsed": "0x57f2",
    "effectiveGasPrice": "0x0",
    "from": "0x658bdf435d810c91414ec09147daa6db62406379",
    "gasUsed": "0x57f2",
    "logs": [
      {
        "address": "0x99466ed2e37b892a2ee3e9cd55a98b68f5735db2",
        "topics": [
          "0x24abdb5865df5079dcc5ac590ff6f01d5c16edbc5fab4e195d9febd1114503da"
        ],
        "data": "0x000000000000000000000000000000000000000000000000000000000000002a",
        "blockNumber": "0x4",
        "transactionHash": "0x9da005357b95da4b5c485c08f2ac41ecfe868ead4e6856b909a45dc27a6fcf7d",
        "transactionIndex": "0x0",
        "blockHash": "0x019fdff559b2bf0d3f0f4d3e951875c22d84065a041636179c0a22f5f51a7373",
        "logIndex": "0x0",
        "removed": false
      }
    ],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000020000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000",
    "status": "0x1",
    "to": "0x99466ed2e37b892a2ee3e9cd55a98b68f5735db2",
    "transactionHash": "0x9da005357b95da4b5c485c08f2ac41ecfe868ead4e6856b909a45dc27a6fcf7d",
    "transactionIndex": "0x0",
    "type": "0x0"
  }
}
```
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 