### PR TITLE
Populate the `logsBloom` field for the endpoints that return block info

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -769,10 +769,18 @@ func (b *BlockChainAPI) prepareBlockResponse(
 	}
 	if len(transactions) > 0 {
 		totalGasUsed := hexutil.Uint64(0)
+		logs := make([]*types.Log, 0)
 		for _, tx := range transactions {
+			txReceipt, err := b.receipts.GetByTransactionID(tx.Hash)
+			if err != nil {
+				return nil, err
+			}
 			totalGasUsed += tx.Gas
+			logs = append(logs, txReceipt.Logs...)
 		}
 		blockResponse.GasUsed = totalGasUsed
+		// TODO(m-Peter): Consider if its worthwhile to move this in storage.
+		blockResponse.LogsBloom = types.LogsBloom(logs)
 	}
 
 	if fullTx {

--- a/tests/web3js/eth_deploy_contract_and_interact_test.js
+++ b/tests/web3js/eth_deploy_contract_and_interact_test.js
@@ -60,5 +60,20 @@ it('deploy contract and interact', async() => {
     assert.equal(updateRcp.status, conf.successStatus)
     assert.equal(updateTx.data, updateData)
 
+    // submit a transaction that emits logs
+    res = await helpers.signAndSend({
+        from: conf.eoa.address,
+        to: contractAddress,
+        data: deployed.contract.methods.sum(100, 200).encodeABI(),
+        gas: 1000000,
+        gasPrice: 0
+    })
+    assert.equal(res.receipt.status, conf.successStatus)
+
+    // assert that logsBloom from transaction receipt and block match
+    latestHeight = await web3.eth.getBlockNumber()
+    let block = await web3.eth.getBlock(latestHeight)
+    assert.equal(block.logsBloom, res.receipt.logsBloom)
+
 }).timeout(10*1000)
 

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -17,7 +17,7 @@ it('get block', async () => {
     assert.notDeepEqual(block, {})
     assert.isString(block.hash)
     assert.isString(block.parentHash)
-    assert.isString(block.logsBloom)
+    assert.lengthOf(block.logsBloom, 514)
 
     let blockHash = await web3.eth.getBlock(block.hash)
     assert.deepEqual(block, blockHash)


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/208

## Description

The value for this field can be derived by the logs that can be found on transaction receipts, for a given block. For example:
```json
{
  "jsonrpc": "2.0",
  "id": 7,
  "result": {
    "number": "0x4",
    "hash": "0x0c122ce3fa81c2404226160b757c94afb6302d154d418991cec0890392839030",
    "parentHash": "0x584c9a6585cb2bce5756201db76a76ed9c5ada6a67820b656f9e1aca61c5f121",
    "nonce": "0x0100000000000000",
    "sha3Uncles": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000020000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000",
    "transactionsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "receiptsRoot": "0xeb82225d55f1d7495304835b501cc5c4abbce9f8024cf031195a66e3265a8e55",
    "miner": "0x0000000000000000000000000000000000000000",
    "difficulty": "0x0",
    "totalDifficulty": "0x0",
    "extraData": "0x",
    "size": "0x0",
    "gasLimit": "0xe4e1c0",
    "gasUsed": "0x57f2",
    "timestamp": "0x0",
    "transactions": [
      {...}
    ],
    "uncles": [],
    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
  }
}
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced block response in the API to include transaction receipts, logs, and total gas used.
	- Updated the block response to calculate and display the `LogsBloom` field accurately.

- **Tests**
	- Added tests to verify interactions with deployed contracts and logging functionality.
	- Improved validation for the `logsBloom` property in block responses to ensure accuracy in length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->