### PR TITLE
Set fixed height flag

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -5,4 +5,5 @@
   --coa-address 0x585ef6547d41cc98 \
   --coa-key-file ./previewnet-keys.json \
   --coa-resource-create \
-  --gas-price 0
+  --gas-price 0 \
+  --force-start-height 10814323


### PR DESCRIPTION
Force set the flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an option to specify a start height for operations in the application's run script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->