### PR TITLE
Return EIP55-compliant hex string representation of the addresses in …

### DIFF
--- a/models/receipt.go
+++ b/models/receipt.go
@@ -111,13 +111,19 @@ func MarshalReceipt(
 		return map[string]interface{}{}, err
 	}
 
+	var to *string
+	if tx.To() != nil {
+		hexAddr := tx.To().Hex()
+		to = &hexAddr
+	}
+
 	fields := map[string]interface{}{
 		"blockHash":         receipt.BlockHash,
 		"blockNumber":       hexutil.Uint64(receipt.BlockNumber.Uint64()),
 		"transactionHash":   txHash,
 		"transactionIndex":  hexutil.Uint64(receipt.TransactionIndex),
-		"from":              from,
-		"to":                tx.To(),
+		"from":              from.Hex(),
+		"to":                to,
 		"gasUsed":           hexutil.Uint64(receipt.GasUsed),
 		"cumulativeGasUsed": hexutil.Uint64(receipt.CumulativeGasUsed),
 		"contractAddress":   nil,
@@ -140,7 +146,7 @@ func MarshalReceipt(
 
 	// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation
 	if receipt.ContractAddress != (common.Address{}) {
-		fields["contractAddress"] = receipt.ContractAddress
+		fields["contractAddress"] = receipt.ContractAddress.Hex()
 	}
 
 	return fields, nil

--- a/models/receipt.go
+++ b/models/receipt.go
@@ -111,19 +111,13 @@ func MarshalReceipt(
 		return map[string]interface{}{}, err
 	}
 
-	var to *string
-	if tx.To() != nil {
-		hexAddr := tx.To().Hex()
-		to = &hexAddr
-	}
-
 	fields := map[string]interface{}{
 		"blockHash":         receipt.BlockHash,
 		"blockNumber":       hexutil.Uint64(receipt.BlockNumber.Uint64()),
 		"transactionHash":   txHash,
 		"transactionIndex":  hexutil.Uint64(receipt.TransactionIndex),
 		"from":              from.Hex(),
-		"to":                to,
+		"to":                nil,
 		"gasUsed":           hexutil.Uint64(receipt.GasUsed),
 		"cumulativeGasUsed": hexutil.Uint64(receipt.CumulativeGasUsed),
 		"contractAddress":   nil,
@@ -131,6 +125,10 @@ func MarshalReceipt(
 		"logsBloom":         receipt.Bloom,
 		"type":              hexutil.Uint(tx.Type()),
 		"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
+	}
+
+	if tx.To() != nil {
+		fields["to"] = tx.To().Hex()
 	}
 
 	fields["status"] = hexutil.Uint(receipt.Status)


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/87

## Description

The 3 addresses that are part of the `eth_getTransactionReceipt` endpoint, should be in EIP55-compliant hex representation:
- `from`
- `to`
- `contractAddress`

Example:

```json
{
  "jsonrpc": "2.0",
  "id": 8,
  "result": {
    "blockHash": "0x01c401607925dedce4c63485d3487544e53eda273cb52a312b677a7d76822656",
    "blockNumber": "0x3",
    "contractAddress": "0x99466ED2E37B892A2Ee3E9CD55a98b68f5735db2",
    "cumulativeGasUsed": "0x195b0",
    "effectiveGasPrice": "0x0",
    "from": "0x658Bdf435d810C91414eC09147DAA6DB62406379",
    "gasUsed": "0x195b0",
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "status": "0x1",
    "to": null,
    "transactionHash": "0xe414f90fea2aebd75e8c0b3b6a4a0c9928e86c16ea724343d884f40bfe2c4c6b",
    "transactionIndex": "0x0",
    "type": "0x0"
  }
}
```

And

```json
{
  "jsonrpc": "2.0",
  "id": 8,
  "result": {
    "blockHash": "0xd9bb0798e3fd95e7571ea5608364c6040c0e04d19b92c2dced3ee4373a9c727d",
    "blockNumber": "0x4",
    "contractAddress": null,
    "cumulativeGasUsed": "0x57f2",
    "effectiveGasPrice": "0x0",
    "from": "0x658Bdf435d810C91414eC09147DAA6DB62406379",
    "gasUsed": "0x57f2",
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000020000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000",
    "status": "0x1",
    "to": "0x99466ED2E37B892A2Ee3E9CD55a98b68f5735db2",
    "transactionHash": "0x9da005357b95da4b5c485c08f2ac41ecfe868ead4e6856b909a45dc27a6fcf7d",
    "transactionIndex": "0x0",
    "type": "0x0"
  }
}
```

All the receipt data are compliant with what is described in the JSON-RPC API specification.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the handling of transaction addresses in receipts to enhance data accuracy and representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->