### PR TITLE
Build with `CGO_ENABLED=1`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY go.* ./
 COPY . ./
 RUN go mod download
 RUN go mod verify
-RUN CGO_ENABLED=0 go build -o evm-gateway ./cmd/main/main.go
+RUN CGO_ENABLED=1 go build -o evm-gateway ./cmd/main/main.go
 RUN chmod a+x evm-gateway
 RUN chmod a+x ./scripts/run.sh
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 
 # Install curl, Git, and other required dependencies
-RUN apt-get update && apt-get install -y curl git
+RUN apt-get update && apt-get install -y curl git gcc
 
 # Download and verify the Go archive
 RUN curl -LO https://go.dev/dl/go1.22.2.linux-amd64.tar.gz && \
@@ -23,7 +23,7 @@ RUN git clone https://github.com/onflow/flow-evm-gateway.git /app/flow-evm-gatew
 
 RUN cd /app/flow-evm-gateway && go mod download
 RUN cd /app/flow-evm-gateway && go mod verify
-RUN cd /app/flow-evm-gateway && CGO_ENABLED=0 go build -o /app/flow-evm-gateway/evm-gateway /app/flow-evm-gateway/cmd/main/main.go
+RUN cd /app/flow-evm-gateway && CGO_ENABLED=1 go build -o /app/flow-evm-gateway/evm-gateway /app/flow-evm-gateway/cmd/main/main.go
 RUN chmod a+x /app/flow-evm-gateway/evm-gateway
 
 # Copy the flow.json file to the directory where the gateway expects to find it


### PR DESCRIPTION
## Description

In https://github.com/onflow/flow-evm-gateway/pull/201, the following line:

```bash
replace github.com/onflow/crypto => github.com/onflow/crypto v0.24.9
```

was removed, which caused the build workflow to fail: https://github.com/onflow/flow-evm-gateway/actions/runs/8680506831/job/23801223323.

So now we build by supplying `CGO_ENABLED=1`
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dockerfile to enhance the build environment with additional tools and configuration adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->