### PR TITLE
Overwrite source address with logging

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -243,6 +243,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_ = json.Unmarshal(b, &body)
 
 		h.logger.Debug().
+			Str("IP", r.RemoteAddr).
 			Str("url", r.URL.String()).
 			Fields(body).
 			Bool("is-ws", isWebSocket(r)).

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -9,7 +9,6 @@ import (
 	"github.com/onflow/flow-go-sdk/access/grpc"
 	"github.com/onflow/flow-go-sdk/crypto"
 	broadcast "github.com/onflow/flow-go/engine"
-	"github.com/onflow/go-ethereum/rpc"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-evm-gateway/api"
@@ -201,7 +200,7 @@ func startServer(
 	l := logger.With().Str("component", "API").Logger()
 	l.Info().Msg("starting up RPC server")
 
-	srv := api.NewHTTPServer(l, rpc.DefaultHTTPTimeouts)
+	srv := api.NewHTTPServer(l, cfg)
 
 	// create the signer based on either a single coa key being provided and using a simple in-memory
 	// signer, or multiple keys being provided and using signer with key-rotation mechanism.

--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,10 @@ type Config struct {
 	LogLevel zerolog.Level
 	// LogWriter defines the writer used for logging
 	LogWriter io.Writer
+	// RateLimit requests made by the client identified by IP over any protocol (ws/http).
+	RateLimit uint64
+	// Address header used to identified clients, usually set by the proxy
+	AddressHeader string
 	// StreamLimit rate-limits the events sent to the client within 1 second time interval.
 	StreamLimit float64
 	// StreamTimeout defines the timeout the server waits for the event to be sent to the client.
@@ -100,6 +104,8 @@ func FromFlags() (*Config, error) {
 	flag.BoolVar(&cfg.CreateCOAResource, "coa-resource-create", false, "Auto-create the COA resource in the Flow COA account provided if one doesn't exist")
 	flag.StringVar(&logLevel, "log-level", "debug", "Define verbosity of the log output ('debug', 'info', 'error')")
 	flag.Float64Var(&cfg.StreamLimit, "stream-limit", 10, "Rate-limits the events sent to the client within one second")
+	flag.Uint64Var(&cfg.RateLimit, "rate-limit", 50, "Rate-limit requests per second made by the client over any protocol (ws/http)")
+	flag.StringVar(&cfg.AddressHeader, "address-header", "", "Address header that contains the client IP, this is useful when the server is behind a proxy that sets the source IP of the client. Leave empty if no proxy is used.")
 	flag.Uint64Var(&cfg.HeartbeatInterval, "heartbeat-interval", 100, "Heartbeat interval for AN event subscription")
 	flag.IntVar(&streamTimeout, "stream-timeout", 3, "Defines the timeout in seconds the server waits for the event to be sent to the client")
 	flag.Uint64Var(&forceStartHeight, "force-start-height", 0, "Force set starting Cadence height. This should only be used locally or for testing, never in production.")


### PR DESCRIPTION
## Description
Allow defining header value used for determining the client source IP. This is useful when the EVM GW is behind a proxy that sets the source IP in a header. 
Also add this source IP to logs so we can validate how this behaves on a deployment.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 