### PR TITLE
Add Wallet APIs for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ start:
 .PHONY: start-local
 start-local:
 	rm -rf db/
-	go run cmd/main/main.go --flow-network-id=flow-emulator --coinbase=FACF71692421039876a5BB4F10EF7A439D8ef61E --coa-address=f8d6e0586b0a20c7 --coa-key=2619878f0e2ff438d17835c2a4561cb87b4d24d72d12ec34569acd0dd4af7c21 --coa-resource-create=true --gas-price=0 --log-writer=console
+	go run cmd/main/main.go --flow-network-id=flow-emulator --coinbase=FACF71692421039876a5BB4F10EF7A439D8ef61E --coa-address=f8d6e0586b0a20c7 --coa-key=2619878f0e2ff438d17835c2a4561cb87b4d24d72d12ec34569acd0dd4af7c21 --wallet-api-key=2619878f0e2ff438d17835c2a4561cb87b4d24d72d12ec34569acd0dd4af7c21 --coa-resource-create=true --gas-price=0 --log-writer=console

--- a/api/api.go
+++ b/api/api.go
@@ -33,6 +33,7 @@ func SupportedAPIs(
 	streamAPI *StreamAPI,
 	pullAPI *PullAPI,
 	debugAPI *DebugAPI,
+	walletAPI *WalletAPI,
 	config *config.Config,
 ) []rpc.API {
 	apis := []rpc.API{{
@@ -60,6 +61,13 @@ func SupportedAPIs(
 		apis = append(apis, rpc.API{
 			Namespace: "debug",
 			Service:   debugAPI,
+		})
+	}
+
+	if walletAPI != nil {
+		apis = append(apis, rpc.API{
+			Namespace: "eth",
+			Service:   walletAPI,
 		})
 	}
 

--- a/api/api.go
+++ b/api/api.go
@@ -964,6 +964,7 @@ This is because a decision to not support this API was made either because we do
 ever or we don't support it at this phase.
 */
 
+// address: 0x2F3e28D2Ef6860Eb8e8317C237AEA4FD08c76df5
 var testKey, _ = crypto.HexToECDSA("6a0eb450085e825dd41cc3dd85e4166d4afbb0162488a3d811a0637fa7656abf")
 
 // Accounts returns the collection of accounts this node manages.

--- a/api/api.go
+++ b/api/api.go
@@ -7,13 +7,11 @@ import (
 	"fmt"
 	"math/big"
 
-	evmEmulator "github.com/onflow/flow-go/fvm/evm/emulator"
 	evmTypes "github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/go-ethereum/common"
 	"github.com/onflow/go-ethereum/common/hexutil"
 	"github.com/onflow/go-ethereum/common/math"
 	"github.com/onflow/go-ethereum/core/types"
-	"github.com/onflow/go-ethereum/crypto"
 	"github.com/onflow/go-ethereum/eth/filters"
 	"github.com/onflow/go-ethereum/rpc"
 	"github.com/rs/zerolog"
@@ -963,96 +961,6 @@ The API endpoints bellow return a non-supported error indicating the API request
 This is because a decision to not support this API was made either because we don't intend to support it
 ever or we don't support it at this phase.
 */
-
-// address: 0x2F3e28D2Ef6860Eb8e8317C237AEA4FD08c76df5
-var testKey, _ = crypto.HexToECDSA("6a0eb450085e825dd41cc3dd85e4166d4afbb0162488a3d811a0637fa7656abf")
-
-// Accounts returns the collection of accounts this node manages.
-func (b *BlockChainAPI) Accounts() []common.Address {
-	return []common.Address{
-		crypto.PubkeyToAddress(testKey.PublicKey),
-	}
-}
-
-// Sign calculates an ECDSA signature for:
-// keccak256("\x19Ethereum Signed Message:\n" + len(message) + message).
-//
-// Note, the produced signature conforms to the secp256k1 curve R, S and V values,
-// where the V value will be 27 or 28 for legacy reasons.
-//
-// The account associated with addr must be unlocked.
-//
-// https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign
-func (b *BlockChainAPI) Sign(
-	addr common.Address,
-	data hexutil.Bytes,
-) (hexutil.Bytes, error) {
-	return nil, errs.ErrNotSupported
-}
-
-// SignTransaction will sign the given transaction with the from account.
-// The node needs to have the private key of the account corresponding with
-// the given from address and it needs to be unlocked.
-func (b *BlockChainAPI) SignTransaction(
-	ctx context.Context,
-	args TransactionArgs,
-) (*SignTransactionResult, error) {
-
-	nonce := uint64(0)
-	if args.Nonce != nil {
-		nonce = uint64(*args.Nonce)
-	} else {
-		num := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
-		n, err := b.GetTransactionCount(ctx, *args.From, &num)
-		if err != nil {
-			return nil, err
-		}
-		nonce = uint64(*n)
-	}
-
-	var data []byte
-	if args.Data != nil {
-		data = *args.Data
-	}
-
-	tx := types.NewTx(&types.LegacyTx{
-		Nonce:    nonce,
-		To:       args.To,
-		Value:    args.Value.ToInt(),
-		Gas:      uint64(*args.Gas),
-		GasPrice: args.GasPrice.ToInt(),
-		Data:     data,
-	})
-
-	signed, err := types.SignTx(tx, evmEmulator.GetDefaultSigner(), testKey)
-	if err != nil {
-		return nil, fmt.Errorf("error signing EVM transaction: %w", err)
-	}
-
-	raw, err := signed.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
-
-	return &SignTransactionResult{
-		Raw: raw,
-		Tx:  tx,
-	}, nil
-}
-
-// SendTransaction creates a transaction for the given argument, sign it
-// and submit it to the transaction pool.
-func (b *BlockChainAPI) SendTransaction(
-	ctx context.Context,
-	args TransactionArgs,
-) (common.Hash, error) {
-	signed, err := b.SignTransaction(ctx, args)
-	if err != nil {
-		return common.Hash{}, err
-	}
-
-	return b.SendRawTransaction(ctx, signed.Raw)
-}
 
 // GetProof returns the Merkle-proof for a given account and optionally some storage keys.
 func (b *BlockChainAPI) GetProof(

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -12,16 +12,26 @@ import (
 	"github.com/onflow/go-ethereum/rpc"
 
 	errs "github.com/onflow/flow-evm-gateway/api/errors"
+	"github.com/onflow/flow-evm-gateway/config"
 )
 
-// address: 0x2F3e28D2Ef6860Eb8e8317C237AEA4FD08c76df5
-var testKey, _ = crypto.HexToECDSA("6a0eb450085e825dd41cc3dd85e4166d4afbb0162488a3d811a0637fa7656abf")
+type WalletAPI struct {
+	net    *BlockChainAPI
+	config *config.Config
+}
+
+func NewWalletAPI(config *config.Config, net *BlockChainAPI) *WalletAPI {
+	return &WalletAPI{
+		net:    net,
+		config: config,
+	}
+}
 
 // Accounts returns the collection of accounts this node manages.
-func (b *BlockChainAPI) Accounts() []common.Address {
+func (w *WalletAPI) Accounts() ([]common.Address, error) {
 	return []common.Address{
-		crypto.PubkeyToAddress(testKey.PublicKey),
-	}
+		crypto.PubkeyToAddress(w.config.WalletKey.PublicKey),
+	}, nil
 }
 
 // Sign calculates an ECDSA signature for:
@@ -33,7 +43,7 @@ func (b *BlockChainAPI) Accounts() []common.Address {
 // The account associated with addr must be unlocked.
 //
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign
-func (b *BlockChainAPI) Sign(
+func (w *WalletAPI) Sign(
 	addr common.Address,
 	data hexutil.Bytes,
 ) (hexutil.Bytes, error) {
@@ -43,17 +53,16 @@ func (b *BlockChainAPI) Sign(
 // SignTransaction will sign the given transaction with the from account.
 // The node needs to have the private key of the account corresponding with
 // the given from address and it needs to be unlocked.
-func (b *BlockChainAPI) SignTransaction(
+func (w *WalletAPI) SignTransaction(
 	ctx context.Context,
 	args TransactionArgs,
 ) (*SignTransactionResult, error) {
-
 	nonce := uint64(0)
 	if args.Nonce != nil {
 		nonce = uint64(*args.Nonce)
 	} else {
 		num := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
-		n, err := b.GetTransactionCount(ctx, *args.From, &num)
+		n, err := w.net.GetTransactionCount(ctx, *args.From, &num)
 		if err != nil {
 			return nil, err
 		}
@@ -74,7 +83,7 @@ func (b *BlockChainAPI) SignTransaction(
 		Data:     data,
 	})
 
-	signed, err := types.SignTx(tx, evmEmulator.GetDefaultSigner(), testKey)
+	signed, err := types.SignTx(tx, evmEmulator.GetDefaultSigner(), w.config.WalletKey)
 	if err != nil {
 		return nil, fmt.Errorf("error signing EVM transaction: %w", err)
 	}
@@ -92,14 +101,14 @@ func (b *BlockChainAPI) SignTransaction(
 
 // SendTransaction creates a transaction for the given argument, sign it
 // and submit it to the transaction pool.
-func (b *BlockChainAPI) SendTransaction(
+func (w *WalletAPI) SendTransaction(
 	ctx context.Context,
 	args TransactionArgs,
 ) (common.Hash, error) {
-	signed, err := b.SignTransaction(ctx, args)
+	signed, err := w.SignTransaction(ctx, args)
 	if err != nil {
 		return common.Hash{}, err
 	}
 
-	return b.SendRawTransaction(ctx, signed.Raw)
+	return w.net.SendRawTransaction(ctx, signed.Raw)
 }

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	evmEmulator "github.com/onflow/flow-go/fvm/evm/emulator"
+	"github.com/onflow/go-ethereum/common"
+	"github.com/onflow/go-ethereum/common/hexutil"
+	"github.com/onflow/go-ethereum/core/types"
+	"github.com/onflow/go-ethereum/crypto"
+	"github.com/onflow/go-ethereum/rpc"
+
+	errs "github.com/onflow/flow-evm-gateway/api/errors"
+)
+
+// address: 0x2F3e28D2Ef6860Eb8e8317C237AEA4FD08c76df5
+var testKey, _ = crypto.HexToECDSA("6a0eb450085e825dd41cc3dd85e4166d4afbb0162488a3d811a0637fa7656abf")
+
+// Accounts returns the collection of accounts this node manages.
+func (b *BlockChainAPI) Accounts() []common.Address {
+	return []common.Address{
+		crypto.PubkeyToAddress(testKey.PublicKey),
+	}
+}
+
+// Sign calculates an ECDSA signature for:
+// keccak256("\x19Ethereum Signed Message:\n" + len(message) + message).
+//
+// Note, the produced signature conforms to the secp256k1 curve R, S and V values,
+// where the V value will be 27 or 28 for legacy reasons.
+//
+// The account associated with addr must be unlocked.
+//
+// https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign
+func (b *BlockChainAPI) Sign(
+	addr common.Address,
+	data hexutil.Bytes,
+) (hexutil.Bytes, error) {
+	return nil, errs.ErrNotSupported
+}
+
+// SignTransaction will sign the given transaction with the from account.
+// The node needs to have the private key of the account corresponding with
+// the given from address and it needs to be unlocked.
+func (b *BlockChainAPI) SignTransaction(
+	ctx context.Context,
+	args TransactionArgs,
+) (*SignTransactionResult, error) {
+
+	nonce := uint64(0)
+	if args.Nonce != nil {
+		nonce = uint64(*args.Nonce)
+	} else {
+		num := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+		n, err := b.GetTransactionCount(ctx, *args.From, &num)
+		if err != nil {
+			return nil, err
+		}
+		nonce = uint64(*n)
+	}
+
+	var data []byte
+	if args.Data != nil {
+		data = *args.Data
+	}
+
+	tx := types.NewTx(&types.LegacyTx{
+		Nonce:    nonce,
+		To:       args.To,
+		Value:    args.Value.ToInt(),
+		Gas:      uint64(*args.Gas),
+		GasPrice: args.GasPrice.ToInt(),
+		Data:     data,
+	})
+
+	signed, err := types.SignTx(tx, evmEmulator.GetDefaultSigner(), testKey)
+	if err != nil {
+		return nil, fmt.Errorf("error signing EVM transaction: %w", err)
+	}
+
+	raw, err := signed.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	return &SignTransactionResult{
+		Raw: raw,
+		Tx:  tx,
+	}, nil
+}
+
+// SendTransaction creates a transaction for the given argument, sign it
+// and submit it to the transaction pool.
+func (b *BlockChainAPI) SendTransaction(
+	ctx context.Context,
+	args TransactionArgs,
+) (common.Hash, error) {
+	signed, err := b.SignTransaction(ctx, args)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return b.SendRawTransaction(ctx, signed.Raw)
+}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -344,11 +344,17 @@ func startServer(
 		debugAPI = api.NewDebugAPI(trace, blocks, logger)
 	}
 
+	var walletAPI *api.WalletAPI
+	if cfg.WalletEnabled {
+		walletAPI = api.NewWalletAPI(cfg, blockchainAPI)
+	}
+
 	supportedAPIs := api.SupportedAPIs(
 		blockchainAPI,
 		streamAPI,
 		pullAPI,
 		debugAPI,
+		walletAPI,
 		cfg,
 	)
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/129

This adds Wallet APIs for local development. 

**This should not be used in production.**

Some tools and clients rely on wallet APIs for local development and testing. This implementation enables the APIs by using a provided wallet key for operations through the config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Wallet API to manage accounts, sign messages and transactions, and send transactions within the blockchain network.
	- Added command-line support for enabling the Wallet API and setting a private key.

- **Improvements**
	- Enhanced API handling with conditional inclusion of Wallet API based on configuration settings.

- **Configuration**
	- Added `wallet-api-key` command-line flag for setting an ECDSA private key for the Wallet API (intended for local/testing use only).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->