### PR TITLE
Add `mux.Lock()` and `mux.Unlock()` during tests to avoid data race warning

### DIFF
--- a/api/pull_test.go
+++ b/api/pull_test.go
@@ -69,6 +69,9 @@ func TestFilterExpiryChecker(t *testing.T) {
 			// sleep to let the goroutine work
 			time.Sleep(100 * time.Millisecond)
 
+			api.mux.Lock()
+			defer api.mux.Unlock()
+
 			if len(api.filters) > 0 {
 				for id, f := range api.filters {
 					require.Falsef(t, f.expired(), "filter with id %s should be expired", id)


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/204

## Description

Fixes a data race warning coming from tests.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved synchronization in data access to enhance stability and performance.
	- Added a mutex lock and unlock for proper synchronization in the `TestFilterExpiryChecker` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->