### PR TITLE
Revamp `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,6 @@ RUN chmod a+x bin
 
 FROM debian:latest
 
-ENV ACCESS_NODE_GRPC_HOST=""
-ENV RPC_PORT=""
-ENV FLOW_NETWORK_ID=""
-ENV COINBASE=""
-ENV COA_ADDRESS=""
-ENV COA_KEY_FILE=""
-ENV COA_RESOURCE_CREATE=""
-ENV GAS_PRICE=""
-ENV INIT_CADENCE_HEIGHT=""
-
 WORKDIR /flow-evm-gateway
 
 RUN apt-get update
@@ -39,12 +29,4 @@ COPY --from=app-builder /app/previewnet-keys.json /flow-evm-gateway/previewnet-k
 
 EXPOSE 8545
 
-ENTRYPOINT /flow-evm-gateway/app -access-node-grpc-host=$ACCESS_NODE_GRPC_HOST \
-    -rpc-port=$RPC_PORT \
-    -flow-network-id=$FLOW_NETWORK_ID \
-    -coinbase=$COINBASE \
-    -coa-address=$COA_ADDRESS \
-    -coa-key-file=$COA_KEY_FILE \
-    -coa-resource-create=$COA_RESOURCE_CREATE \
-    -gas-price=$GAS_PRICE \
-    -init-cadence-height=$INIT_CADENCE_HEIGHT
+ENTRYPOINT ["/flow-evm-gateway/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,12 @@ COPY --from=app-builder /app/previewnet-keys.json /flow-evm-gateway/previewnet-k
 
 EXPOSE 8545
 
-ENTRYPOINT /flow-evm-gateway/app -access-node-grpc-host=$ACCESS_NODE_GRPC_HOST -rpc-port=$RPC_PORT -flow-network-id=$FLOW_NETWORK_ID -coinbase=$COINBASE -coa-address=$COA_ADDRESS -coa-key-file=$COA_KEY_FILE -coa-resource-create=$COA_RESOURCE_CREATE -gas-price=$GAS_PRICE -init-cadence-height=$INIT_CADENCE_HEIGHT
+ENTRYPOINT /flow-evm-gateway/app -access-node-grpc-host=$ACCESS_NODE_GRPC_HOST \
+    -rpc-port=$RPC_PORT \
+    -flow-network-id=$FLOW_NETWORK_ID \
+    -coinbase=$COINBASE \
+    -coa-address=$COA_ADDRESS \
+    -coa-key-file=$COA_KEY_FILE \
+    -coa-resource-create=$COA_RESOURCE_CREATE \
+    -gas-price=$GAS_PRICE \
+    -init-cadence-height=$INIT_CADENCE_HEIGHT

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,16 @@ RUN chmod a+x bin
 
 FROM debian:latest
 
+ENV ACCESS_NODE_GRPC_HOST=""
+ENV RPC_PORT=""
+ENV FLOW_NETWORK_ID=""
+ENV COINBASE=""
+ENV COA_ADDRESS=""
+ENV COA_KEY_FILE=""
+ENV COA_RESOURCE_CREATE=""
+ENV GAS_PRICE=""
+ENV INIT_CADENCE_HEIGHT=""
+
 WORKDIR /flow-evm-gateway
 
 RUN apt-get update
@@ -29,4 +39,4 @@ COPY --from=app-builder /app/previewnet-keys.json /flow-evm-gateway/previewnet-k
 
 EXPOSE 8545
 
-ENTRYPOINT ["/flow-evm-gateway/app"]
+ENTRYPOINT /flow-evm-gateway/app -access-node-grpc-host=$ACCESS_NODE_GRPC_HOST -rpc-port=$RPC_PORT -flow-network-id=$FLOW_NETWORK_ID -coinbase=$COINBASE -coa-address=$COA_ADDRESS -coa-key-file=$COA_KEY_FILE -coa-resource-create=$COA_RESOURCE_CREATE -gas-price=$GAS_PRICE -init-cadence-height=$INIT_CADENCE_HEIGHT

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,8 +1,0 @@
-./evm-gateway --access-node-grpc-host access.previewnet.nodes.onflow.org:9000 \
-  --rpc-port 3000 \
-  --flow-network-id flow-previewnet \
-  --coinbase FACF71692421039876a5BB4F10EF7A439D8ef61E \
-  --coa-address 0x585ef6547d41cc98 \
-  --coa-key-file ./previewnet-keys.json \
-  --coa-resource-create \
-  --gas-price 0


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/101

## Description

- Removes the `run.sh` bash script, which contained configuration for PreviewNet deployments
- Revamps the `Dockerfile` to use `ENV` variables.

Example of running a Docker container of a built image:

```bash
docker run -e ACCESS_NODE_GRPC_HOST="access.previewnet.nodes.onflow.org:9000" -e RPC_PORT="8545" -e FLOW_NETWORK_ID="flow-previewnet" -e COINBASE="FACF71692421039876a5BB4F10EF7A439D8ef61E" -e COA_ADDRESS="0x585ef6547d41cc98" -e COA_KEY_FILE="./previewnet-keys.json" -e COA_RESOURCE_CREATE="false" -e GAS_PRICE="0" -e INIT_CADENCE_HEIGHT="12740483" -d -p 127.0.0.1:8545:8545 onflow/flow-evm-gateway
```
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Docker base image version for security and compatibility enhancements.
  - Renamed the builder stage in the Dockerfile for clarity and organization.
  - Adjusted binary build commands in the Dockerfile for improved efficiency.
  - Set environment variables for better configuration management.
  - Modified final image setup for optimized application runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->