### PR TITLE
Make websocket support configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The application can be configured using the following flags at runtime:
 | `--database-dir`            | `./db`           | Path to the directory for the database.                                                                                                         |
 | `--rpc-host`                | `localhost`      | Host for the JSON RPC API server.                                                                                                               |
 | `--rpc-port`                | `8545`           | Port for the JSON RPC API server.                                                                                                               |
+| `--ws-enabled`              | `false`          | Enable websocket support.                                                                                                                       |
 | `--access-node-grpc-host`   | `localhost:3569` | Host to the current spork Flow access node (AN) gRPC API.                                                                                       |
 | `--access-node-spork-hosts` |                  | Previous spork AN hosts, defined following the schema: `{latest height}@{host}` as comma separated list (e.g. `"200@host-1.com,300@host2.com"`) |
 | `--evm-network-id`          | `testnet`        | EVM network ID (options: `testnet`, `mainnet`).                                                                                                 |

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -270,8 +270,10 @@ func startServer(
 		return err
 	}
 
-	if err := srv.EnableWS(supportedAPIs); err != nil {
-		return err
+	if cfg.WSEnabled {
+		if err := srv.EnableWS(supportedAPIs); err != nil {
+			return err
+		}
 	}
 
 	if err := srv.SetListenAddr(cfg.RPCHost, cfg.RPCPort); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,8 @@ type Config struct {
 	RPCPort int
 	// GRPCHost for the RPC API server
 	RPCHost string
+	// WSEnabled determines if the websocket server is enabled.
+	WSEnabled bool
 	// EVMNetworkID provides the EVM chain ID.
 	EVMNetworkID *big.Int
 	// FlowNetworkID is the Flow network ID that the EVM is hosted on (mainnet, testnet, emulator...)
@@ -84,6 +86,7 @@ func FromFlags() (*Config, error) {
 	flag.StringVar(&cfg.DatabaseDir, "database-dir", "./db", "Path to the directory for the database")
 	flag.StringVar(&cfg.RPCHost, "rpc-host", "", "Host for the RPC API server")
 	flag.IntVar(&cfg.RPCPort, "rpc-port", 8545, "Port for the RPC API server")
+	flag.BoolVar(&cfg.WSEnabled, "ws-enabled", false, "Enable websocket connections")
 	flag.StringVar(&cfg.AccessNodeHost, "access-node-grpc-host", "localhost:3569", "Host to the flow access node gRPC API")
 	flag.StringVar(&accessSporkHosts, "access-node-spork-hosts", "", `Previous spork AN hosts, defined following the schema: {host1},{host2} as a comma separated list (e.g. "host-1.com,host2.com")`)
 	flag.StringVar(&evmNetwork, "evm-network-id", "previewnet", "EVM network ID (previewnet, testnet, mainnet)")

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -16,9 +16,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onflow/flow-evm-gateway/bootstrap"
 	evmTypes "github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-evm-gateway/bootstrap"
 
 	"github.com/goccy/go-json"
 	"github.com/onflow/cadence"
@@ -144,6 +145,7 @@ func servicesSetup(t *testing.T) (emulator.Emulator, func()) {
 		LogWriter:         zerolog.NewConsoleWriter(),
 		StreamTimeout:     time.Second * 30,
 		StreamLimit:       10,
+		WSEnabled:         true,
 	}
 
 	if !logOutput {


### PR DESCRIPTION

## Description
Enable configuration of WebSocket server. By default, it's disabled and can be enabled using `--ws-enabled` flag.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new flag `--ws-enabled` to enable WebSocket support in the application configuration.
  
- **Documentation**
  - Updated README to include information about the new `--ws-enabled` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->