### PR TITLE
Return the released version in `web3_clientVersion`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: "Build & Push EVM Gateway Image to Public Repo"
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - '*'
 
 env:
   DOCKER_IMAGE_URL: ${{ vars.REPO_DOCKER_IMAGE_URL }}:${{ github.sha }}
@@ -15,7 +15,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Google auth
         id: auth
@@ -33,5 +36,5 @@ jobs:
       - name: Docker Auth
         run: |-
           gcloud auth configure-docker ${{ vars.GAR_LOCATION }}-docker.pkg.dev
-          docker build -t ${{ env.DOCKER_IMAGE_URL }} --file Dockerfile .
+          docker build -t ${{ env.DOCKER_IMAGE_URL }} --build-arg GATEWAY_VERSION=$(git describe --tags --abbrev=0 2>/dev/null) --file Dockerfile .
           docker push ${{ env.DOCKER_IMAGE_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM golang:1.20.0 as app-builder
 
+ARG GATEWAY_VERSION="v0.1.0"
+
 # Build the app binary in /app
 WORKDIR /app
 
@@ -13,7 +15,7 @@ RUN go mod download
 RUN go mod verify
 
 # Build binary
-RUN CGO_ENABLED=1 go build -o bin ./cmd/main/main.go
+RUN CGO_ENABLED=1 go build -o bin -ldflags="-X github.com/onflow/flow-evm-gateway/api.Version=${GATEWAY_VERSION}" ./cmd/main/main.go
 RUN chmod a+x bin
 
 # RUN APP

--- a/api/web3.go
+++ b/api/web3.go
@@ -1,16 +1,20 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/onflow/go-ethereum/common/hexutil"
 	"github.com/onflow/go-ethereum/crypto"
 )
+
+var Version = "development"
 
 // Web3API offers helper utils
 type Web3API struct{}
 
 // ClientVersion returns the node name
 func (s *Web3API) ClientVersion() string {
-	return "flow-evm-gateway@v0.1.0"
+	return fmt.Sprintf("flow-evm-gateway@%s", Version)
 }
 
 // Sha3 applies the ethereum sha3 implementation on the input.


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/326

## Description

- Adds an argument variable to the Dockerfile, `GATEWAY_VERSION`
- Injects that variable from the `Build` CI workflow
- Uses the value of that variable in the response of `web3_clientVersion`

Note: Needs to be tested out.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Docker builds to include version tagging for better version control.
  - Updated `ClientVersion` API to dynamically reflect the current version.

- **Chores**
  - Updated CI/CD workflow to trigger on tag pushes instead of branch pushes.
  - Upgraded GitHub Actions checkout to the latest version for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->