### PR TITLE
Bring back `zerolog.ConsoleWriter` for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ start:
 .PHONY: start-local
 start-local:
 	rm -rf db/
-	go run cmd/main/main.go --flow-network-id=flow-emulator --coinbase=FACF71692421039876a5BB4F10EF7A439D8ef61E --coa-address=f8d6e0586b0a20c7 --coa-key=2619878f0e2ff438d17835c2a4561cb87b4d24d72d12ec34569acd0dd4af7c21 --coa-resource-create=true --gas-price=0
+	go run cmd/main/main.go --flow-network-id=flow-emulator --coinbase=FACF71692421039876a5BB4F10EF7A439D8ef61E --coa-address=f8d6e0586b0a20c7 --coa-key=2619878f0e2ff438d17835c2a4561cb87b4d24d72d12ec34569acd0dd4af7c21 --coa-resource-create=true --gas-price=0 --log-writer=console

--- a/api/server.go
+++ b/api/server.go
@@ -21,7 +21,6 @@ import (
 	"github.com/onflow/go-ethereum/rpc"
 	"github.com/rs/cors"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 
 	errs "github.com/onflow/flow-evm-gateway/api/errors"
 	"github.com/onflow/flow-evm-gateway/config"
@@ -212,12 +211,12 @@ func (h *httpServer) Start() error {
 	}()
 
 	if h.rpcAllowed() {
-		log.Info().Msg(fmt.Sprintf("JSON-RPC over HTTP enabled: %v", listener.Addr()))
+		h.logger.Info().Msgf("JSON-RPC over HTTP enabled: %v", listener.Addr())
 	}
 
 	if h.wsAllowed() {
 		url := fmt.Sprintf("ws://%v", listener.Addr())
-		log.Info().Msg(fmt.Sprint("JSON-RPC over WebSocket enabled: ", url))
+		h.logger.Info().Msgf("JSON-RPC over WebSocket enabled: %s", url)
 	}
 
 	return nil
@@ -303,13 +302,13 @@ func (h *httpServer) Stop() {
 	defer cancel()
 	err := h.server.Shutdown(ctx)
 	if err != nil && err == ctx.Err() {
-		log.Warn().Msg("HTTP server graceful shutdown timed out")
+		h.logger.Warn().Msg("HTTP server graceful shutdown timed out")
 		h.server.Close()
 	}
 
 	h.listener.Close()
-	log.Info().Msg(
-		fmt.Sprint("HTTP server stopped", "endpoint", h.listener.Addr()),
+	h.logger.Info().Msgf(
+		"HTTP server stopped, endpoint: %s", h.listener.Addr(),
 	)
 
 	// Clear out everything to allow re-configuring it later.
@@ -320,7 +319,7 @@ func (h *httpServer) Stop() {
 // CheckTimeouts ensures that timeout values are meaningful
 func CheckTimeouts(logger zerolog.Logger, timeouts *rpc.HTTPTimeouts) {
 	if timeouts.ReadTimeout < time.Second {
-		log.Warn().Msg(
+		logger.Warn().Msg(
 			fmt.Sprint(
 				"Sanitizing invalid HTTP read timeout",
 				"provided",
@@ -332,7 +331,7 @@ func CheckTimeouts(logger zerolog.Logger, timeouts *rpc.HTTPTimeouts) {
 		timeouts.ReadTimeout = rpc.DefaultHTTPTimeouts.ReadTimeout
 	}
 	if timeouts.ReadHeaderTimeout < time.Second {
-		log.Warn().Msg(
+		logger.Warn().Msg(
 			fmt.Sprint(
 				"Sanitizing invalid HTTP read header timeout",
 				"provided",
@@ -344,7 +343,7 @@ func CheckTimeouts(logger zerolog.Logger, timeouts *rpc.HTTPTimeouts) {
 		timeouts.ReadHeaderTimeout = rpc.DefaultHTTPTimeouts.ReadHeaderTimeout
 	}
 	if timeouts.WriteTimeout < time.Second {
-		log.Warn().Msg(
+		logger.Warn().Msg(
 			fmt.Sprint(
 				"Sanitizing invalid HTTP write timeout",
 				"provided",
@@ -356,7 +355,7 @@ func CheckTimeouts(logger zerolog.Logger, timeouts *rpc.HTTPTimeouts) {
 		timeouts.WriteTimeout = rpc.DefaultHTTPTimeouts.WriteTimeout
 	}
 	if timeouts.IdleTimeout < time.Second {
-		log.Warn().Msg(
+		logger.Warn().Msg(
 			fmt.Sprint(
 				"Sanitizing invalid HTTP idle timeout",
 				"provided",

--- a/config/config.go
+++ b/config/config.go
@@ -89,7 +89,7 @@ type Config struct {
 
 func FromFlags() (*Config, error) {
 	cfg := &Config{}
-	var evmNetwork, coinbase, gas, coa, key, keysPath, flowNetwork, logLevel, filterExpiry, accessSporkHosts, cloudKMSKeys, cloudKMSProjectID, cloudKMSLocationID, cloudKMSKeyRingID string
+	var evmNetwork, coinbase, gas, coa, key, keysPath, flowNetwork, logLevel, logWriter, filterExpiry, accessSporkHosts, cloudKMSKeys, cloudKMSProjectID, cloudKMSLocationID, cloudKMSKeyRingID string
 	var streamTimeout int
 	var initHeight, forceStartHeight uint64
 
@@ -109,7 +109,8 @@ func FromFlags() (*Config, error) {
 	flag.StringVar(&key, "coa-key", "", "Private key value for the COA address used for submitting transactions")
 	flag.StringVar(&keysPath, "coa-key-file", "", "File path that contains JSON array of COA keys used in key-rotation mechanism, this is exclusive with coa-key flag.")
 	flag.BoolVar(&cfg.CreateCOAResource, "coa-resource-create", false, "Auto-create the COA resource in the Flow COA account provided if one doesn't exist")
-	flag.StringVar(&logLevel, "log-level", "debug", "Define verbosity of the log output ('debug', 'info', 'error')")
+	flag.StringVar(&logLevel, "log-level", "debug", "Define verbosity of the log output ('debug', 'info', 'warn', 'error', 'fatal', 'panic')")
+	flag.StringVar(&logWriter, "log-writer", "stderr", "Log writer used for output ('stderr', 'console')")
 	flag.Float64Var(&cfg.StreamLimit, "stream-limit", 10, "Rate-limits the events sent to the client within one second")
 	flag.Uint64Var(&cfg.RateLimit, "rate-limit", 50, "Rate-limit requests per second made by the client over any protocol (ws/http)")
 	flag.StringVar(&cfg.AddressHeader, "address-header", "", "Address header that contains the client IP, this is useful when the server is behind a proxy that sets the source IP of the client. Leave empty if no proxy is used.")
@@ -226,11 +227,21 @@ func FromFlags() (*Config, error) {
 		cfg.LogLevel = zerolog.DebugLevel
 	case "info":
 		cfg.LogLevel = zerolog.InfoLevel
+	case "warn":
+		cfg.LogLevel = zerolog.WarnLevel
 	case "error":
 		cfg.LogLevel = zerolog.ErrorLevel
+	case "fatal":
+		cfg.LogLevel = zerolog.FatalLevel
+	case "panic":
+		cfg.LogLevel = zerolog.PanicLevel
 	}
 
-	cfg.LogWriter = os.Stdout
+	if logWriter == "stderr" {
+		cfg.LogWriter = os.Stderr
+	} else {
+		cfg.LogWriter = zerolog.NewConsoleWriter()
+	}
 
 	cfg.StreamTimeout = time.Second * time.Duration(streamTimeout)
 

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -39,9 +39,9 @@ import (
 )
 
 var (
-	logger         = zerolog.New(os.Stdout)
+	logger         = zerolog.New(zerolog.NewConsoleWriter())
 	sc             = systemcontracts.SystemContractsForChain(flow.Emulator)
-	logOutput      = true // hardcoded to toggle logging during development
+	logOutput      = os.Getenv("LOG_OUTPUT")
 	eoaTestAccount = common.HexToAddress(eoaTestAddress)
 )
 
@@ -67,9 +67,8 @@ func startEmulator(createTestAccounts bool) (*server.EmulatorServer, error) {
 		return nil, err
 	}
 
-	log := logger.With().Str("component", "emulator").Logger().Level(zerolog.DebugLevel)
-	// todo remove
-	if !logOutput {
+	log := logger.With().Timestamp().Str("component", "emulator").Logger().Level(zerolog.DebugLevel)
+	if logOutput == "false" {
 		log = zerolog.Nop()
 	}
 	srv := server.NewEmulatorServer(&log, &server.Config{
@@ -148,7 +147,7 @@ func servicesSetup(t *testing.T) (emulator.Emulator, func()) {
 		WSEnabled:         true,
 	}
 
-	if !logOutput {
+	if logOutput == "false" {
 		cfg.LogWriter = zerolog.Nop()
 	}
 
@@ -265,7 +264,7 @@ func flowSendTransaction(
 		code,
 	))
 
-	log := logger.With().Str("component", "adapter").Logger().Level(zerolog.DebugLevel)
+	log := logger.With().Timestamp().Str("component", "adapter").Logger().Level(zerolog.DebugLevel)
 	adapter := adapters.NewSDKAdapter(&log, emu)
 
 	blk, _, err := adapter.GetLatestBlock(context.Background(), true)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -71,7 +71,7 @@ func Test_ConcurrentTransactionSubmission(t *testing.T) {
 		CreateCOAResource: true,
 		GasPrice:          new(big.Int).SetUint64(0),
 		LogLevel:          zerolog.DebugLevel,
-		LogWriter:         os.Stdout,
+		LogWriter:         zerolog.NewConsoleWriter(),
 	}
 
 	// todo change this test to use ingestion and emulator directly so we can completely remove
@@ -201,7 +201,7 @@ func Test_CloudKMSConcurrentTransactionSubmission(t *testing.T) {
 		CreateCOAResource: true,
 		GasPrice:          new(big.Int).SetUint64(0),
 		LogLevel:          zerolog.DebugLevel,
-		LogWriter:         os.Stdout,
+		LogWriter:         zerolog.NewConsoleWriter(),
 	}
 
 	// todo change this test to use ingestion and emulator directly so we can completely remove


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/162

## Description

> There's a potential bug in the logging changes of ID: https://github.com/onflow/flow-evm-gateway/pull/152/files#diff-a5457320f6b67f92cbcb51459dd5ebd160912638c6b22d0964e52921b58a05d9R223
This ID is not always a number, it can be a string, or anything defined by the client.

This has been already fixed:

```json
{
    "level": "debug",
    "component": "API",
    "IP": "127.0.0.1:60314",
    "url": "/",
    "id": 1,
    "jsonrpc": "2.0",
    "method": "eth_blockNumber",
    "params": [],
    "is-ws": false,
    "time": "2024-06-21T11:39:02Z",
    "message": "API request"
}

{
    "level": "debug",
    "component": "API",
    "IP": "127.0.0.1:33588",
    "url": "/",
    "id": "abc-123-abd", // id is a string, and it does not error out
    "jsonrpc": "2.0",
    "method": "eth_blockNumber",
    "params": [],
    "is-ws": false,
    "time": "2024-06-21T11:39:14Z",
    "message": "API request"
}
```

> I would also bring back console writer if configured because it's very useful when running locally: https://github.com/onflow/flow-evm-gateway/pull/152/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L158
The change should just be to change the stderr to stdout not to change the option of console output.

This has been brought back.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced logging capabilities with new options for log levels ('warn', 'fatal', 'panic') and log writer output ('stderr', 'console').

- **Bug Fixes**
  - Improved logging configuration and usage in test helper functions, ensuring consistent log output handling.

- **Refactor**
  - Replaced global log usage with specific logger instances for better logging management.
  
- **Chores**
  - Updated `Makefile` to include enhanced logging options for local execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->