### PR TITLE
Add support for debug trace APIs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -26,8 +26,13 @@ import (
 	storageErrs "github.com/onflow/flow-evm-gateway/storage/errors"
 )
 
-func SupportedAPIs(blockChainAPI *BlockChainAPI, streamAPI *StreamAPI, pullAPI *PullAPI) []rpc.API {
-	return []rpc.API{{
+func SupportedAPIs(
+	blockChainAPI *BlockChainAPI,
+	streamAPI *StreamAPI,
+	pullAPI *PullAPI,
+	debugAPI *DebugAPI,
+) []rpc.API {
+	apis := []rpc.API{{
 		Namespace: "eth",
 		Service:   blockChainAPI,
 	}, {
@@ -46,6 +51,16 @@ func SupportedAPIs(blockChainAPI *BlockChainAPI, streamAPI *StreamAPI, pullAPI *
 		Namespace: "txpool",
 		Service:   NewTxPoolAPI(),
 	}}
+
+	// optional debug api
+	if debugAPI != nil {
+		apis = append(apis, rpc.API{
+			Namespace: "debug",
+			Service:   debugAPI,
+		})
+	}
+
+	return apis
 }
 
 type BlockChainAPI struct {

--- a/api/debug.go
+++ b/api/debug.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"context"
+
+	gethCommon "github.com/onflow/go-ethereum/common"
+	"github.com/onflow/go-ethereum/eth/tracers"
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-evm-gateway/storage"
+)
+
+type DebugAPI struct {
+	logger zerolog.Logger
+	tracer storage.TraceIndexer
+}
+
+// TraceTransaction will return a debug execution trace of a transaction if it exists,
+// currently we only support CALL traces, so the config is ignored.
+func (d *DebugAPI) TraceTransaction(
+	ctx context.Context,
+	hash gethCommon.Hash,
+	_ *tracers.TraceConfig,
+) (interface{}, error) {
+	res, err := d.tracer.GetTransaction(hash)
+	if err != nil {
+		return handleError[any](d.logger, err)
+	}
+	return res, nil
+}

--- a/api/debug.go
+++ b/api/debug.go
@@ -15,6 +15,13 @@ type DebugAPI struct {
 	tracer storage.TraceIndexer
 }
 
+func NewDebugAPI(tracer storage.TraceIndexer, logger zerolog.Logger) *DebugAPI {
+	return &DebugAPI{
+		logger: logger,
+		tracer: tracer,
+	}
+}
+
 // TraceTransaction will return a debug execution trace of a transaction if it exists,
 // currently we only support CALL traces, so the config is ignored.
 func (d *DebugAPI) TraceTransaction(

--- a/api/debug.go
+++ b/api/debug.go
@@ -18,10 +18,11 @@ type DebugAPI struct {
 	blocks storage.BlockIndexer
 }
 
-func NewDebugAPI(tracer storage.TraceIndexer, logger zerolog.Logger) *DebugAPI {
+func NewDebugAPI(tracer storage.TraceIndexer, blocks storage.BlockIndexer, logger zerolog.Logger) *DebugAPI {
 	return &DebugAPI{
 		logger: logger,
 		tracer: tracer,
+		blocks: blocks,
 	}
 }
 

--- a/api/debug.go
+++ b/api/debug.go
@@ -3,8 +3,10 @@ package api
 import (
 	"context"
 
+	"github.com/goccy/go-json"
 	gethCommon "github.com/onflow/go-ethereum/common"
 	"github.com/onflow/go-ethereum/eth/tracers"
+	"github.com/onflow/go-ethereum/rpc"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-evm-gateway/storage"
@@ -13,6 +15,7 @@ import (
 type DebugAPI struct {
 	logger zerolog.Logger
 	tracer storage.TraceIndexer
+	blocks storage.BlockIndexer
 }
 
 func NewDebugAPI(tracer storage.TraceIndexer, logger zerolog.Logger) *DebugAPI {
@@ -28,10 +31,52 @@ func (d *DebugAPI) TraceTransaction(
 	ctx context.Context,
 	hash gethCommon.Hash,
 	_ *tracers.TraceConfig,
-) (interface{}, error) {
+) (json.RawMessage, error) {
 	res, err := d.tracer.GetTransaction(hash)
 	if err != nil {
-		return handleError[any](d.logger, err)
+		return handleError[json.RawMessage](d.logger, err)
 	}
 	return res, nil
+}
+
+func (d *DebugAPI) TraceBlockByNumber(
+	ctx context.Context,
+	number rpc.BlockNumber,
+	_ *tracers.TraceConfig,
+) ([]json.RawMessage, error) {
+	block, err := d.blocks.GetByHeight(uint64(number.Int64()))
+	if err != nil {
+		return handleError[[]json.RawMessage](d.logger, err)
+	}
+
+	results := make([]json.RawMessage, len(block.TransactionHashes))
+	for i, h := range block.TransactionHashes {
+		results[i], err = d.TraceTransaction(ctx, h, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return results, nil
+}
+
+func (d *DebugAPI) TraceBlockByHash(
+	ctx context.Context,
+	hash gethCommon.Hash,
+	_ *tracers.TraceConfig,
+) ([]json.RawMessage, error) {
+	block, err := d.blocks.GetByID(hash)
+	if err != nil {
+		return handleError[[]json.RawMessage](d.logger, err)
+	}
+
+	results := make([]json.RawMessage, len(block.TransactionHashes))
+	for i, h := range block.TransactionHashes {
+		results[i], err = d.TraceTransaction(ctx, h, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return results, nil
 }

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -335,7 +335,7 @@ func startServer(
 
 	var debugAPI *api.DebugAPI
 	if cfg.TracesEnabled {
-		debugAPI = api.NewDebugAPI(trace, logger)
+		debugAPI = api.NewDebugAPI(trace, blocks, logger)
 	}
 
 	supportedAPIs := api.SupportedAPIs(blockchainAPI, streamAPI, pullAPI, debugAPI)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -103,6 +103,7 @@ func Start(ctx context.Context, cfg *config.Config) error {
 			transactions,
 			receipts,
 			accounts,
+			trace,
 			blocksBroadcaster,
 			transactionsBroadcaster,
 			logsBroadcaster,
@@ -247,6 +248,7 @@ func startServer(
 	transactions storage.TransactionIndexer,
 	receipts storage.ReceiptIndexer,
 	accounts storage.AccountIndexer,
+	trace storage.TraceIndexer,
 	blocksBroadcaster *broadcast.Broadcaster,
 	transactionsBroadcaster *broadcast.Broadcaster,
 	logsBroadcaster *broadcast.Broadcaster,
@@ -331,7 +333,12 @@ func startServer(
 		ratelimiter,
 	)
 
-	supportedAPIs := api.SupportedAPIs(blockchainAPI, streamAPI, pullAPI)
+	var debugAPI *api.DebugAPI
+	if cfg.TracesEnabled {
+		debugAPI = api.NewDebugAPI(trace, logger)
+	}
+
+	supportedAPIs := api.SupportedAPIs(blockchainAPI, streamAPI, pullAPI, debugAPI)
 
 	if err := srv.EnableRPC(supportedAPIs); err != nil {
 		return err


### PR DESCRIPTION
Closes: #251 

## Description
This PR exposes APIs for debug tracing functionality. It adds 3 API methods:
- `debug_traceTransaction` which returns transaction call trace by ID
- `debug_traceBlockByNumber` which accumulates transaction call traces by block number
- `debug_traceBlockByHash` which accumulates transaction call traces by block hash

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 