### PR TITLE
Use decoder for `EVM.Result` structs from evm `stdlib` package

### DIFF
--- a/services/requester/cadence/call.cdc
+++ b/services/requester/cadence/call.cdc
@@ -1,13 +1,12 @@
 import EVM
 
 access(all)
-fun main(hexEncodedTx: String): String {
+fun main(hexEncodedTx: String): EVM.Result {
     let account = getAuthAccount<auth(Storage) &Account>(Address(0xCOA))
 
     let coa = account.storage.borrow<&EVM.CadenceOwnedAccount>(
         from: /storage/evm
     ) ?? panic("Could not borrow reference to the COA!")
-    let txResult = EVM.run(tx: hexEncodedTx.decodeHex(), coinbase: coa.address())
 
-    return String.encodeHex(txResult.data)
+    return EVM.run(tx: hexEncodedTx.decodeHex(), coinbase: coa.address())
 }

--- a/services/requester/cadence/estimate_gas.cdc
+++ b/services/requester/cadence/estimate_gas.cdc
@@ -1,13 +1,12 @@
 import EVM
 
 access(all)
-fun main(hexEncodedTx: String): [UInt64; 2] {
+fun main(hexEncodedTx: String): EVM.Result {
     let account = getAuthAccount<auth(Storage) &Account>(Address(0xCOA))
 
     let coa = account.storage.borrow<&EVM.CadenceOwnedAccount>(
         from: /storage/evm
     ) ?? panic("Could not borrow reference to the COA!")
-    let txResult = EVM.run(tx: hexEncodedTx.decodeHex(), coinbase: coa.address())
 
-    return [txResult.errorCode, txResult.gasUsed]
+    return EVM.run(tx: hexEncodedTx.decodeHex(), coinbase: coa.address())
 }

--- a/tests/web3js/eth_transfer_between_eoa_accounts_test.js
+++ b/tests/web3js/eth_transfer_between_eoa_accounts_test.js
@@ -4,76 +4,90 @@ const conf = require('./config')
 const helpers = require('./helpers')
 const web3 = conf.web3
 
-it('transfer flow between two EOA accounts', async() => {
-    let receiver = web3.eth.accounts.create()
+it('transfer flow between two EOA accounts', async () => {
+  // TODO: Temporary workaround until `EVM.dryRun` is introduced
+  let transferValue = utils.toWei("0.5", "ether")
+  const signedTx = await conf.eoa.signTransaction({
+    from: conf.eoa.address,
+    to: '0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B',
+    value: transferValue,
+    gasPrice: '0',
+    gasLimit: 55000,
+  })
+  let response = await helpers.callRPCMethod('eth_sendRawTransaction', [signedTx.rawTransaction])
+  assert.equal(200, response.status)
+  assert.isDefined(response.body['result'])
 
-    // make sure receiver balance is initially 0
-    let receiverWei = await web3.eth.getBalance(receiver.address)
-    assert.equal(receiverWei, 0n)
+  let receiver = web3.eth.accounts.create()
 
-    // get sender balance
-    let senderBalance = await web3.eth.getBalance(conf.eoa.address)
-    assert.equal(senderBalance, utils.toWei(conf.fundedAmount, "ether"))
+  // make sure receiver balance is initially 0
+  let receiverWei = await web3.eth.getBalance(receiver.address)
+  assert.equal(receiverWei, 0n)
 
-    let txCount = await web3.eth.getTransactionCount(conf.eoa.address)
-    assert.equal(0n, txCount)
+  // get sender balance
+  let senderBalance = await web3.eth.getBalance(conf.eoa.address)
+  // we moved some value before, for `eth_call` to work properly with the
+  // test EOA.
+  assert.equal(senderBalance, utils.toWei(conf.fundedAmount, "ether") - transferValue)
 
-    let transferValue = utils.toWei("0.5", "ether")
-    let transfer = await helpers.signAndSend({
-        from: conf.eoa.address,
-        to: receiver.address,
-        value: transferValue,
-        gasPrice: '0',
-        gasLimit: 55000,
-    })
-    assert.equal(transfer.receipt.status, conf.successStatus)
-    assert.equal(transfer.receipt.from, conf.eoa.address)
-    assert.equal(transfer.receipt.to, receiver.address)
+  let txCount = await web3.eth.getTransactionCount(conf.eoa.address)
+  assert.equal(1n, txCount)
 
-    // check that transaction count was increased
-    txCount = await web3.eth.getTransactionCount(conf.eoa.address)
-    assert.equal(1n, txCount)
+  let transfer = await helpers.signAndSend({
+    from: conf.eoa.address,
+    to: receiver.address,
+    value: transferValue,
+    gasPrice: '0',
+    gasLimit: 55000,
+  })
+  assert.equal(transfer.receipt.status, conf.successStatus)
+  assert.equal(transfer.receipt.from, conf.eoa.address)
+  assert.equal(transfer.receipt.to, receiver.address)
 
-    // check balance was moved
-    receiverWei = await web3.eth.getBalance(receiver.address)
+  // check that transaction count was increased
+  txCount = await web3.eth.getTransactionCount(conf.eoa.address)
+  assert.equal(2n, txCount)
+
+  // check balance was moved
+  receiverWei = await web3.eth.getBalance(receiver.address)
+  assert.equal(receiverWei, transferValue)
+
+  senderBalance = await web3.eth.getBalance(conf.eoa.address)
+  assert.equal(senderBalance, utils.toWei(conf.fundedAmount, "ether") - (2*transferValue))
+
+  // make sure latest block includes the transfer tx
+  let latest = await web3.eth.getBlockNumber()
+  let transferTx = await web3.eth.getTransactionFromBlock(latest, 0)
+  assert.equal(transferTx.hash, transfer.receipt.transactionHash)
+  assert.equal(transferTx.value, transferValue)
+
+  // check that getTransactionCount can handle specific block heights
+  txCount = await web3.eth.getTransactionCount(conf.eoa.address, latest - 1n)
+  assert.equal(1n, txCount)
+
+  // get balance at special block tags
+  let blockTags = ["latest", "pending", "safe", "finalized"]
+  for (let blockTag of blockTags) {
+    receiverWei = await web3.eth.getBalance(receiver.address, blockTag)
     assert.equal(receiverWei, transferValue)
+  }
 
-    senderBalance = await web3.eth.getBalance(conf.eoa.address)
-    assert.equal(senderBalance, utils.toWei(conf.fundedAmount, "ether")-transferValue)
+  // get balance at earliest block tag
+  receiverWei = await web3.eth.getBalance(receiver.address, "earliest")
+  assert.equal(receiverWei, 0n)
 
-    // make sure latest block includes the transfer tx
-    let latest = await web3.eth.getBlockNumber()
-    let transferTx = await web3.eth.getTransactionFromBlock(latest, 0)
-    assert.equal(transferTx.hash, transfer.receipt.transactionHash)
-    assert.equal(transferTx.value, transferValue)
+  // get balance at past block
+  receiverWei = await web3.eth.getBalance(receiver.address, latest - 1n)
+  assert.equal(receiverWei, 0n)
 
-    // check that getTransactionCount can handle specific block heights
-    txCount = await web3.eth.getTransactionCount(conf.eoa.address, latest - 1n)
-    assert.equal(0n, txCount)
+  // get balance at non-existent block number
+  try {
+    receiverWei = await web3.eth.getBalance(receiver.address, latest + 15n)
+  } catch (error) {
+    assert.match(error.message, /entity not found/)
+  }
 
-    // get balance at special block tags
-    let blockTags = ["latest", "pending", "safe", "finalized"]
-    for (let blockTag of blockTags) {
-        receiverWei = await web3.eth.getBalance(receiver.address, blockTag)
-        assert.equal(receiverWei, transferValue)
-    }
-
-    // get balance at earliest block tag
-    receiverWei = await web3.eth.getBalance(receiver.address, "earliest")
-    assert.equal(receiverWei, 0n)
-
-    // get balance at past block
-    receiverWei = await web3.eth.getBalance(receiver.address, latest - 1n)
-    assert.equal(receiverWei, 0n)
-
-    // get balance at non-existent block number
-    try {
-        receiverWei = await web3.eth.getBalance(receiver.address, latest + 15n)
-    } catch(error) {
-        assert.match(error.message, /entity not found/)
-    }
-
-    // get balance at latest block number
-    receiverWei = await web3.eth.getBalance(receiver.address, latest)
-    assert.equal(receiverWei, transferValue)
-}).timeout(10*1000)
+  // get balance at latest block number
+  receiverWei = await web3.eth.getBalance(receiver.address, latest)
+  assert.equal(receiverWei, transferValue)
+}).timeout(10 * 1000)


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/171

## Description

With this, we can now return this `EVM.Result` struct in Cadence scripts (`call.cdc` / `estimate_gas.cdc`) used by the Gateway:

```cadence
access(all)
fun main(hexEncodedTx: String): EVM.Result
```

And access all of its fields in the Go code-base.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the results processing in blockchain interactions to provide clearer outcomes and error handling.
  
- **Bug Fixes**
	- Implemented a temporary workaround in transaction testing to ensure reliability until further updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->