### PR TITLE
Bugfix invalid block number or hash

### DIFF
--- a/api/encode_transaction.go
+++ b/api/encode_transaction.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/onflow/go-ethereum/core/types"
+
+	errs "github.com/onflow/flow-evm-gateway/api/errors"
 )
 
 const blockGasLimit uint64 = 15_000_000
@@ -44,5 +47,10 @@ func encodeTxFromArgs(args TransactionArgs) ([]byte, error) {
 		},
 	)
 
-	return tx.MarshalBinary()
+	enc, err := tx.MarshalBinary()
+	if err != nil {
+		return nil, errors.Join(err, errs.ErrInvalid)
+	}
+
+	return enc, nil
 }


### PR DESCRIPTION
## Description
Bugfix for a crasher when the block hash or number is nil.

Also improve handling of invalid requests errors.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling across various functions to ensure consistent error responses and better logging.
  - Enhanced specific error cases handling for more accurate error messaging.

- **New Features**
  - Introduced a comprehensive `handleError` function to standardize error handling across the API.

- **Chores**
  - Updated import statements to include necessary error handling packages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->