### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,5 @@ COPY --from=builder /flow-evm-gateway/evm-gateway /flow-evm-gateway/evm-gateway
 COPY --from=builder /flow-evm-gateway/previewnet-keys.json /flow-evm-gateway/previewnet-keys.json
 COPY --from=builder /flow-evm-gateway/scripts/run.sh /flow-evm-gateway/run.sh
 EXPOSE 8545
-CMD cd /flow-evm-gateway && ./run.sh
+WORKDIR /flow-evm-gateway
+ENTRYPOINT ["sh", "run.sh"]


### PR DESCRIPTION
Switch to ENTRYPOINT

Entrypoint allows us to do `docker run <image_name> -c "--flags"` which is what we have set up with ansible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the Docker configuration to enhance the initialization of the application by using `ENTRYPOINT` for running scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->