### PR TITLE
Download transaction traces

### DIFF
--- a/services/traces/downloader.go
+++ b/services/traces/downloader.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/onflow/go-ethereum/common"
 	"github.com/rs/zerolog"
 )
 
@@ -15,7 +16,7 @@ const downloadTimeout = 60 * time.Second
 
 type Downloader interface {
 	// Download traces or returning an error with the failure
-	Download(id string) (json.RawMessage, error)
+	Download(id common.Hash) (json.RawMessage, error)
 }
 
 var _ Downloader = &GCPDownloader{}
@@ -50,14 +51,14 @@ func NewGCPDownloader(bucketName string, logger zerolog.Logger) (*GCPDownloader,
 	}, nil
 }
 
-func (g *GCPDownloader) Download(id string) (json.RawMessage, error) {
-	l := g.logger.With().Str("tx-id", id).Logger()
+func (g *GCPDownloader) Download(id common.Hash) (json.RawMessage, error) {
+	l := g.logger.With().Str("tx-id", id.String()).Logger()
 	l.Debug().Msg("downloading transaction trace")
 
 	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
 	defer cancel()
 
-	rc, err := g.client.Bucket(g.bucketName).Object(id).NewReader(ctx)
+	rc, err := g.client.Bucket(g.bucketName).Object(id.String()).NewReader(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download id %s: %w", id, err)
 	}

--- a/services/traces/downloader.go
+++ b/services/traces/downloader.go
@@ -1,8 +1,17 @@
 package traces
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/rs/zerolog"
 )
+
+const downloadTimeout = 60 * time.Second
 
 type Downloader interface {
 	// Download traces or returning an error with the failure
@@ -12,9 +21,54 @@ type Downloader interface {
 var _ Downloader = &GCPDownloader{}
 
 type GCPDownloader struct {
+	client     *storage.Client
+	logger     zerolog.Logger
 	bucketName string
 }
 
-func (G *GCPDownloader) Download(id string) (json.RawMessage, error) {
-	return nil, nil
+func NewGCPDownloader(bucketName string, logger zerolog.Logger) (*GCPDownloader, error) {
+	if bucketName == "" {
+		return nil, fmt.Errorf("must provide bucket name")
+	}
+
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("storage.NewClient: %w", err)
+	}
+
+	// try accessing buckets to validate settings
+	_, err = client.Bucket(bucketName).Attrs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error accessing bucket: %s, make sure bucket exists: %w", bucketName, err)
+	}
+
+	return &GCPDownloader{
+		client:     client,
+		logger:     logger,
+		bucketName: bucketName,
+	}, nil
+}
+
+func (g *GCPDownloader) Download(id string) (json.RawMessage, error) {
+	l := g.logger.With().Str("tx-id", id).Logger()
+	l.Debug().Msg("downloading transaction trace")
+
+	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
+	defer cancel()
+
+	rc, err := g.client.Bucket(g.bucketName).Object(id).NewReader(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download id %s: %w", id, err)
+	}
+	defer rc.Close()
+
+	trace, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read trace id %s: %w", id, err)
+	}
+
+	l.Info().Int("trace-size", len(trace)).Msg("transaction trace downloaded")
+
+	return trace, nil
 }

--- a/services/traces/downloader.go
+++ b/services/traces/downloader.go
@@ -1,0 +1,20 @@
+package traces
+
+import (
+	"encoding/json"
+)
+
+type Downloader interface {
+	// Download traces or returning an error with the failure
+	Download(id string) (json.RawMessage, error)
+}
+
+var _ Downloader = &GCPDownloader{}
+
+type GCPDownloader struct {
+	bucketName string
+}
+
+func (G *GCPDownloader) Download(id string) (json.RawMessage, error) {
+	return nil, nil
+}

--- a/services/traces/downloader.go
+++ b/services/traces/downloader.go
@@ -46,10 +46,16 @@ func NewGCPDownloader(bucketName string, logger zerolog.Logger) (*GCPDownloader,
 		return nil, fmt.Errorf("error accessing bucket: %s, make sure bucket exists: %w", bucketName, err)
 	}
 
+	valueCache, err := lru.New2Q[string, []byte](128)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create trace cache: %w", err)
+	}
+
 	return &GCPDownloader{
 		client:     client,
 		logger:     logger,
 		bucketName: bucketName,
+		cache:      valueCache,
 	}, nil
 }
 


### PR DESCRIPTION
Closes: #251 

## Description
This PR introduces a new tracer ingestion engine that subscribes to block events produced by the event ingestion engine. On receiving a new block event, the engine loads the block, checks the transaction hashes it contains, and downloads the transaction traces for each transaction. These traces are then indexed in storage.

Additionally, this update allows for the configuration of transaction trace ingestion to be optional.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to download transaction traces from Google Cloud Storage, enhancing trace retrieval efficiency through caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->