### PR TITLE
Return proper timestamp value for block endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -579,6 +579,7 @@ func (b *BlockChainAPI) prepareBlockResponse(
 		Uncles:       []common.Hash{},
 		GasLimit:     hexutil.Uint64(15_000_000),
 		Nonce:        types.BlockNonce{0x1},
+		Timestamp:    hexutil.Uint64(block.Timestamp),
 	}
 
 	transactions, err := b.fetchBlockTransactions(ctx, block)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/onflow/flow-evm-gateway
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593

--- a/models/block.go
+++ b/models/block.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/go-ethereum/common"

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,8 +1,6 @@
 module github.com/onflow/flow-evm-gateway/integration
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/goccy/go-json v0.10.2

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -18,6 +18,8 @@ it('get block', async () => {
     assert.isString(block.hash)
     assert.isString(block.parentHash)
     assert.lengthOf(block.logsBloom, 514)
+    assert.isDefined(block.timestamp)
+    assert.isTrue(block.timestamp >= 1714413860n)
 
     let blockHash = await web3.eth.getBlock(block.hash)
     assert.deepEqual(block, blockHash)


### PR DESCRIPTION
## Description

Include the `timestamp` field in the endpoints that return block info.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 