### PR TITLE
Return `null` `to` address for contract creation

### DIFF
--- a/api/models.go
+++ b/api/models.go
@@ -82,7 +82,7 @@ type StorageResult struct {
 type Transaction struct {
 	BlockHash           *common.Hash             `json:"blockHash"`
 	BlockNumber         *hexutil.Big             `json:"blockNumber"`
-	From                *common.MixedcaseAddress `json:"from"`
+	From                common.MixedcaseAddress  `json:"from"`
 	Gas                 hexutil.Uint64           `json:"gas"`
 	GasPrice            *hexutil.Big             `json:"gasPrice"`
 	GasFeeCap           *hexutil.Big             `json:"maxFeePerGas,omitempty"`
@@ -116,9 +116,10 @@ func NewTransaction(tx models.Transaction, receipt types.Receipt) (*Transaction,
 	}
 	from := common.NewMixedcaseAddress(f)
 
-	var to common.MixedcaseAddress
+	var to *common.MixedcaseAddress
 	if t := tx.To(); t != nil {
-		to = common.NewMixedcaseAddress(*t)
+		mixedCaseAddress := common.NewMixedcaseAddress(*t)
+		to = &mixedCaseAddress
 	}
 
 	v, r, s := tx.RawSignatureValues()
@@ -128,8 +129,8 @@ func NewTransaction(tx models.Transaction, receipt types.Receipt) (*Transaction,
 		Hash:             txHash,
 		BlockHash:        &receipt.BlockHash,
 		BlockNumber:      (*hexutil.Big)(receipt.BlockNumber),
-		From:             &from,
-		To:               &to,
+		From:             from,
+		To:               to,
 		Gas:              hexutil.Uint64(receipt.GasUsed),
 		GasPrice:         (*hexutil.Big)(receipt.EffectiveGasPrice),
 		Input:            tx.Data(),

--- a/tests/web3js/eth_deploy_contract_and_interact_test.js
+++ b/tests/web3js/eth_deploy_contract_and_interact_test.js
@@ -12,15 +12,18 @@ it('deploy contract and interact', async() => {
     assert.isString(deployed.receipt.transactionHash)
     assert.isString(contractAddress)
     assert.equal(deployed.receipt.from, conf.eoa.address)
+    assert.isUndefined(deployed.receipt.to)
 
     let rcp = await web3.eth.getTransactionReceipt(deployed.receipt.transactionHash)
     assert.equal(rcp.contractAddress, contractAddress)
     assert.equal(rcp.status, conf.successStatus)
+    assert.isUndefined(rcp.to)
 
     // check if latest block contains the deploy results
     let latestHeight = await web3.eth.getBlockNumber()
     let deployTx = await web3.eth.getTransactionFromBlock(latestHeight, 0)
     assert.equal(deployTx.hash, deployed.receipt.transactionHash)
+    assert.isUndefined(deployTx.to)
 
     let code = await web3.eth.getCode(contractAddress)
     // deploy data has more than just the contract


### PR DESCRIPTION
## Description

As specified by the JSON-RPC API specification (https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactionbyhash), `eth_getTransactionByHash` should return `null` for the `to` field (instead of `0x`), when the transaction is a contract deployment.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of transaction data types for enhanced stability and reliability.

- **Tests**
	- Enhanced testing for smart contracts to ensure the integrity of transaction receipts and details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->