### PR TITLE
Add request limits for JSON-RPC batch calls

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -53,7 +53,9 @@ type httpServer struct {
 }
 
 const (
-	shutdownTimeout = 5 * time.Second
+	shutdownTimeout      = 5 * time.Second
+	batchRequestLimit    = 5
+	batchResponseMaxSize = 5 * 1000 * 1000 // 5 MB
 )
 
 func NewHTTPServer(logger zerolog.Logger, cfg *config.Config) *httpServer {
@@ -107,6 +109,7 @@ func (h *httpServer) EnableRPC(apis []rpc.API) error {
 
 	// Create RPC server and handler.
 	srv := rpc.NewServer()
+	srv.SetBatchLimits(batchRequestLimit, batchResponseMaxSize)
 
 	// Register all the APIs exposed by the services
 	for _, api := range apis {


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/211

## Description

Add some sane default limits for batch calls:
- Maximum number of requests is **5**
- Maximum number of response bytes across all requests is **5 MB**

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced batch limits for RPC requests and responses to improve performance and handling of large data sets.

- **Tests**
  - Added a new test case to verify batch request functionality.
  - Improved test syntax and formatting for better readability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->