### PR TITLE
Update `eth_estimateGas` to correctly handle execution reverts

### DIFF
--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -373,7 +373,11 @@ func (e *EVM) EstimateGas(
 	if err != nil {
 		return 0, fmt.Errorf("failed to decode EVM result from gas estimation: %w", err)
 	}
+
 	if evmResult.ErrorCode != 0 {
+		if evmResult.ErrorCode == evmTypes.ExecutionErrCodeExecutionReverted {
+			return 0, errs.NewRevertError(evmResult.ReturnedData)
+		}
 		return 0, getErrorForCode(evmResult.ErrorCode)
 	}
 

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -21,7 +21,6 @@ import (
 	gethCore "github.com/onflow/go-ethereum/core"
 	"github.com/onflow/go-ethereum/core/types"
 	gethVM "github.com/onflow/go-ethereum/core/vm"
-	"github.com/onflow/go-ethereum/params"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 
@@ -381,12 +380,7 @@ func (e *EVM) EstimateGas(
 		return 0, getErrorForCode(evmResult.ErrorCode)
 	}
 
-	// This minimum gas availability is needed for:
-	// https://github.com/onflow/go-ethereum/blob/master/core/vm/operations_acl.go#L29-L32
-	// Note that this is not actually consumed in the end.
-	// TODO: Consider moving this to `EVM.dryRun`, if we want the
-	// fix to also apply for the EVM API, on Cadence side.
-	gasConsumed := evmResult.GasConsumed + params.SstoreSentryGasEIP2200 + 1
+	gasConsumed := evmResult.GasConsumed
 
 	e.logger.Debug().
 		Uint64("gas", gasConsumed).

--- a/tests/web3js/eth_deploy_contract_and_interact_test.js
+++ b/tests/web3js/eth_deploy_contract_and_interact_test.js
@@ -173,4 +173,40 @@ it('deploy contract and interact', async() => {
         )
     }
 
+    // check that revert reason for custom error is correctly returned for gas estimation
+    try {
+        let callCustomError = deployed.contract.methods.customError().encodeABI()
+        result = await web3.eth.estimateGas({
+            from: conf.eoa.address,
+            to: contractAddress,
+            data: callCustomError,
+            gas: 1_000_000,
+            gasPrice: 0
+        })
+    } catch (error) {
+        assert.equal(error.innerError.message, 'execution reverted')
+        assert.equal(
+            error.innerError.data,
+            '0x9195785a00000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001056616c756520697320746f6f206c6f7700000000000000000000000000000000'
+        )
+    }
+
+    // check that assertion error is correctly returned for gas estimation
+    try {
+        let callAssertError = deployed.contract.methods.assertError().encodeABI()
+        result = await web3.eth.estimateGas({
+            from: conf.eoa.address,
+            to: contractAddress,
+            data: callAssertError,
+            gas: 1_000_000,
+            gasPrice: 0
+        })
+    } catch (error) {
+        assert.equal(error.innerError.message, 'execution reverted: Assert Error Message')
+        assert.equal(
+            error.innerError.data,
+            '0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000014417373657274204572726f72204d657373616765000000000000000000000000'
+        )
+    }
+
 }).timeout(10*1000)


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/302

## Description

Also remove the temporary fix regarding the gas estimation failures for calls that had gas refunds from `SSTORE` opcode.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 