### PR TITLE
Always add a buffer gas of `SstoreSentryGasEIP2200` for `eth_estimateGas` endpoint

### DIFF
--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -20,6 +20,7 @@ import (
 	gethCore "github.com/onflow/go-ethereum/core"
 	"github.com/onflow/go-ethereum/core/types"
 	gethVM "github.com/onflow/go-ethereum/core/vm"
+	"github.com/onflow/go-ethereum/params"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 
@@ -401,7 +402,14 @@ func (e *EVM) EstimateGas(
 		return 0, getErrorForCode(evmResult.ErrorCode)
 	}
 
-	return evmResult.GasConsumed, nil
+	// This minimum gas availability is needed for:
+	// https://github.com/onflow/go-ethereum/blob/master/core/vm/operations_acl.go#L29-L32
+	// Note that this is not actually consumed in the end.
+	// TODO: Consider moving this to `EVM.dryRun`, if we want the
+	// fix to also apply for the EVM API, on Cadence side.
+	gasConsumed := evmResult.GasConsumed + params.SstoreSentryGasEIP2200 + 1
+
+	return gasConsumed, nil
 }
 
 func (e *EVM) GetCode(

--- a/tests/web3js/eth_deploy_contract_and_interact_test.js
+++ b/tests/web3js/eth_deploy_contract_and_interact_test.js
@@ -44,11 +44,27 @@ it('deploy contract and interact', async() => {
     result = await web3.eth.call({to: contractAddress, data: callRetrieve}, "latest")
     assert.equal(result, initValue)
 
-    // update the value on the contract
-    let newValue = 100
-    let updateData = deployed.contract.methods.store(newValue).encodeABI()
+    // set the value on the contract, to its current value
+    let updateData = deployed.contract.methods.store(initValue).encodeABI()
     // store a value in the contract
     let res = await helpers.signAndSend({
+        from: conf.eoa.address,
+        to: contractAddress,
+        data: updateData,
+        value: '0',
+        gasPrice: '0',
+    })
+    assert.equal(res.receipt.status, conf.successStatus)
+
+    // check the new value on contract
+    result = await web3.eth.call({to: contractAddress, data: callRetrieve}, "latest")
+    assert.equal(result, initValue)
+
+    // update the value on the contract
+    newValue = 100
+    updateData = deployed.contract.methods.store(newValue).encodeABI()
+    // store a value in the contract
+    res = await helpers.signAndSend({
         from: conf.eoa.address,
         to: contractAddress,
         data: updateData,


### PR DESCRIPTION
## Description

There was a strange issue reported, when a tx was attempting to update a contract's field, to its current value.

The `eth_estimateGas` would return a gas estimation of `28380`, but when sending the tx with this value as the gas limit, then it would error out with an `errorCode` of `301, which is `out of gas`.

The problem arises from this check: https://github.com/onflow/go-ethereum/blob/master/core/vm/operations_acl.go#L29-L32.

In this PR, we update the `eth_estimateGas` endpoint to add [SstoreSentryGasEIP2200](https://github.com/onflow/go-ethereum/blob/fb8de1862fe8db58b76aebf13f8f1183e6c67608/params/protocol_params.go#L61), to the gas consumed returned by `EVM.dryRun`. Note that the gas value of `SstoreSentryGasEIP2200` is not actually consumed, but it has to be available._____

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 