### PR TITLE
Update the supported endpoints section on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Listed below are the JSON-RPC namespaces and methods currently supported by the 
     * eth_getTransactionByHash
     * eth_getCode
     * eth_gasPrice 
+    * eth_feeHistory
     * eth_getBalance
     * eth_estimateGas
     * eth_getTransactionByBlockNumberAndIndex
@@ -190,6 +191,7 @@ Listed below are the JSON-RPC namespaces and methods currently supported by the 
     * eth_newFilter
     * eth_uninstallFilter
     * eth_getFilterChanges
+    * eth_getFilterLogs
     * eth_newBlockFilter
     * eth_newPendingTransactionFilter
     * eth_getUncleCountByBlockHash // return 0
@@ -197,11 +199,9 @@ Listed below are the JSON-RPC namespaces and methods currently supported by the 
     * eth_syncing // return false for now
   * Unsupported but coming soon
     * eth_createAccessList
-    * eth_feeHistory
     * eth_maxPriorityFeePerGas
     * eth_getProof
     * eth_getStorageAt
-    * eth_getFilterLogs
     * eth_accounts
     * eth_sign
     * eth_signTransaction
@@ -215,6 +215,11 @@ Listed below are the JSON-RPC namespaces and methods currently supported by the 
     * net_listening
     * net_peerCount
     * net_version
+* `debug`
+  * Supported
+    * debug_traceTransaction
+    * debug_traceBlockByNumber
+    * debug_traceBlockByHash
 
 We also plan to add support for the `admin` namespace in the near future.
 


### PR DESCRIPTION
## Description

We now support the following JSON-RPC endpoints:
- `eth_feeHistory`
- `eth_getFilterLogs`
- `debug_traceTransaction`
- `debug_traceBlockByNumber`
- `debug_traceBlockByHash`

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `eth_feeHistory` method under the `eth` namespace.
  - Added support for `debug_traceTransaction` and `debug_traceBlockByNumber` methods under the `debug` namespace.

- **Removed Features**
  - Removed support for `eth_getFilterLogs` method under the `eth` namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->