### PR TITLE
Update Dockerfile to install ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM debian:latest
 
 WORKDIR /flow-evm-gateway
 
-RUN apt-get update
+RUN apt-get update && apt-get install ca-certificates -y
 
 COPY --from=app-builder /app/bin /flow-evm-gateway/app
 COPY --from=app-builder /app/previewnet-keys.json /flow-evm-gateway/previewnet-keys.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Docker image build process by adding the installation of `ca-certificates`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->