### PR TITLE
Patch `models.StorageReceipt` decoding

### DIFF
--- a/storage/pebble/receipts.go
+++ b/storage/pebble/receipts.go
@@ -138,7 +138,12 @@ func (r *Receipts) getByBlockHeight(height []byte, batch *pebble.Batch) ([]*mode
 		// try to decode single receipt (breaking change migration)
 		var storeReceipt models.StorageReceipt
 		if err = rlp.DecodeBytes(val, &storeReceipt); err != nil {
-			return nil, err
+			gethReceipt := gethTypes.Receipt{}
+			if err = rlp.DecodeBytes(val, &gethReceipt); err != nil {
+				return nil, err
+			}
+
+			storeReceipt = *models.NewStorageReceipt(&gethReceipt)
 		}
 
 		receipts = []*models.StorageReceipt{&storeReceipt}


### PR DESCRIPTION
## Description

Fixes the issue of old stored receipts not having the `RevertReason` field.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved receipt handling to ensure correct decoding, enhancing data integrity and reliability when fetching receipts by block height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->