### PR TITLE
Pass the gateway config to `NetAPI` so it can return the proper network ID

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -33,6 +33,7 @@ func SupportedAPIs(
 	streamAPI *StreamAPI,
 	pullAPI *PullAPI,
 	debugAPI *DebugAPI,
+	config *config.Config,
 ) []rpc.API {
 	apis := []rpc.API{{
 		Namespace: "eth",
@@ -48,7 +49,7 @@ func SupportedAPIs(
 		Service:   &Web3API{},
 	}, {
 		Namespace: "net",
-		Service:   &NetAPI{},
+		Service:   NewNetAPI(config),
 	}, {
 		Namespace: "txpool",
 		Service:   NewTxPoolAPI(),

--- a/api/net.go
+++ b/api/net.go
@@ -3,12 +3,20 @@ package api
 import (
 	"fmt"
 
-	"github.com/onflow/flow-go/fvm/evm/types"
+	"github.com/onflow/flow-evm-gateway/config"
 	"github.com/onflow/go-ethereum/common/hexutil"
 )
 
 // NetAPI offers network related RPC methods
-type NetAPI struct{}
+type NetAPI struct {
+	config *config.Config
+}
+
+func NewNetAPI(config *config.Config) *NetAPI {
+	return &NetAPI{
+		config: config,
+	}
+}
 
 // Listening returns an indication if the node is
 // listening for network connections.
@@ -23,5 +31,5 @@ func (s *NetAPI) PeerCount() hexutil.Uint {
 
 // Version returns the current ethereum protocol version.
 func (s *NetAPI) Version() string {
-	return fmt.Sprintf("%d", types.FlowEVMTestNetChainID)
+	return fmt.Sprintf("%d", s.config.EVMNetworkID)
 }

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -344,7 +344,13 @@ func startServer(
 		debugAPI = api.NewDebugAPI(trace, blocks, logger)
 	}
 
-	supportedAPIs := api.SupportedAPIs(blockchainAPI, streamAPI, pullAPI, debugAPI)
+	supportedAPIs := api.SupportedAPIs(
+		blockchainAPI,
+		streamAPI,
+		pullAPI,
+		debugAPI,
+		cfg,
+	)
 
 	if err := srv.EnableRPC(supportedAPIs); err != nil {
 		return err

--- a/tests/e2e_web3js_test.go
+++ b/tests/e2e_web3js_test.go
@@ -18,6 +18,10 @@ func TestWeb3_E2E(t *testing.T) {
 		runWeb3Test(t, "setup_test")
 	})
 
+	t.Run("test net_* JSON-RPC endpoints", func(t *testing.T) {
+		runWeb3Test(t, "net_namespace_test")
+	})
+
 	t.Run("read-only interactions", func(t *testing.T) {
 		runWeb3Test(t, "eth_non_interactive_test")
 	})

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -190,7 +190,7 @@ it('can make batch requests', async () => {
     )
     assert.deepEqual(
         results[3],
-        { jsonrpc: '2.0', id: 4, result: '545' }
+        { jsonrpc: '2.0', id: 4, result: '646' }
     )
     assert.deepEqual(
         results[4],

--- a/tests/web3js/net_namespace_test.js
+++ b/tests/web3js/net_namespace_test.js
@@ -1,0 +1,18 @@
+const { assert } = require('chai')
+const conf = require('./config')
+const web3 = conf.web3
+
+it('should get net_version', async () => {
+    let networkID = await web3.eth.net.getId()
+    assert.equal(networkID, 646n)
+})
+
+it('should get net_listening', async () => {
+    let isListening = await web3.eth.net.isListening()
+    assert.isTrue(isListening)
+})
+
+it('should get net_peerCount', async () => {
+    let peerCount = await web3.eth.net.getPeerCount()
+    assert.equal(1n, peerCount)
+})


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/310

## Description

Until now, the `net_version` was hard-coded to return the testnet chain ID.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented enhanced network information retrieval for JSON-RPC endpoints, including network ID, listening status, and peer count.
  - Added end-to-end tests to validate the new network information retrieval functionality.

- **Bug Fixes**
  - Corrected expected result values in batch request tests to reflect updated responses.

- **Tests**
  - Introduced new test cases for `net_*` JSON-RPC endpoints and network information retrieval using `web3.eth.net`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->