### PR TITLE
Revert "Patch `DirectCall` hash calculation change"

### DIFF
--- a/models/events.go
+++ b/models/events.go
@@ -72,12 +72,11 @@ func (c *CadenceEvents) Transactions() ([]Transaction, []*StorageReceipt, error)
 	rcps := make([]*StorageReceipt, 0)
 	for _, e := range c.events.Events {
 		if isTransactionExecutedEvent(e.Value) {
-			rcp, err := decodeReceipt(e.Value)
+			tx, err := decodeTransaction(e.Value)
 			if err != nil {
 				return nil, nil, err
 			}
-
-			tx, err := decodeTransaction(e.Value, rcp.BlockNumber.Uint64())
+			rcp, err := decodeReceipt(e.Value)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/models/receipt.go
+++ b/models/receipt.go
@@ -142,7 +142,7 @@ func decodeReceipt(event cadence.Event) (*StorageReceipt, error) {
 		}
 	}
 
-	t, err := decodeTransaction(event, tx.BlockHeight)
+	t, err := decodeTransaction(event)
 	if err != nil {
 		return nil, err
 	}

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -184,7 +184,7 @@ func (tc TransactionCall) MarshalBinary() ([]byte, error) {
 // decodeTransaction takes a cadence event for transaction executed
 // and decodes it into a Transaction interface. The concrete type
 // will be either a TransactionCall or a DirectCall.
-func decodeTransaction(event cadence.Event, evmHeight uint64) (Transaction, error) {
+func decodeTransaction(event cadence.Event) (Transaction, error) {
 	tx, err := types.DecodeTransactionEventPayload(event)
 	if err != nil {
 		return nil, fmt.Errorf("failed to cadence decode transaction: %w", err)
@@ -203,7 +203,7 @@ func decodeTransaction(event cadence.Event, evmHeight uint64) (Transaction, erro
 			return nil, fmt.Errorf("failed to rlp decode direct call: %w", err)
 		}
 
-		return DirectCall{DirectCall: directCall, blockHeight: evmHeight}, nil
+		return DirectCall{DirectCall: directCall}, nil
 	}
 
 	gethTx := &gethTypes.Transaction{}

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -87,7 +87,7 @@ func createTestEvent(t *testing.T, txBinary string) (cadence.Event, *types.Resul
 func Test_DecodeEVMTransaction(t *testing.T) {
 	cdcEv, _ := createTestEvent(t, evmTxBinary)
 
-	decTx, err := decodeTransaction(cdcEv, 10)
+	decTx, err := decodeTransaction(cdcEv)
 	require.NoError(t, err)
 	require.IsType(t, TransactionCall{}, decTx)
 
@@ -133,7 +133,7 @@ func Test_DecodeEVMTransaction(t *testing.T) {
 func Test_DecodeDirectCall(t *testing.T) {
 	cdcEv, _ := createTestEvent(t, directCallBinary)
 
-	decTx, err := decodeTransaction(cdcEv, 10)
+	decTx, err := decodeTransaction(cdcEv)
 	require.NoError(t, err)
 	require.IsType(t, DirectCall{}, decTx)
 
@@ -181,7 +181,7 @@ func Test_UnmarshalTransaction(t *testing.T) {
 
 		cdcEv, _ := createTestEvent(t, evmTxBinary)
 
-		tx, err := decodeTransaction(cdcEv, 10)
+		tx, err := decodeTransaction(cdcEv)
 		require.NoError(t, err)
 
 		encodedTx, err := tx.MarshalBinary()
@@ -235,7 +235,7 @@ func Test_UnmarshalTransaction(t *testing.T) {
 
 		cdcEv, _ := createTestEvent(t, directCallBinary)
 
-		tx, err := decodeTransaction(cdcEv, 10)
+		tx, err := decodeTransaction(cdcEv)
 		require.NoError(t, err)
 
 		encodedTx, err := tx.MarshalBinary()
@@ -287,7 +287,7 @@ func Test_UnmarshalTransaction(t *testing.T) {
 
 		cdcEv, _ := createTestEvent(t, directCallBinary)
 
-		tx, err := decodeTransaction(cdcEv, 10)
+		tx, err := decodeTransaction(cdcEv)
 		require.NoError(t, err)
 
 		encodedTx, err := tx.MarshalBinary()


### PR DESCRIPTION
Temp migration for previewnet, merge after previewnet is deprecated.

Reverts onflow/flow-evm-gateway#344