### PR TITLE
Calculate the `CumulativeGasUsed` field for transaction receipts

### DIFF
--- a/models/events.go
+++ b/models/events.go
@@ -80,11 +80,12 @@ func (c *CadenceEvents) Transactions() ([]Transaction, []*StorageReceipt, error)
 				return nil, nil, err
 			}
 
-			if lastReceipt != nil && lastReceipt.BlockHash == receipt.BlockHash {
+			if lastReceipt != nil && lastReceipt.BlockNumber.Cmp(receipt.BlockNumber) == 0 {
 				cumulativeGasUsed += lastReceipt.GasUsed
 				receipt.CumulativeGasUsed = cumulativeGasUsed
 			} else {
 				cumulativeGasUsed = receipt.GasUsed
+				receipt.CumulativeGasUsed = cumulativeGasUsed
 			}
 
 			lastReceipt = receipt

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -199,14 +199,13 @@ func decodeTransactionEvent(
 	}
 
 	gethReceipt := &gethTypes.Receipt{
-		BlockNumber:       big.NewInt(int64(txEvent.BlockHeight)),
-		Type:              txEvent.TransactionType,
-		TxHash:            common.HexToHash(txEvent.Hash),
-		ContractAddress:   common.HexToAddress(txEvent.ContractAddress),
-		GasUsed:           txEvent.GasConsumed,
-		CumulativeGasUsed: txEvent.GasConsumed, // todo use cumulative after added to the tx result
-		TransactionIndex:  uint(txEvent.Index),
-		BlockHash:         common.HexToHash(txEvent.BlockHash),
+		BlockNumber:      big.NewInt(int64(txEvent.BlockHeight)),
+		Type:             txEvent.TransactionType,
+		TxHash:           common.HexToHash(txEvent.Hash),
+		ContractAddress:  common.HexToAddress(txEvent.ContractAddress),
+		GasUsed:          txEvent.GasConsumed,
+		TransactionIndex: uint(txEvent.Index),
+		BlockHash:        common.HexToHash(txEvent.BlockHash),
 	}
 
 	encLogs, err := hex.DecodeString(txEvent.Logs)

--- a/tests/web3js/eth_batch_retrieval_test.js
+++ b/tests/web3js/eth_batch_retrieval_test.js
@@ -2,21 +2,27 @@ const { assert } = require('chai')
 const conf = require('./config')
 const web3 = conf.web3
 
-it('retrieve batch transactions', async () => {
-  // this test relies on the setup of batched transactions found in ../e2e_web3js_test.go
+it('should retrieve batch transactions', async () => {
+    // this test relies on the setup of batched transactions found in ../e2e_web3js_test.go
 
-  let latestHeight = await web3.eth.getBlockNumber()
-  let block = await web3.eth.getBlock(latestHeight)
+    let latestHeight = await web3.eth.getBlockNumber()
+    let block = await web3.eth.getBlock(latestHeight)
 
-  let batchSize = 10
-  assert.lengthOf(block.transactions, batchSize)
+    let batchSize = 10
+    assert.lengthOf(block.transactions, batchSize)
 
-  for (let i = 0; i < block.transactions.length; i++) {
-    let tx = await web3.eth.getTransactionFromBlock(latestHeight, i)
-    assert.equal(tx.blockNumber, block.number, "wrong block number")
-    assert.equal(tx.blockHash, block.hash, "wrong block hash")
-    assert.equal(tx.type, 0, "wrong type")
-    assert.equal(tx.transactionIndex, i, "wrong index")
-    assert.isBelow(i, batchSize, "wrong batch size")
-  }
+    let cumulativeGasUsed = 0n
+    for (let i = 0; i < block.transactions.length; i++) {
+        let tx = await web3.eth.getTransactionFromBlock(latestHeight, i)
+        assert.equal(tx.blockNumber, block.number, "wrong block number")
+        assert.equal(tx.blockHash, block.hash, "wrong block hash")
+        assert.equal(tx.type, 0, "wrong type")
+        assert.equal(tx.transactionIndex, i, "wrong index")
+        assert.isBelow(i, batchSize, "wrong batch size")
+
+        let receipt = await web3.eth.getTransactionReceipt(tx.hash)
+        cumulativeGasUsed += receipt.gasUsed
+
+        assert.equal(receipt.cumulativeGasUsed, cumulativeGasUsed)
+    }
 })

--- a/tests/web3js/eth_deploy_contract_and_interact_test.js
+++ b/tests/web3js/eth_deploy_contract_and_interact_test.js
@@ -18,6 +18,8 @@ it('deploy contract and interact', async() => {
     assert.equal(rcp.contractAddress, contractAddress)
     assert.equal(rcp.status, conf.successStatus)
     assert.isUndefined(rcp.to)
+    assert.equal(rcp.gasUsed, 338798n)
+    assert.equal(rcp.gasUsed, rcp.cumulativeGasUsed)
 
     // check if latest block contains the deploy results
     let latestHeight = await web3.eth.getBlockNumber()

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -60,6 +60,12 @@ it('get block and transactions with COA interactions', async () => {
         let receipt = await web3.eth.getTransactionReceipt(tx.hash)
         // Assert that the transaction type from receipt is `0`, the type of `LegacyTx`.
         assert.equal(receipt.type, 0n)
+        if (receipt.contractAddress != null) {
+            assert.equal(receipt.gasUsed, 702600n)
+        } else {
+            assert.equal(receipt.gasUsed, 21055n)
+        }
+        assert.equal(receipt.gasUsed, receipt.cumulativeGasUsed)
     }
 
     // get block transaction
@@ -120,10 +126,10 @@ it('get transaction', async () => {
     assert.equal(rcp.blockNumber, conf.startBlockHeight)
     assert.equal(rcp.from, tx.from)
     assert.equal(rcp.to, tx.to)
-    assert.equal(rcp.cumulativeGasUsed, 21000n) // todo check
+    assert.equal(rcp.gasUsed, 21000n)
+    assert.equal(rcp.gasUsed, rcp.cumulativeGasUsed)
     assert.equal(rcp.transactionHash, tx.hash)
     assert.equal(rcp.status, conf.successStatus)
-    assert.equal(rcp.gasUsed, 21000n)
 })
 
 it('get mining status', async () => {


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/357

## Description

We calculate this field when consuming the Cadence events, as it is not included in the `EVM.TransactionExecuted` event. I am not sure if it is easy to add it there.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added logic to calculate cumulative gas usage for transaction receipts.

- **Tests**
  - Enhanced tests to validate gas usage metrics for contract deployment and batch transactions.
  - Updated assertions to verify gas usage and ensure consistency with cumulative values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->