### PR TITLE
Some more CI fixes to assist debugging of flaky tests

### DIFF
--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -71,7 +71,7 @@ func Test_ConcurrentTransactionSubmission(t *testing.T) {
 		CreateCOAResource: true,
 		GasPrice:          new(big.Int).SetUint64(0),
 		LogLevel:          zerolog.DebugLevel,
-		LogWriter:         zerolog.NewConsoleWriter(),
+		LogWriter:         testLogWriter(),
 	}
 
 	// todo change this test to use ingestion and emulator directly so we can completely remove
@@ -201,7 +201,7 @@ func Test_CloudKMSConcurrentTransactionSubmission(t *testing.T) {
 		CreateCOAResource: true,
 		GasPrice:          new(big.Int).SetUint64(0),
 		LogLevel:          zerolog.DebugLevel,
-		LogWriter:         zerolog.NewConsoleWriter(),
+		LogWriter:         testLogWriter(),
 	}
 
 	// todo change this test to use ingestion and emulator directly so we can completely remove


### PR DESCRIPTION
## Description

- Fix usage of `LOG_OUTPUT` ENV var
- Remove redundant `fmt.Println` statements
- Log early the output of running an E2E test through `mocha` and `web3.js` 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved logging setup in tests to conditionally return a writer based on `logOutput`.
  - Enhanced log writer initialization in concurrent transaction submission tests for better output management.
  - Refined test output by removing unnecessary print statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->