### PR TITLE
Improve error logging for `eth_call` JSON-RPC endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -423,8 +423,8 @@ func (b *BlockChainAPI) Call(
 
 	res, err := b.evm.Call(ctx, tx, from, cadenceHeight)
 	if err != nil {
-		b.logger.Error().Err(err).Msg("failed to execute call")
-		return handleError[hexutil.Bytes](b.logger, errs.ErrInternal)
+		b.logger.Debug().Err(err).Msg("failed to execute call")
+		return nil, err
 	}
 
 	return res, nil

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -323,6 +323,10 @@ func (e *EVM) Call(
 	from common.Address,
 	height uint64,
 ) ([]byte, error) {
+	e.logger.Debug().
+		Str("data", fmt.Sprintf("%x", data)).
+		Msg("call")
+
 	hexEncodedTx, err := cadence.NewString(hex.EncodeToString(data))
 	if err != nil {
 		return nil, err
@@ -332,10 +336,6 @@ func (e *EVM) Call(
 	if err != nil {
 		return nil, err
 	}
-
-	e.logger.Debug().
-		Str("data", fmt.Sprintf("%x", data)).
-		Msg("call")
 
 	scriptResult, err := e.executeScriptAtHeight(
 		ctx,


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/238

## Description

Failures from `EVM.dryRun`, used by the `eth_call` endpoint, should not be logged as errors, as they only occur from the passed-in user transaction arguments. Logging them as errors will only skew the Grafana dashboards, as these are not actionable errors.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 