### PR TITLE
Add force set height flag

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -47,6 +47,14 @@ func Start(ctx context.Context, cfg *config.Config) error {
 		logger.Info().Msg("database initialized with 0 evm and cadence heights")
 	}
 
+	// this should only be used locally or for testing
+	if cfg.ForceStartCadenceHeight != 0 {
+		logger.Warn().Uint64("height", cfg.ForceStartCadenceHeight).Msg("force setting starting Cadence height!!!")
+		if err := blocks.SetLatestCadenceHeight(cfg.ForceStartCadenceHeight); err != nil {
+			return err
+		}
+	}
+
 	go func() {
 		err := startServer(
 			ctx,

--- a/config/config.go
+++ b/config/config.go
@@ -65,13 +65,15 @@ type Config struct {
 	StreamTimeout time.Duration
 	// FilterExpiry defines the time it takes for an idle filter to expire
 	FilterExpiry time.Duration
+	// ForceStartCadenceHeight will force set the starting Cadence height, this should be only used for testing or locally.
+	ForceStartCadenceHeight uint64
 }
 
 func FromFlags() (*Config, error) {
 	cfg := &Config{}
 	var evmNetwork, coinbase, gas, coa, key, keysPath, flowNetwork, logLevel, filterExpiry string
 	var streamTimeout int
-	var initHeight uint64
+	var initHeight, forceStartHeight uint64
 
 	// parse from flags
 	flag.StringVar(&cfg.DatabaseDir, "database-dir", "./db", "Path to the directory for the database")
@@ -90,6 +92,7 @@ func FromFlags() (*Config, error) {
 	flag.StringVar(&logLevel, "log-level", "debug", "Define verbosity of the log output ('debug', 'info', 'error')")
 	flag.Float64Var(&cfg.StreamLimit, "stream-limit", 10, "Rate-limits the events sent to the client within one second")
 	flag.IntVar(&streamTimeout, "stream-timeout", 3, "Defines the timeout in seconds the server waits for the event to be sent to the client")
+	flag.Uint64Var(&forceStartHeight, "force-start-height", 0, "Force set starting Cadence height. This should only be used locally or for testing, never in production.")
 	flag.StringVar(&filterExpiry, "filter-expiry", "5m", "Filter defines the time it takes for an idle filter to expire")
 	flag.Parse()
 
@@ -180,6 +183,10 @@ func FromFlags() (*Config, error) {
 		return nil, fmt.Errorf("filter expiry not valid unit: %w", err)
 	}
 	cfg.FilterExpiry = exp
+
+	if forceStartHeight != 0 {
+		cfg.ForceStartCadenceHeight = forceStartHeight
+	}
 
 	// todo validate Config values
 	return cfg, nil


### PR DESCRIPTION
## Description
This flag can force set the starting height even if the database contains existing indexed blocks.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a configuration option to manually set the starting Cadence height, enhancing control over operational parameters.

- **Bug Fixes**
	- Implemented a warning system for cases where the starting Cadence height is set manually, ensuring users are aware of the implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->