### PR TITLE
Add the appropriate buffer size on `eth_estimateGas` to account for slot clearing refunds

### DIFF
--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -373,12 +373,14 @@ func (e *EVM) EstimateGas(
 		return 0, getErrorForCode(evmResult.ErrorCode)
 	}
 
-	// This minimum gas availability is needed for:
-	// https://github.com/onflow/go-ethereum/blob/master/core/vm/operations_acl.go#L29-L32
+	// This buffer size is needed in the case where there's a refund
+	// after clearing a lot. This happens when changing a fields value
+	// to its zero value (according to what Solidity considers a
+	// zero value).
 	// Note that this is not actually consumed in the end.
 	// TODO: Consider moving this to `EVM.dryRun`, if we want the
 	// fix to also apply for the EVM API, on Cadence side.
-	gasConsumed := evmResult.GasConsumed + params.SstoreSentryGasEIP2200 + 1
+	gasConsumed := evmResult.GasConsumed + params.SstoreClearsScheduleRefundEIP3529 + 1
 
 	e.logger.Debug().
 		Uint64("gas", gasConsumed).

--- a/tests/web3js/eth_deploy_contract_and_interact_test.js
+++ b/tests/web3js/eth_deploy_contract_and_interact_test.js
@@ -77,6 +77,24 @@ it('deploy contract and interact', async() => {
     result = await web3.eth.call({to: contractAddress, data: callRetrieve}, "latest")
     assert.equal(result, newValue)
 
+    // clear the value on the contract
+    newValue = 0
+    updateData = deployed.contract.methods.store(newValue).encodeABI()
+    // store a value in the contract
+    res = await helpers.signAndSend({
+        from: conf.eoa.address,
+        to: contractAddress,
+        data: updateData,
+        value: '0',
+        gasPrice: '0',
+    })
+    assert.equal(res.receipt.status, conf.successStatus)
+
+    // check the new value on contract
+    result = await web3.eth.call({to: contractAddress, data: callRetrieve}, "latest")
+    console.log("Result: ", result)
+    assert.equal(result, newValue)
+
     // make sure receipts and txs are indexed
     latestHeight = await web3.eth.getBlockNumber()
     let updateTx = await web3.eth.getTransactionFromBlock(latestHeight, 0)
@@ -85,7 +103,7 @@ it('deploy contract and interact', async() => {
     assert.equal(updateTx.data, updateData)
 
     // check that call can handle specific block heights
-    result = await web3.eth.call({to: contractAddress, data: callRetrieve}, latestHeight - 1n)
+    result = await web3.eth.call({to: contractAddress, data: callRetrieve}, latestHeight - 2n)
     assert.equal(result, initValue)
 
     // submit a transaction that emits logs


### PR DESCRIPTION
## Description

When resetting a contract's field from a non-zero value to a zero value, we have to take into account that the gas estimation will be higher, but it will be refunded in the end, see https://github.com/onflow/go-ethereum/blob/master/core/vm/operations_acl.go#L64-L66

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved gas estimation accuracy in transaction processing.

- **Tests**
  - Enhanced test coverage for contract deployment and interaction, ensuring consistent results and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->