### PR TITLE
Allow configuring heartbeat interval

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -152,7 +152,7 @@ func startIngestion(
 		Uint64("missed-heights", blk.Height-latestCadenceHeight).
 		Msg("indexing cadence height information")
 
-	subscriber := ingestion.NewRPCSubscriber(client, cfg.FlowNetworkID, logger)
+	subscriber := ingestion.NewRPCSubscriber(client, cfg.HeartbeatInterval, cfg.FlowNetworkID, logger)
 	engine := ingestion.NewEventIngestionEngine(
 		subscriber,
 		blocks,

--- a/config/config.go
+++ b/config/config.go
@@ -71,7 +71,7 @@ type Config struct {
 	// ForceStartCadenceHeight will force set the starting Cadence height, this should be only used for testing or locally.
 	ForceStartCadenceHeight uint64
 	// HeartbeatInterval sets custom heartbeat interval for events
-	HeartbeatInterval int
+	HeartbeatInterval uint64
 }
 
 func FromFlags() (*Config, error) {
@@ -97,7 +97,7 @@ func FromFlags() (*Config, error) {
 	flag.BoolVar(&cfg.CreateCOAResource, "coa-resource-create", false, "Auto-create the COA resource in the Flow COA account provided if one doesn't exist")
 	flag.StringVar(&logLevel, "log-level", "debug", "Define verbosity of the log output ('debug', 'info', 'error')")
 	flag.Float64Var(&cfg.StreamLimit, "stream-limit", 10, "Rate-limits the events sent to the client within one second")
-	flag.IntVar(&cfg.HeartbeatInterval, "heartbeat-interval", 100, "Heartbeat interval for AN event subscription")
+	flag.Uint64Var(&cfg.HeartbeatInterval, "heartbeat-interval", 100, "Heartbeat interval for AN event subscription")
 	flag.IntVar(&streamTimeout, "stream-timeout", 3, "Defines the timeout in seconds the server waits for the event to be sent to the client")
 	flag.Uint64Var(&forceStartHeight, "force-start-height", 0, "Force set starting Cadence height. This should only be used locally or for testing, never in production.")
 	flag.StringVar(&filterExpiry, "filter-expiry", "5m", "Filter defines the time it takes for an idle filter to expire")

--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,8 @@ type Config struct {
 	FilterExpiry time.Duration
 	// ForceStartCadenceHeight will force set the starting Cadence height, this should be only used for testing or locally.
 	ForceStartCadenceHeight uint64
+	// HeartbeatInterval sets custom heartbeat interval for events
+	HeartbeatInterval int
 }
 
 func FromFlags() (*Config, error) {
@@ -95,6 +97,7 @@ func FromFlags() (*Config, error) {
 	flag.BoolVar(&cfg.CreateCOAResource, "coa-resource-create", false, "Auto-create the COA resource in the Flow COA account provided if one doesn't exist")
 	flag.StringVar(&logLevel, "log-level", "debug", "Define verbosity of the log output ('debug', 'info', 'error')")
 	flag.Float64Var(&cfg.StreamLimit, "stream-limit", 10, "Rate-limits the events sent to the client within one second")
+	flag.IntVar(&cfg.HeartbeatInterval, "heartbeat-interval", 100, "Heartbeat interval for AN event subscription")
 	flag.IntVar(&streamTimeout, "stream-timeout", 3, "Defines the timeout in seconds the server waits for the event to be sent to the client")
 	flag.Uint64Var(&forceStartHeight, "force-start-height", 0, "Force set starting Cadence height. This should only be used locally or for testing, never in production.")
 	flag.StringVar(&filterExpiry, "filter-expiry", "5m", "Filter defines the time it takes for an idle filter to expire")

--- a/services/ingestion/subscriber_test.go
+++ b/services/ingestion/subscriber_test.go
@@ -97,7 +97,7 @@ func Test_Subscribing(t *testing.T) {
 	client, err := requester.NewCrossSporkClient(currentClient, sporkClients, zerolog.Nop())
 	require.NoError(t, err)
 
-	subscriber := NewRPCSubscriber(client, flowGo.Emulator, zerolog.Nop())
+	subscriber := NewRPCSubscriber(client, 100, flowGo.Emulator, zerolog.Nop())
 
 	events := subscriber.Subscribe(context.Background(), 1)
 


### PR DESCRIPTION
## Description
This PR allows configuring heartbeat interval

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a customizable heartbeat interval for event subscriptions to improve flexibility and control.

- **Improvements**
  - Enhanced event subscription reliability with the addition of a heartbeat interval setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->