### PR TITLE
Print command error when failing, not output

### DIFF
--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -191,7 +191,7 @@ func executeTest(t *testing.T, testFile string) {
 			var exitError *exec.ExitError
 			if errors.As(err, &exitError) {
 				if exitError.ExitCode() == 1 {
-					require.Fail(t, string(out))
+					require.Fail(t, err.Error())
 				}
 				t.Fatalf("unknown test issue: %s, output: %s", err.Error(), string(out))
 			}

--- a/tests/web3js/eth_streaming_filters_test.js
+++ b/tests/web3js/eth_streaming_filters_test.js
@@ -4,7 +4,7 @@ const conf = require("./config");
 const {assert} = require("chai");
 const storageABI = require('../fixtures/storageABI.json')
 
-const timeout = 20
+const timeout = 30
 
 async function assertFilterLogs(subscription, expectedLogs) {
     let allLogs = []
@@ -65,7 +65,9 @@ async function assertFilterLogs(subscription, expectedLogs) {
 }
 
 it('streaming of logs using filters', async() => {
-    setTimeout(() => process.exit(1), (timeout-1)*1000) // hack if the ws connection is not closed
+    // hack if the ws connection is not closed
+    // TMP: disable
+    // setTimeout(() => process.exit(1), (timeout - 1) * 1000)
 
     let contractDeployment = await helpers.deployContract("storage")
     let contractAddress = contractDeployment.receipt.contractAddress

--- a/tests/web3js/eth_streaming_filters_test.js
+++ b/tests/web3js/eth_streaming_filters_test.js
@@ -4,8 +4,6 @@ const conf = require("./config");
 const {assert} = require("chai");
 const storageABI = require('../fixtures/storageABI.json')
 
-const timeout = 30
-
 async function assertFilterLogs(subscription, expectedLogs) {
     let allLogs = []
     return new Promise((res, rej) => {
@@ -65,10 +63,6 @@ async function assertFilterLogs(subscription, expectedLogs) {
 }
 
 it('streaming of logs using filters', async() => {
-    // hack if the ws connection is not closed
-    // TMP: disable
-    // setTimeout(() => process.exit(1), (timeout - 1) * 1000)
-
     let contractDeployment = await helpers.deployContract("storage")
     let contractAddress = contractDeployment.receipt.contractAddress
 

--- a/tests/web3js/eth_streaming_test.js
+++ b/tests/web3js/eth_streaming_test.js
@@ -3,13 +3,7 @@ const helpers = require('./helpers')
 const { assert } = require('chai')
 const { Web3 } = require("web3");
 
-const timeout = 30 // test timeout seconds
-
 it('streaming of blocks, transactions, logs using filters', async () => {
-    // hack if the ws connection is not closed
-    // TMP: disable
-    // setTimeout(() => process.exit(1), (timeout - 1) * 1000)
-
     let deployed = await helpers.deployContract("storage")
     let contractAddress = deployed.receipt.contractAddress
 

--- a/tests/web3js/eth_streaming_test.js
+++ b/tests/web3js/eth_streaming_test.js
@@ -6,7 +6,9 @@ const { Web3 } = require("web3");
 const timeout = 30 // test timeout seconds
 
 it('streaming of blocks, transactions, logs using filters', async () => {
-    setTimeout(() => process.exit(1), (timeout - 1) * 1000) // hack if the ws connection is not closed
+    // hack if the ws connection is not closed
+    // TMP: disable
+    // setTimeout(() => process.exit(1), (timeout - 1) * 1000)
 
     let deployed = await helpers.deployContract("storage")
     let contractAddress = deployed.receipt.contractAddress


### PR DESCRIPTION
## Description


______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved failure message handling in test execution to use direct error messages for clearer debugging.

- **Tests**
  - Increased timeout value in `eth_streaming_filters_test.js` to 30 seconds for better test stability.
  - Temporarily disabled timeout-based exit in `eth_streaming_filters_test.js` and `eth_streaming_test.js` to prevent premature test termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->