### PR TITLE
Update flow-go v0.35.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/goccy/go-json v0.10.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/onflow/cadence v1.0.0-preview.33
-	github.com/onflow/flow-go v0.35.13-0.20240611224823-09b08708974c
+	github.com/onflow/flow-go v0.35.13
 	github.com/onflow/flow-go-sdk v1.0.0-preview.35
 	github.com/onflow/go-ethereum v1.13.4
 	github.com/rs/cors v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1954,8 +1954,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0 h1:mToacZ5NWqtlWwk/7RgIl/jeKB/
 github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.35.13-0.20240611224823-09b08708974c h1:IY5MYhOwz+N/38uURYOnepbm2Vaqq2QDUb3kMd1MVz4=
-github.com/onflow/flow-go v0.35.13-0.20240611224823-09b08708974c/go.mod h1:SIGA1krHtMyu23JxrR23blKXQfCl8eyA+JFr3h+TVX0=
+github.com/onflow/flow-go v0.35.13 h1:PnB5yCATcXKhrwa4VAXbWw8VTCuDoJMNkXDfIf9HR9w=
+github.com/onflow/flow-go v0.35.13/go.mod h1:SIGA1krHtMyu23JxrR23blKXQfCl8eyA+JFr3h+TVX0=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
 github.com/onflow/flow-go-sdk v1.0.0-preview.35 h1:2ptBhFYFGOaYghZTRbj51BbYqTZjkyEpXDyaWDYrHwA=
 github.com/onflow/flow-go-sdk v1.0.0-preview.35/go.mod h1:/G8vtAekhvgynLYVDtd6OnhixoGTzzknmhYCJB2YWWU=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-emulator v1.0.0-preview.31
 	github.com/onflow/flow-evm-gateway v0.0.0-20240201154855-4d4d3d3f19c7
-	github.com/onflow/flow-go v0.35.13-0.20240611224823-09b08708974c
+	github.com/onflow/flow-go v0.35.13
 	github.com/onflow/flow-go-sdk v1.0.0-preview.35
 	github.com/onflow/go-ethereum v1.13.4
 	github.com/rs/zerolog v1.31.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/goccy/go-json v0.10.2
 	github.com/onflow/cadence v1.0.0-preview.33
 	github.com/onflow/crypto v0.25.1
-	github.com/onflow/flow-emulator v1.0.0-preview.31
+	github.com/onflow/flow-emulator v1.0.0-preview.31.0.20240612194122-a8028efdf884
 	github.com/onflow/flow-evm-gateway v0.0.0-20240201154855-4d4d3d3f19c7
 	github.com/onflow/flow-go v0.35.13
 	github.com/onflow/flow-go-sdk v1.0.0-preview.35

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -2097,6 +2097,7 @@ github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnp
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go v0.35.13-0.20240611224823-09b08708974c h1:IY5MYhOwz+N/38uURYOnepbm2Vaqq2QDUb3kMd1MVz4=
 github.com/onflow/flow-go v0.35.13-0.20240611224823-09b08708974c/go.mod h1:SIGA1krHtMyu23JxrR23blKXQfCl8eyA+JFr3h+TVX0=
+github.com/onflow/flow-go v0.35.13/go.mod h1:SIGA1krHtMyu23JxrR23blKXQfCl8eyA+JFr3h+TVX0=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
 github.com/onflow/flow-go-sdk v1.0.0-preview.35 h1:2ptBhFYFGOaYghZTRbj51BbYqTZjkyEpXDyaWDYrHwA=
 github.com/onflow/flow-go-sdk v1.0.0-preview.35/go.mod h1:/G8vtAekhvgynLYVDtd6OnhixoGTzzknmhYCJB2YWWU=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -2089,14 +2089,13 @@ github.com/onflow/flow-core-contracts/lib/go/contracts v1.1.0 h1:AegPBm079X0qjne
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.1.0/go.mod h1:u/mkP/B+PbV33tEG3qfkhhBlydSvAKxfLZSfB4lsJHg=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0 h1:za6bxPPW4JIsthhasUDTa1ruKjIO8DIhun9INQfj61Y=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0/go.mod h1:NgbMOYnMh0GN48VsNKZuiwK7uyk38Wyo8jN9+C9QE30=
-github.com/onflow/flow-emulator v1.0.0-preview.31 h1:5YCVFodWfGwkLaQHJ81lMV0ShSb7bWRm6ooB+G9VfIw=
-github.com/onflow/flow-emulator v1.0.0-preview.31/go.mod h1:aZeYXgpE8YEtWT/A9ZHfu/AO2riFEY6nJP+sc1Iru/0=
+github.com/onflow/flow-emulator v1.0.0-preview.31.0.20240612194122-a8028efdf884 h1:cTFwDFTTfHlHSn8F9lDPBdZ8orFAC5BHB5FX+kGUNUU=
+github.com/onflow/flow-emulator v1.0.0-preview.31.0.20240612194122-a8028efdf884/go.mod h1:/UiNvOLVrJFHVJ+vR5rNIPxd7JXc/9DQf6RsaiPxSEE=
 github.com/onflow/flow-ft/lib/go/contracts v1.0.0 h1:mToacZ5NWqtlWwk/7RgIl/jeKB/Sy/tIXdw90yKHcV0=
 github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.35.13-0.20240611224823-09b08708974c h1:IY5MYhOwz+N/38uURYOnepbm2Vaqq2QDUb3kMd1MVz4=
-github.com/onflow/flow-go v0.35.13-0.20240611224823-09b08708974c/go.mod h1:SIGA1krHtMyu23JxrR23blKXQfCl8eyA+JFr3h+TVX0=
+github.com/onflow/flow-go v0.35.13 h1:PnB5yCATcXKhrwa4VAXbWw8VTCuDoJMNkXDfIf9HR9w=
 github.com/onflow/flow-go v0.35.13/go.mod h1:SIGA1krHtMyu23JxrR23blKXQfCl8eyA+JFr3h+TVX0=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
 github.com/onflow/flow-go-sdk v1.0.0-preview.35 h1:2ptBhFYFGOaYghZTRbj51BbYqTZjkyEpXDyaWDYrHwA=


### PR DESCRIPTION
Update flow-go to latest tagged version [v0.35.13](https://github.com/onflow/flow-go/releases/tag/v0.35.13)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the version of `github.com/onflow/flow-go` to `v0.35.13` for improved compatibility and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->