### PR TITLE
Return the raw signature values for direct calls

### DIFF
--- a/models/transaction.go
+++ b/models/transaction.go
@@ -49,7 +49,7 @@ func (dc DirectCall) RawSignatureValues() (
 	r *big.Int,
 	s *big.Int,
 ) {
-	return big.NewInt(0), big.NewInt(0), big.NewInt(0)
+	return dc.Transaction().RawSignatureValues()
 }
 
 func (dc DirectCall) From() (common.Address, error) {

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -139,9 +139,9 @@ func Test_DecodeDirectCall(t *testing.T) {
 		gethCommon.HexToHash("0xb055748f36d6bbe99a7ab5e45202b5c095ceda985dec0cc2a8747fd88c80c8c9"),
 		txHash,
 	)
-	assert.Equal(t, big.NewInt(0), v)
-	assert.Equal(t, big.NewInt(0), r)
-	assert.Equal(t, big.NewInt(0), s)
+	assert.Equal(t, big.NewInt(255), v)
+	assert.Equal(t, new(big.Int).SetBytes(from.Bytes()), r)
+	assert.Equal(t, big.NewInt(1), s)
 	assert.Equal(
 		t,
 		gethCommon.HexToAddress("0x0000000000000000000000010000000000000000"),
@@ -246,9 +246,9 @@ func Test_UnmarshalTransaction(t *testing.T) {
 			gethCommon.HexToHash("0xb055748f36d6bbe99a7ab5e45202b5c095ceda985dec0cc2a8747fd88c80c8c9"),
 			txHash,
 		)
-		assert.Equal(t, big.NewInt(0), v)
-		assert.Equal(t, big.NewInt(0), r)
-		assert.Equal(t, big.NewInt(0), s)
+		assert.Equal(t, big.NewInt(255), v)
+		assert.Equal(t, new(big.Int).SetBytes(from.Bytes()), r)
+		assert.Equal(t, big.NewInt(1), s)
 		assert.Equal(
 			t,
 			gethCommon.HexToAddress("0x0000000000000000000000010000000000000000"),

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -61,6 +61,17 @@ it('get block and transactions with COA interactions', async () => {
         // Assert that the transaction type from receipt is `0`, the type of `LegacyTx`.
         assert.equal(receipt.type, 0n)
     }
+
+    // get block transaction
+    let tx = await web3.eth.getTransactionFromBlock(1n, 0)
+    assert.equal(tx.v, "0xff")
+    assert.equal(tx.r, "0x0000000000000000000000000000000000000000000000020000000000000000")
+    assert.equal(tx.s, "0x0000000000000000000000000000000000000000000000000000000000000004")
+
+    tx = await web3.eth.getTransactionFromBlock(2n, 0)
+    assert.equal(tx.v, "0xff")
+    assert.equal(tx.r, "0x0000000000000000000000000000000000000000000000010000000000000000")
+    assert.equal(tx.s, "0x0000000000000000000000000000000000000000000000000000000000000001")
 })
 
 it('get balance', async () => {


### PR DESCRIPTION
Follow up of https://github.com/onflow/flow-evm-gateway/issues/307

## Description

The sample response for `eth_getTransactionByHash`, should look like:

```json
{
    "blockHash": "0xe165a6e93f2ed4e3ccf0039f4a618d2cc7a7d984756e8d234dd46046acb498fd",
    "blockNumber": "0x2",
    "from": "0x0000000000000000000000010000000000000000",
    "gas": "0x5b04",
    "gasPrice": "0x0",
    "hash": "0xa8421f41d16a333d6fc718e5370044225bfed398b762c4d94f9e6c1819da77ee",
    "input": "0x",
    "nonce": "0x0",
    "to": "0x000000000000000000000002a9B9e8CcbbAA9977",
    "transactionIndex": "0x0",
    "value": "0x2540be400",
    "type": "0x0",
    "chainId": "0x286",
    "v": "0xff",
    "r": "0x10000000000000000",
    "s": "0x1"
}
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the values returned by the transaction signature method to ensure accurate raw signature data.

- **Tests**
  - Updated test cases to reflect the new signature value outputs.
  - Added assertions in non-interactive tests to verify transaction signature values in blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->