### PR TITLE
Safeguard EVM event identifier comparisons

### DIFF
--- a/models/events_test.go
+++ b/models/events_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go/fvm/evm/types"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
+	flowGo "github.com/onflow/flow-go/model/flow"
 	gethCommon "github.com/onflow/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,7 +58,7 @@ func TestCadenceEvents_Block(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewCadenceEvents(tt.events)
+			c := NewCadenceEvents(tt.events, DefaultEVMEventIdentifiers)
 			blocks, err := c.Blocks()
 			require.NoError(t, err)
 
@@ -79,7 +81,10 @@ func newBlock(height uint64) (*types.Block, flow.Event, error) {
 	evmBlock := types.NewBlock(gethCommon.HexToHash("0x01"), height, uint64(1337), big.NewInt(100), gethCommon.HexToHash("0x02"), nil)
 	ev := types.NewBlockEvent(evmBlock)
 
-	location := common.NewAddressLocation(nil, common.Address{0x1}, string(types.EventTypeBlockExecuted))
+	address := common.Address(
+		systemcontracts.SystemContractsForChain(flowGo.Previewnet).EVMContract.Address,
+	)
+	location := common.NewAddressLocation(nil, address, string(types.EventTypeBlockExecuted))
 	cadenceEvent, err := ev.Payload.ToCadence(location)
 	if err != nil {
 		return nil, flow.Event{}, err


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/356

## Description

This change performs a **strict** comparison on the type IDs from the emitted events, to make sure that we're only accepting events emitted from the `AddressLocation` of the `EVM` contract, on each network.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced event identification by incorporating EVM event IDs, improving accuracy in event processing.

- **Refactor**
  - Updated functions and methods to accept and utilize EVM event identifiers, streamlining event type comparisons.

- **Bug Fixes**
  - Fixed various issues related to event ID mismanagement and improved the reliability of block and transaction event handling.

- **Tests**
  - Updated test cases to integrate the new EVM event ID parameters, ensuring thorough validation of changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->