### PR TITLE
Run 'npm install' for e2e-test recipe and fail when JS test command errors out regardless of exit code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ test:
 .PHONY: e2e-test
 e2e-test:
 	# test all packages
+	go clean -testcache
+	cd tests/web3js && npm install
 	cd tests && go test -cover ./...
 
 .PHONY: check-tidy

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -7,9 +7,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/onflow/flow-evm-gateway/bootstrap"
-	evmTypes "github.com/onflow/flow-go/fvm/evm/types"
-	"github.com/stretchr/testify/require"
 	"io"
 	"math/big"
 	"net/http"
@@ -18,6 +15,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/onflow/flow-evm-gateway/bootstrap"
+	evmTypes "github.com/onflow/flow-go/fvm/evm/types"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -170,6 +171,7 @@ func executeTest(t *testing.T, testFile string) {
 				}
 				t.Fatalf("unknown test issue: %s, output: %s", err.Error(), string(out))
 			}
+			require.Fail(t, err.Error())
 		}
 		t.Log(string(out))
 	})

--- a/tests/web3js/config.js
+++ b/tests/web3js/config.js
@@ -1,6 +1,6 @@
 const { Web3 } = require('web3')
 
-const web3 = new Web3("http://localhost:8545")
+const web3 = new Web3("http://127.0.0.1:8545")
 
 module.exports = {
     web3: web3,

--- a/tests/web3js/eth_streaming_test.js
+++ b/tests/web3js/eth_streaming_test.js
@@ -20,7 +20,7 @@ it('streaming of logs using filters', async() => {
         { A: repeatA, B: 400 },
     ]
 
-    let ws = new Web3("ws://localhost:8545")
+    let ws = new Web3("ws://127.0.0.1:8545")
 
     // subscribe to new blocks being produced by bellow transaction submission
     let blockCount = 0

--- a/tests/web3js/package-lock.json
+++ b/tests/web3js/package-lock.json
@@ -1209,6 +1209,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -2482,6 +2495,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    },
+    "typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "peer": true
     },
     "undici-types": {
       "version": "5.26.5",


### PR DESCRIPTION
## Description

This caused the client integration tests to be reported as successful, even though they didn't run. The error was:
```bash
fork/exec ./web3js/node_modules/.bin/mocha: no such file or directory
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Improved the efficiency of running end-to-end tests by adding commands to clean test cache and install necessary packages.

- **Refactor**
	- Optimized imports and enhanced test assertions in helper functions for better reliability and readability.
- **Bug Fixes**
	- Updated the URL used to initialize the Web3 instance for improved connectivity.
	- Updated the WebSocket connection URL for enhanced streaming functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->