### PR TITLE
Add a first implementation for `eth_feeHistory` JSON-RPC API endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -26,6 +26,8 @@ import (
 	storageErrs "github.com/onflow/flow-evm-gateway/storage/errors"
 )
 
+const maxFeeHistoryBlockCount = 1024
+
 func SupportedAPIs(blockChainAPI *BlockChainAPI, streamAPI *StreamAPI, pullAPI *PullAPI) []rpc.API {
 	return []rpc.API{{
 		Namespace: "eth",
@@ -610,7 +612,7 @@ func (b *BlockChainAPI) EstimateGas(
 	tx, err := encodeTxFromArgs(args)
 	if err != nil {
 		b.logger.Error().Err(err).Msg("failed to encode transaction for gas estimate")
-		return hexutil.Uint64(defaultGasLimit), nil // return default gas limit
+		return hexutil.Uint64(blockGasLimit), nil // return block gas limit
 	}
 
 	// Default address in case user does not provide one
@@ -707,15 +709,16 @@ func (b *BlockChainAPI) prepareBlockResponse(
 	}
 
 	blockResponse := &Block{
-		Hash:         h,
-		Number:       hexutil.Uint64(block.Height),
-		ParentHash:   block.ParentBlockHash,
-		ReceiptsRoot: block.ReceiptRoot,
-		Transactions: block.TransactionHashes,
-		Uncles:       []common.Hash{},
-		GasLimit:     hexutil.Uint64(15_000_000),
-		Nonce:        types.BlockNonce{0x1},
-		Timestamp:    hexutil.Uint64(block.Timestamp),
+		Hash:          h,
+		Number:        hexutil.Uint64(block.Height),
+		ParentHash:    block.ParentBlockHash,
+		ReceiptsRoot:  block.ReceiptRoot,
+		Transactions:  block.TransactionHashes,
+		Uncles:        []common.Hash{},
+		GasLimit:      hexutil.Uint64(blockGasLimit),
+		Nonce:         types.BlockNonce{0x1},
+		Timestamp:     hexutil.Uint64(block.Timestamp),
+		BaseFeePerGas: hexutil.Big(*big.NewInt(0)),
 	}
 
 	// todo remove after previewnet, temp fix to mock some of the timestamps
@@ -772,6 +775,80 @@ func (b *BlockChainAPI) getBlockNumber(blockNumberOrHash *rpc.BlockNumberOrHash)
 	}
 
 	return 0, fmt.Errorf("invalid arguments; neither block nor hash specified")
+}
+
+// FeeHistory returns transaction base fee per gas and effective priority fee
+// per gas for the requested/supported block range.
+// blockCount: Requested range of blocks. Clients will return less than the
+// requested range if not all blocks are available.
+// lastBlock: Highest block of the requested range.
+// rewardPercentiles: A monotonically increasing list of percentile values.
+// For each block in the requested range, the transactions will be sorted in
+// ascending order by effective tip per gas and the coresponding effective tip
+// for the percentile will be determined, accounting for gas consumed.
+func (b *BlockChainAPI) FeeHistory(
+	ctx context.Context,
+	blockCount math.HexOrDecimal64,
+	lastBlock rpc.BlockNumber,
+	rewardPercentiles []float64,
+) (*FeeHistoryResult, error) {
+	if blockCount > maxFeeHistoryBlockCount {
+		return nil, fmt.Errorf("block count has to be between 1 and 1024")
+	}
+
+	lastBlockNumber := uint64(lastBlock)
+	var err error
+	if lastBlock < 0 {
+		// From the special block tags, we only support "latest".
+		lastBlockNumber, err = b.blocks.LatestEVMHeight()
+		if err != nil {
+			return nil, fmt.Errorf("could not fetch latest EVM block number")
+		}
+	}
+
+	var oldestBlock *hexutil.Big
+	baseFees := []*hexutil.Big{}
+	rewards := [][]*hexutil.Big{}
+	gasUsedRatios := []float64{}
+
+	maxCount := uint64(blockCount)
+	if maxCount > lastBlockNumber {
+		maxCount = lastBlockNumber
+	}
+
+	blockRewards := make([]*hexutil.Big, len(rewardPercentiles))
+	for i := range rewardPercentiles {
+		blockRewards[i] = (*hexutil.Big)(b.config.GasPrice)
+	}
+
+	for i := maxCount; i >= uint64(1); i-- {
+		// If the requested block count is 5, and the last block number
+		// is 20, then we need the blocks [16, 17, 18, 19, 20] in this
+		// specific order. The first block we fetch is 20 - 5 + 1 = 16.
+		blockHeight := lastBlockNumber - i + 1
+		block, err := b.blocks.GetByHeight(blockHeight)
+		if err != nil {
+			continue
+		}
+
+		if i == maxCount {
+			oldestBlock = (*hexutil.Big)(big.NewInt(int64(block.Height)))
+		}
+
+		baseFees = append(baseFees, (*hexutil.Big)(big.NewInt(0)))
+
+		rewards = append(rewards, blockRewards)
+
+		gasUsedRatio := float64(block.TotalGasUsed) / float64(blockGasLimit)
+		gasUsedRatios = append(gasUsedRatios, gasUsedRatio)
+	}
+
+	return &FeeHistoryResult{
+		OldestBlock:  oldestBlock,
+		Reward:       rewards,
+		BaseFee:      baseFees,
+		GasUsedRatio: gasUsedRatios,
+	}, nil
 }
 
 /* ====================================================================================================================
@@ -885,24 +962,6 @@ func (b *BlockChainAPI) CreateAccessList(
 	args TransactionArgs,
 	blockNumberOrHash *rpc.BlockNumberOrHash,
 ) (*AccessListResult, error) {
-	return nil, errs.ErrNotSupported
-}
-
-// FeeHistory returns transaction base fee per gas and effective priority fee
-// per gas for the requested/supported block range.
-// blockCount: Requested range of blocks. Clients will return less than the
-// requested range if not all blocks are available.
-// lastBlock: Highest block of the requested range.
-// rewardPercentiles: A monotonically increasing list of percentile values.
-// For each block in the requested range, the transactions will be sorted in
-// ascending order by effective tip per gas and the coresponding effective tip
-// for the percentile will be determined, accounting for gas consumed.
-func (b *BlockChainAPI) FeeHistory(
-	ctx context.Context,
-	blockCount math.HexOrDecimal64,
-	lastBlock rpc.BlockNumber,
-	rewardPercentiles []float64,
-) (*FeeHistoryResult, error) {
 	return nil, errs.ErrNotSupported
 }
 

--- a/api/encode_transaction.go
+++ b/api/encode_transaction.go
@@ -6,7 +6,7 @@ import (
 	"github.com/onflow/go-ethereum/core/types"
 )
 
-const defaultGasLimit uint64 = 15_000_000
+const blockGasLimit uint64 = 15_000_000
 
 // encodeTxFromArgs will create a transaction from the given arguments.
 // The resulting unsigned transaction is only supposed to be used through
@@ -23,7 +23,7 @@ func encodeTxFromArgs(args TransactionArgs) ([]byte, error) {
 
 	// provide a high enough gas for the tx to be able to execute,
 	// capped by the gas set in transaction args.
-	gasLimit := defaultGasLimit
+	gasLimit := blockGasLimit
 	if args.Gas != nil {
 		gasLimit = uint64(*args.Gas)
 	}

--- a/api/models.go
+++ b/api/models.go
@@ -187,6 +187,7 @@ type Block struct {
 	Transactions     interface{}      `json:"transactions"`
 	Uncles           []common.Hash    `json:"uncles"`
 	MixHash          common.Hash      `json:"mixHash"`
+	BaseFeePerGas    hexutil.Big      `json:"baseFeePerGas"`
 }
 
 type SyncStatus struct {

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -1,6 +1,7 @@
 const web3Utils = require('web3-utils')
 const { assert } = require('chai')
 const conf = require('./config')
+const helpers = require('./helpers')
 const web3 = conf.web3
 
 it('get chain ID', async () => {
@@ -193,4 +194,18 @@ it('can make batch requests', async () => {
     } catch (error) {
         assert.equal(error.innerError[0].message, 'batch too large')
     }
+})
+
+it('get fee history', async () => {
+    let response = await web3.eth.getFeeHistory(10, 'latest', [20])
+
+    assert.deepEqual(
+        response,
+        {
+            oldestBlock: 1n,
+            reward: [['0x0'], ['0x0'], ['0x0']], // gas price is always 0 during testing
+            baseFeePerGas: [0n, 0n, 0n],
+            gasUsedRatio: [0.04684, 0.0014036666666666666, 0.0014]
+        }
+    )
 })


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/143

## Description

A sample response can be seen below:
```json
{
  "jsonrpc": "2.0",
  "id": 9,
  "result": {
    "oldestBlock": "0x1",
    "reward": [
      [
        "0x61a8"
      ],
      [
        "0x61a8"
      ]
    ],
    "baseFeePerGas": [
      "0x0",
      "0x0"
    ],
    "gasUsedRatio": [
      0.006923733333333334,
      0.0015009333333333332
    ]
  }
}
```

This is used from tools such as foundry's `cast`, to make EIP 1559 transactions (a.k.a dynamic fee transactions).

```bash
cast send 0x99466ED2E37B892A2Ee3E9CD55a98b68f5735db2 \
--private-key d9ae6467cabb04657fc1b69d61d44876041292c0fddad1e34bf731bd10826ec6 \
--rpc-url localhost:8545 \
 "multiply(uint256)" 7

blockHash               0x0b2e42c1fa254c9688cc2f7b0ad6d5bedc5a7411c76c2cde9653325222b55460
blockNumber             4
contractAddress         
cumulativeGasUsed       22514
effectiveGasPrice       0
from                    0x0514250500425DdE3bb35D49cC75F5ea861BCbFc
gasUsed                 22514
logs                    [{"address":"0x99466ed2e37b892a2ee3e9cd55a98b68f5735db2","topics":["0x24abdb5865df5079dcc5ac590ff6f01d5c16edbc5fab4e195d9febd1114503da"],"data":"0x0000000000000000000000000000000000000000000000000000000000000031","blockHash":"0x0b2e42c1fa254c9688cc2f7b0ad6d5bedc5a7411c76c2cde9653325222b55460","blockNumber":"0x4","transactionHash":"0x71b113f6bad96bedb0bd754496c112760dd29c32c82feb06b55c8349548ba1fa","transactionIndex":"0x0","logIndex":"0x0","removed":false}]
logsBloom               0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000020000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000
root                    
status                  1 (success)
transactionHash         0x71b113f6bad96bedb0bd754496c112760dd29c32c82feb06b55c8349548ba1fa
transactionIndex        0
type                    2
blobGasPrice            
blobGasUsed             
to                      0x99466ED2E37B892A2Ee3E9CD55a98b68f5735db2
```

The transaction `type` is correctly set to `2`, which is for dynamic fee transactions.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added transaction fee history retrieval functionality, allowing users to view base fees, rewards, and gas usage ratios for specified block ranges.

- **Enhancements**
  - Updated block details to include `BaseFeePerGas` for more detailed transaction information.

- **Tests**
  - Refactored test cases to support new fee history retrieval and other Ethereum blockchain interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->