### PR TITLE
Patch `DirectCall` hash calculation change

### DIFF
--- a/models/events.go
+++ b/models/events.go
@@ -72,11 +72,12 @@ func (c *CadenceEvents) Transactions() ([]Transaction, []*StorageReceipt, error)
 	rcps := make([]*StorageReceipt, 0)
 	for _, e := range c.events.Events {
 		if isTransactionExecutedEvent(e.Value) {
-			tx, err := decodeTransaction(e.Value)
+			rcp, err := decodeReceipt(e.Value)
 			if err != nil {
 				return nil, nil, err
 			}
-			rcp, err := decodeReceipt(e.Value)
+
+			tx, err := decodeTransaction(e.Value, rcp.BlockNumber.Uint64())
 			if err != nil {
 				return nil, nil, err
 			}

--- a/models/receipt.go
+++ b/models/receipt.go
@@ -142,7 +142,7 @@ func decodeReceipt(event cadence.Event) (*StorageReceipt, error) {
 		}
 	}
 
-	t, err := decodeTransaction(event)
+	t, err := decodeTransaction(event, tx.BlockHeight)
 	if err != nil {
 		return nil, err
 	}

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -184,7 +184,7 @@ func (tc TransactionCall) MarshalBinary() ([]byte, error) {
 // decodeTransaction takes a cadence event for transaction executed
 // and decodes it into a Transaction interface. The concrete type
 // will be either a TransactionCall or a DirectCall.
-func decodeTransaction(event cadence.Event) (Transaction, error) {
+func decodeTransaction(event cadence.Event, evmHeight uint64) (Transaction, error) {
 	tx, err := types.DecodeTransactionEventPayload(event)
 	if err != nil {
 		return nil, fmt.Errorf("failed to cadence decode transaction: %w", err)
@@ -203,7 +203,7 @@ func decodeTransaction(event cadence.Event) (Transaction, error) {
 			return nil, fmt.Errorf("failed to rlp decode direct call: %w", err)
 		}
 
-		return DirectCall{DirectCall: directCall}, nil
+		return DirectCall{DirectCall: directCall, blockHeight: evmHeight}, nil
 	}
 
 	gethTx := &gethTypes.Transaction{}

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -87,7 +87,7 @@ func createTestEvent(t *testing.T, txBinary string) (cadence.Event, *types.Resul
 func Test_DecodeEVMTransaction(t *testing.T) {
 	cdcEv, _ := createTestEvent(t, evmTxBinary)
 
-	decTx, err := decodeTransaction(cdcEv)
+	decTx, err := decodeTransaction(cdcEv, 10)
 	require.NoError(t, err)
 	require.IsType(t, TransactionCall{}, decTx)
 
@@ -133,7 +133,7 @@ func Test_DecodeEVMTransaction(t *testing.T) {
 func Test_DecodeDirectCall(t *testing.T) {
 	cdcEv, _ := createTestEvent(t, directCallBinary)
 
-	decTx, err := decodeTransaction(cdcEv)
+	decTx, err := decodeTransaction(cdcEv, 10)
 	require.NoError(t, err)
 	require.IsType(t, DirectCall{}, decTx)
 
@@ -181,7 +181,7 @@ func Test_UnmarshalTransaction(t *testing.T) {
 
 		cdcEv, _ := createTestEvent(t, evmTxBinary)
 
-		tx, err := decodeTransaction(cdcEv)
+		tx, err := decodeTransaction(cdcEv, 10)
 		require.NoError(t, err)
 
 		encodedTx, err := tx.MarshalBinary()
@@ -235,7 +235,7 @@ func Test_UnmarshalTransaction(t *testing.T) {
 
 		cdcEv, _ := createTestEvent(t, directCallBinary)
 
-		tx, err := decodeTransaction(cdcEv)
+		tx, err := decodeTransaction(cdcEv, 10)
 		require.NoError(t, err)
 
 		encodedTx, err := tx.MarshalBinary()
@@ -287,7 +287,7 @@ func Test_UnmarshalTransaction(t *testing.T) {
 
 		cdcEv, _ := createTestEvent(t, directCallBinary)
 
-		tx, err := decodeTransaction(cdcEv)
+		tx, err := decodeTransaction(cdcEv, 10)
 		require.NoError(t, err)
 
 		encodedTx, err := tx.MarshalBinary()


### PR DESCRIPTION
## Description

We need to make use of the `EVM` height of a transaction, instead of the Cadence height.

```bash
--hash-calc-height-change=14763
```

Where **14763** is the EVM height the DirectCall hash calculation change was deployed on PreviewNet.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced transaction handling by introducing block height parameter in various functions for more precise transaction decoding.

- **Bug Fixes**
  - Improved decoding accuracy of transactions and receipts by passing block height throughout the decoding process.

- **Performance Improvements**
  - Optimized height handling in transaction storage by replacing `encoding/binary` with `math/big` for better precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->