### PR TITLE
Empty transaction pool

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -41,6 +41,9 @@ func SupportedAPIs(blockChainAPI *BlockChainAPI, streamAPI *StreamAPI, pullAPI *
 	}, {
 		Namespace: "net",
 		Service:   &NetAPI{},
+	}, {
+		Namespace: "txpool",
+		Service:   NewTxPoolAPI(),
 	}}
 }
 

--- a/api/pool.go
+++ b/api/pool.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"github.com/onflow/go-ethereum/common"
+	"github.com/onflow/go-ethereum/common/hexutil"
+)
+
+type TxPool struct{}
+
+func NewTxPoolAPI() *TxPool {
+	return &TxPool{}
+}
+
+type content struct {
+	Pending []any
+	Queued  []any
+}
+
+func (s *TxPool) Content() content {
+	return content{}
+}
+
+func (s *TxPool) ContentFrom(addr common.Address) content {
+	return content{}
+}
+
+func (s *TxPool) Status() map[string]hexutil.Uint {
+	return map[string]hexutil.Uint{
+		"pending": hexutil.Uint(0),
+		"queued":  hexutil.Uint(0),
+	}
+}
+
+func (s *TxPool) Inspect() content {
+	return content{}
+}

--- a/api/pool.go
+++ b/api/pool.go
@@ -12,16 +12,23 @@ func NewTxPoolAPI() *TxPool {
 }
 
 type content struct {
-	Pending []any
-	Queued  []any
+	Pending any
+	Queued  any
+}
+
+func emptyPool() content {
+	return content{
+		Pending: struct{}{},
+		Queued:  struct{}{},
+	}
 }
 
 func (s *TxPool) Content() content {
-	return content{}
+	return emptyPool()
 }
 
 func (s *TxPool) ContentFrom(addr common.Address) content {
-	return content{}
+	return emptyPool()
 }
 
 func (s *TxPool) Status() map[string]hexutil.Uint {
@@ -32,5 +39,5 @@ func (s *TxPool) Status() map[string]hexutil.Uint {
 }
 
 func (s *TxPool) Inspect() content {
-	return content{}
+	return emptyPool()
 }

--- a/api/server.go
+++ b/api/server.go
@@ -419,10 +419,17 @@ func (w *loggingResponseWriter) Write(data []byte) (int, error) {
 	_ = json.Unmarshal(data, &body)
 	delete(body, "jsonrpc")
 
-	w.logger.
-		Debug().
-		Fields(body).
-		Msg("API response")
+	if body["error"] != nil {
+		w.logger.
+			Error().
+			Fields(body).
+			Msg("API response")
+	} else {
+		w.logger.
+			Debug().
+			Fields(body).
+			Msg("API response")
+	}
 
 	return w.ResponseWriter.Write(data)
 }


### PR DESCRIPTION
Closes: #???

## Description
Implement missing transaction pool APIs that return empty since we currently don't have a transaction pool.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `txpool` namespace with a `TxPool` service for managing transaction pool content, status, and inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->