### PR TITLE
Patch `models.StorageReceipt` to accommodate the old format

### DIFF
--- a/models/receipt.go
+++ b/models/receipt.go
@@ -15,6 +15,46 @@ import (
 	"github.com/onflow/go-ethereum/rlp"
 )
 
+// TEMP: Remove this type after PreviewNet is reset
+type StorageReceiptV0 struct {
+	Type              uint8
+	PostState         []byte
+	Status            uint64
+	CumulativeGasUsed uint64
+	Bloom             gethTypes.Bloom
+	Logs              []*gethTypes.Log
+	TxHash            common.Hash
+	ContractAddress   common.Address
+	GasUsed           uint64
+	EffectiveGasPrice *big.Int
+	BlobGasUsed       uint64
+	BlobGasPrice      *big.Int
+	BlockHash         common.Hash
+	BlockNumber       *big.Int
+	TransactionIndex  uint
+}
+
+func (sr *StorageReceiptV0) ToNewReceipt() *StorageReceipt {
+	return &StorageReceipt{
+		Type:              sr.Type,
+		PostState:         sr.PostState,
+		Status:            sr.Status,
+		CumulativeGasUsed: sr.CumulativeGasUsed,
+		Bloom:             sr.Bloom,
+		Logs:              sr.Logs,
+		TxHash:            sr.TxHash,
+		ContractAddress:   sr.ContractAddress,
+		GasUsed:           sr.GasUsed,
+		EffectiveGasPrice: sr.EffectiveGasPrice,
+		BlobGasUsed:       sr.BlobGasUsed,
+		BlobGasPrice:      sr.BlobGasPrice,
+		BlockHash:         sr.BlockHash,
+		BlockNumber:       sr.BlockNumber,
+		TransactionIndex:  sr.TransactionIndex,
+		RevertReason:      []byte{},
+	}
+}
+
 // StorageReceipt is a receipt representation for storage.
 //
 // This struct copies the geth.Receipt type found here: https://github.com/ethereum/go-ethereum/blob/9bbb9df18549d6f81c3d1f4fc6c65f71bc92490d/core/types/receipt.go#L52


### PR DESCRIPTION
## Description

Add the `models.StorageReceiptV0`, to accommodate the encoding/decoding of the old format.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a temporary `StorageReceiptV0` type for handling receipts until the `PreviewNet` reset.
- **Refactor**
  - Updated receipt decoding logic to use the new `StorageReceiptV0` type.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->