### PR TITLE
Revert "Set fixed height flag"

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -5,5 +5,4 @@
   --coa-address 0x585ef6547d41cc98 \
   --coa-key-file ./previewnet-keys.json \
   --coa-resource-create \
-  --gas-price 0 \
-  --force-start-height 10814323
+  --gas-price 0


### PR DESCRIPTION
Reverts onflow/flow-evm-gateway#233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
	- Updated the script to remove the `--force-start-height` option and set the `--gas-price` to 0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->