### PR TITLE
Remote ledger

### DIFF
--- a/emulator/remote_state.go
+++ b/emulator/remote_state.go
@@ -15,6 +15,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var previewnetStorage = flow.HexToAddress("0x4f6fd534ddd3fc5f")
+
 var _ atree.Ledger = &remoteLedger{}
 
 func newRemoteLedger(host string, cadenceHeight uint64) (*remoteLedger, error) {

--- a/emulator/remote_state.go
+++ b/emulator/remote_state.go
@@ -1,0 +1,82 @@
+package emulator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onflow/atree"
+	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow/protobuf/go/flow/entities"
+	"github.com/onflow/flow/protobuf/go/flow/executiondata"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+var _ atree.Ledger = &remoteLedger{}
+
+func newRemoteLedger(host string, cadenceHeight uint64) (*remoteLedger, error) {
+	conn, err := grpc.Dial(
+		host,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1024*1024*1024)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to rpc host: %w", err)
+	}
+
+	return &remoteLedger{
+		execution: executiondata.NewExecutionDataAPIClient(conn),
+		height:    cadenceHeight,
+	}, nil
+}
+
+// remoteLedger is a ledger that uses execution data APIs to fetch register values,
+// thus simulating execution against the host network.
+//
+// The ledger implements atree.Ledger interface which is used by the type.stateDB
+// to inspect the state.
+type remoteLedger struct {
+	execution executiondata.ExecutionDataAPIClient
+	height    uint64
+}
+
+func (l *remoteLedger) GetValue(owner, key []byte) ([]byte, error) {
+	id := flow.RegisterID{
+		Key:   string(key),
+		Owner: string(owner),
+	}
+	registerID := convert.RegisterIDToMessage(id)
+
+	response, err := l.execution.GetRegisterValues(
+		context.Background(),
+		&executiondata.GetRegisterValuesRequest{
+			BlockHeight: l.height,
+			RegisterIds: []*entities.RegisterID{registerID},
+		},
+	)
+	if err != nil && status.Code(err) != codes.NotFound {
+		return nil, err
+	}
+
+	if response != nil && len(response.Values) > 0 {
+		return response.Values[0], nil
+	}
+
+	return nil, nil
+}
+
+func (l *remoteLedger) ValueExists(owner, key []byte) (exists bool, err error) {
+	val, err := l.GetValue(owner, key)
+	return val != nil, err
+}
+
+func (l *remoteLedger) SetValue(owner, key, value []byte) (err error) {
+	panic("read only")
+}
+
+func (l *remoteLedger) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
+	panic("read only")
+}

--- a/emulator/remote_state_test.go
+++ b/emulator/remote_state_test.go
@@ -28,7 +28,7 @@ func Test_E2E_Previewnet_RemoteLedger(t *testing.T) {
 
 	assert.NotEmpty(t, stateDB.GetCode(testAddress))
 	assert.NotEmpty(t, stateDB.GetNonce(testAddress))
-	assert.NotEmpty(t, stateDB.GetBalance(testAddress))
+	assert.Empty(t, stateDB.GetBalance(testAddress))
 	assert.NotEmpty(t, stateDB.GetCodeSize(testAddress))
 	assert.NotEmpty(t, stateDB.GetState(testAddress, gethCommon.Hash{}))
 }

--- a/emulator/remote_state_test.go
+++ b/emulator/remote_state_test.go
@@ -33,15 +33,25 @@ func Test_E2E_Previewnet_RemoteLedger(t *testing.T) {
 	assert.NotEmpty(t, stateDB.GetState(testAddress, gethCommon.Hash{}))
 }
 
