### PR TITLE
Add `eth_mining` JSON-RPC endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -621,7 +621,7 @@ func (b *BlockChainAPI) NewPendingTransactionFilter(fullTx *bool) rpc.ID {
 
 // Accounts returns the collection of accounts this node manages.
 func (b *BlockChainAPI) Accounts() []common.Address {
-	return nil
+	return []common.Address{}
 }
 
 // GetUncleByBlockHashAndIndex returns the uncle block for the given block hash and index.

--- a/api/api.go
+++ b/api/api.go
@@ -739,6 +739,14 @@ func (b *BlockChainAPI) Mining() bool {
 	return false
 }
 
+// Hashrate returns the number of hashes per second that the
+// node is mining with.
+// This can only return true for proof-of-work networks and
+// may not be available in some clients since The Merge.
+func (b *BlockChainAPI) Hashrate() hexutil.Uint64 {
+	return hexutil.Uint64(0)
+}
+
 func (b *BlockChainAPI) fetchBlockTransactions(
 	ctx context.Context,
 	block *evmTypes.Block,

--- a/api/api.go
+++ b/api/api.go
@@ -732,6 +732,13 @@ func (b *BlockChainAPI) MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big,
 	return nil, errs.ErrNotSupported
 }
 
+// Mining returns true if client is actively mining new blocks.
+// This can only return true for proof-of-work networks and may
+// not be available in some clients since The Merge.
+func (b *BlockChainAPI) Mining() bool {
+	return false
+}
+
 func (b *BlockChainAPI) fetchBlockTransactions(
 	ctx context.Context,
 	block *evmTypes.Block,


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/188

## Description

- We update the `eth_accounts` endpoint to return an `[]common.Address{}`, to avoid error from clients which expect the response of this endpoint to be an array, even if empty.
- We add the `eth_mining` endpoint with a default return value of `false`, since Flow EVM does not have the notion of mining.
- We add the `eth_hashrate` endpoint with a default return value of `0`, since Flow EVM does not have the notion of mining.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 