+/*
+Testing from local machine (bottleneck is network delay to previewnet AN)
+
+Benchmark_RemoteLedger_GetBalance-8   	       9	1144204361 ns/op
+*/
 func Benchmark_RemoteLedger_GetBalance(b *testing.B) {
+	const previewnetHost = "access-001.previewnet1.nodes.onflow.org:9000"
+	cadenceHeight, err := getPreviewnetLatestHeight(previewnetHost)
+	require.NoError(b, err)
+
 	// we have to include ledger creation since the loading of the collection
 	// will be done only once per height, all the subsequent requests for
 	// getting the balance will work on already loaded state and thus be fast
 	for i := 0; i < b.N; i++ {
-		ledger, err := newPreviewnetLedger()
+		ledger, err := newRemoteLedger(previewnetHost, cadenceHeight)
 		require.NoError(b, err)
 
 		stateDB, err := state.NewStateDB(ledger, previewnetStorage)
+		require.NoError(b, err)
 
 		addrBytes, err := hex.DecodeString("BC9985a24c0846cbEdd6249868020A84Df83Ea85")
 		require.NoError(b, err)

--- a/emulator/remote_state_test.go
+++ b/emulator/remote_state_test.go
@@ -25,6 +25,7 @@ func Test_E2E_Previewnet_RemoteLedger(t *testing.T) {
 	testAddress := types.NewAddressFromBytes(addrBytes).ToCommon()
 
 	stateDB, err := state.NewStateDB(ledger, previewnetStorage)
+	require.NoError(t, err)
 
 	assert.NotEmpty(t, stateDB.GetCode(testAddress))
 	assert.NotEmpty(t, stateDB.GetNonce(testAddress))

--- a/emulator/remote_state_test.go
+++ b/emulator/remote_state_test.go
@@ -1,0 +1,50 @@
+package emulator
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/onflow/flow-go/fvm/evm/emulator/state"
+	"github.com/onflow/flow-go/fvm/evm/types"
+	"github.com/onflow/flow-go/model/flow"
+	gethCommon "github.com/onflow/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetCode(t *testing.T) {
+	ledger, err := newRemoteLedger("access-001.previewnet1.nodes.onflow.org:9000", uint64(0))
+	require.NoError(t, err)
+
+	emu := newEmulator(ledger)
+	view, err := emu.view()
+	require.NoError(t, err)
+
+	addrBytes, err := hex.DecodeString("BC9985a24c0846cbEdd6249868020A84Df83Ea85")
+	require.NoError(t, err)
+	address := types.NewAddressFromBytes(addrBytes)
+
+	code, err := view.CodeOf(address)
+	require.NoError(t, err)
+	assert.NotEmpty(t, code)
+	fmt.Println(fmt.Sprintf("%x", code))
+
+	balance, err := view.BalanceOf(address)
+	require.NoError(t, err)
+	assert.NotEmpty(t, balance)
+
+	nonce, err := view.NonceOf(address)
+	require.NoError(t, err)
+	assert.NotEmpty(t, nonce)
+
+	storageAddress := flow.HexToAddress("0x4f6fd534ddd3fc5f")
+	stateDB, err := state.NewStateDB(ledger, storageAddress)
+
+	code2 := stateDB.GetCode(address.ToCommon())
+	assert.NotEmpty(t, code2)
+
+	hash := stateDB.GetState(address.ToCommon(), gethCommon.BytesToHash(address.Bytes()))
+	assert.NotEmpty(t, hash)
+	require.Equal(t, code, hash)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,11 @@ require (
 	cloud.google.com/go/storage v1.36.0
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593
 	github.com/goccy/go-json v0.10.2
+	github.com/onflow/atree v0.7.0-rc.2
 	github.com/onflow/cadence v1.0.0-preview.36
 	github.com/onflow/flow-go v0.36.0
 	github.com/onflow/flow-go-sdk v1.0.0-preview.38
+	github.com/onflow/flow/protobuf/go/flow v0.4.4
 	github.com/onflow/go-ethereum v1.13.4
 	github.com/rs/cors v1.8.0
 	github.com/rs/zerolog v1.31.0
@@ -18,6 +20,7 @@ require (
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
 	golang.org/x/sync v0.6.0
 	google.golang.org/api v0.162.0
+	google.golang.org/grpc v1.63.2
 )
 
 require (
@@ -86,6 +89,8 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/holiman/uint256 v1.2.4 // indirect
+	github.com/huandu/go-clone v1.6.0 // indirect
+	github.com/huandu/go-clone/generic v1.7.2 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
@@ -126,7 +131,6 @@ require (
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onflow/atree v0.7.0-rc.2 // indirect
 	github.com/onflow/crypto v0.25.1 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.0 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.0 // indirect
@@ -134,7 +138,6 @@ require (
 	github.com/onflow/flow-ft/lib/go/templates v1.0.0 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.1 // indirect
 	github.com/onflow/flow-nft/lib/go/templates v1.2.0 // indirect
-	github.com/onflow/flow/protobuf/go/flow v0.4.4 // indirect
 	github.com/onflow/sdks v0.6.0-preview.1 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.18.1 // indirect
@@ -201,7 +204,6 @@ require (
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de // indirect
-	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1609,6 +1609,8 @@ github.com/holiman/uint256 v1.2.3/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZm
 github.com/holiman/uint256 v1.2.4 h1:jUc4Nk8fm9jZabQuqr2JzednajVmBpC+oiTiXZJEApU=
 github.com/holiman/uint256 v1.2.4/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3c=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
 github.com/huandu/go-clone v1.6.0 h1:HMo5uvg4wgfiy5FoGOqlFLQED/VGRm2D9Pi8g1FXPGc=
 github.com/huandu/go-clone v1.6.0/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
 github.com/huandu/go-clone/generic v1.7.2 h1:47pQphxs1Xc9cVADjOHN+Bm5D0hNagwH9UXErbxgVKA=


### PR DESCRIPTION
Related: #351 

This is the first step towards solution 2 in the issue. 

The PR implements a remote ledger that is compliant with the `atree.Ledger` interface that is being used by the state DB. The ledger is read-only and fetches the registers from the configured AN API. 

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for emulating execution against the Flow blockchain preview network.
  - Added functions for retrieving and setting values, and allocating storage indices on a remote ledger.

- **Tests**
  - Implemented tests for remote ledger interactions, including code, nonce, balance, and state information retrieval.
  - Added benchmark tests for performance measurement of balance fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->