### PR TITLE
Get storage at API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -885,6 +885,10 @@ func (b *BlockChainAPI) GetStorageAt(
 	storageSlot string,
 	blockNumberOrHash *rpc.BlockNumberOrHash,
 ) (hexutil.Bytes, error) {
+	if err := rateLimit(ctx, b.limiter, b.logger); err != nil {
+		return nil, err
+	}
+
 	key, _, err := decodeHash(storageSlot)
 	if err != nil {
 		return handleError[hexutil.Bytes](b.logger, errors.Join(errs.ErrInvalid, err))

--- a/api/api.go
+++ b/api/api.go
@@ -3,9 +3,11 @@ package api
 import (
 	"context"
 	_ "embed"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 
 	evmTypes "github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/go-ethereum/common"
@@ -690,28 +692,6 @@ func (b *BlockChainAPI) GetCode(
 	return code, nil
 }
 
-// handleError takes in an error and in case the error is of type ErrNotFound
-// it returns nil instead of an error since that is according to the API spec,
-// if the error is not of type ErrNotFound it will return the error and the generic
-// empty type.
-func handleError[T any](log zerolog.Logger, err error) (T, error) {
-	var zero T
-	switch {
-	// as per specification returning nil and nil for not found resources
-	case errors.Is(err, storageErrs.ErrNotFound):
-		return zero, nil
-	case errors.Is(err, storageErrs.ErrInvalidRange):
-		return zero, err
-	case errors.Is(err, requester.ErrOutOfRange):
-		return zero, fmt.Errorf("requested height is out of supported range")
-	case errors.Is(err, errs.ErrInvalid):
-		return zero, err
-	default:
-		log.Error().Err(err).Msg("api error")
-		return zero, errs.ErrInternal
-	}
-}
-
 func (b *BlockChainAPI) fetchBlockTransactions(
 	ctx context.Context,
 	block *evmTypes.Block,
@@ -896,6 +876,74 @@ func (b *BlockChainAPI) FeeHistory(
 	}, nil
 }
 
+// GetStorageAt returns the storage from the state at the given address, key and
+// block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta block
+// numbers are also allowed.
+func (b *BlockChainAPI) GetStorageAt(
+	ctx context.Context,
+	address common.Address,
+	storageSlot string,
+	blockNumberOrHash *rpc.BlockNumberOrHash,
+) (hexutil.Bytes, error) {
+	key, _, err := decodeHash(storageSlot)
+	if err != nil {
+		return handleError[hexutil.Bytes](b.logger, errors.Join(errs.ErrInvalid, err))
+	}
+
+	evmHeight, err := b.getBlockNumber(blockNumberOrHash)
+	if err != nil {
+		return handleError[hexutil.Bytes](b.logger, err)
+	}
+
+	result, err := b.evm.GetStorageAt(ctx, address, key, evmHeight)
+	if err != nil {
+		return handleError[hexutil.Bytes](b.logger, err)
+	}
+
+	return result[:], nil
+}
+
+// handleError takes in an error and in case the error is of type ErrNotFound
+// it returns nil instead of an error since that is according to the API spec,
+// if the error is not of type ErrNotFound it will return the error and the generic
+// empty type.
+func handleError[T any](log zerolog.Logger, err error) (T, error) {
+	var zero T
+	switch {
+	// as per specification returning nil and nil for not found resources
+	case errors.Is(err, storageErrs.ErrNotFound):
+		return zero, nil
+	case errors.Is(err, storageErrs.ErrInvalidRange):
+		return zero, err
+	case errors.Is(err, requester.ErrOutOfRange):
+		return zero, fmt.Errorf("requested height is out of supported range")
+	case errors.Is(err, errs.ErrInvalid):
+		return zero, err
+	default:
+		log.Error().Err(err).Msg("api error")
+		return zero, errs.ErrInternal
+	}
+}
+
+// decodeHash parses a hex-encoded 32-byte hash. The input may optionally
+// be prefixed by 0x and can have a byte length up to 32.
+func decodeHash(s string) (h common.Hash, inputLength int, err error) {
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		s = s[2:]
+	}
+	if (len(s) & 1) > 0 {
+		s = "0" + s
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return common.Hash{}, 0, errors.New("hex string invalid")
+	}
+	if len(b) > 32 {
+		return common.Hash{}, len(b), errors.New("hex string too long, want at most 32 bytes")
+	}
+	return common.BytesToHash(b), len(b), nil
+}
+
 /*
 Static responses section
 
@@ -975,18 +1023,6 @@ func (b *BlockChainAPI) GetProof(
 	storageKeys []string,
 	blockNumberOrHash rpc.BlockNumberOrHash,
 ) (*AccountResult, error) {
-	return nil, errs.ErrNotSupported
-}
-
-// GetStorageAt returns the storage from the state at the given address, key and
-// block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta block
-// numbers are also allowed.
-func (b *BlockChainAPI) GetStorageAt(
-	ctx context.Context,
-	address common.Address,
-	storageSlot string,
-	blockNumberOrHash *rpc.BlockNumberOrHash,
-) (hexutil.Bytes, error) {
 	return nil, errs.ErrNotSupported
 }
 

--- a/emulator/remote_state_test.go
+++ b/emulator/remote_state_test.go
@@ -28,7 +28,7 @@ func Test_E2E_Previewnet_RemoteLedger(t *testing.T) {
 
 	assert.NotEmpty(t, stateDB.GetCode(testAddress))
 	assert.NotEmpty(t, stateDB.GetNonce(testAddress))
-	assert.NotEmpty(t, stateDB.GetBalance(testAddress))
+	assert.Empty(t, stateDB.GetBalance(testAddress))
 	assert.NotEmpty(t, stateDB.GetCodeSize(testAddress))
 	assert.NotEmpty(t, stateDB.GetState(testAddress, gethCommon.Hash{}))
 }

--- a/services/requester/remote_state.go
+++ b/services/requester/remote_state.go
@@ -1,4 +1,4 @@
-package emulator
+package requester
 
 import (
 	"context"
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var previewnetStorage = flow.HexToAddress("0x4f6fd534ddd3fc5f")
+var previewnetStorageAddress = flow.HexToAddress("0x4f6fd534ddd3fc5f")
 
 var _ atree.Ledger = &remoteLedger{}
 

--- a/services/requester/remote_state.go
+++ b/services/requester/remote_state.go
@@ -64,6 +64,7 @@ func (l *remoteLedger) GetValue(owner, key []byte) ([]byte, error) {
 	}
 
 	if response != nil && len(response.Values) > 0 {
+		// we only request one register so 0 index
 		return response.Values[0], nil
 	}
 

--- a/services/requester/remote_state_test.go
+++ b/services/requester/remote_state_test.go
@@ -1,4 +1,4 @@
-package emulator
+package requester
 
 import (
 	"context"
@@ -24,7 +24,7 @@ func Test_E2E_Previewnet_RemoteLedger(t *testing.T) {
 	require.NoError(t, err)
 	testAddress := types.NewAddressFromBytes(addrBytes).ToCommon()
 
-	stateDB, err := state.NewStateDB(ledger, previewnetStorage)
+	stateDB, err := state.NewStateDB(ledger, previewnetStorageAddress)
 
 	assert.NotEmpty(t, stateDB.GetCode(testAddress))
 	assert.NotEmpty(t, stateDB.GetNonce(testAddress))
@@ -50,7 +50,7 @@ func Benchmark_RemoteLedger_GetBalance(b *testing.B) {
 		ledger, err := newRemoteLedger(previewnetHost, cadenceHeight)
 		require.NoError(b, err)
 
-		stateDB, err := state.NewStateDB(ledger, previewnetStorage)
+		stateDB, err := state.NewStateDB(ledger, previewnetStorageAddress)
 		require.NoError(b, err)
 
 		addrBytes, err := hex.DecodeString("BC9985a24c0846cbEdd6249868020A84Df83Ea85")

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -380,7 +380,6 @@ func (e *EVM) stateAt(evmHeight int64) (*state.StateDB, error) {
 		return nil, err
 	}
 
-	fmt.Println("###", "cadence", height, "evm", evmHeight)
 	ledger, err := newRemoteLedger(e.config.AccessNodeHost, height)
 	if err != nil {
 		return nil, fmt.Errorf("could not create a remote ledger: %w", err)

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -87,6 +87,9 @@ type Requester interface {
 
 	// GetLatestEVMHeight returns the latest EVM height of the network.
 	GetLatestEVMHeight(ctx context.Context) (uint64, error)
+
+	// GetStorageAt returns the storage from the state at the given address, key and block number.
+	GetStorageAt(ctx context.Context, address common.Address, hash common.Hash, evmHeight int64) (common.Hash, error)
 }
 
 var _ Requester = &EVM{}

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -380,7 +380,8 @@ func (e *EVM) stateAt(evmHeight int64) (*state.StateDB, error) {
 		return nil, err
 	}
 
-	ledger, err := newRemoteLedger(e.config.RPCHost, height)
+	fmt.Println("###", "cadence", height, "evm", evmHeight)
+	ledger, err := newRemoteLedger(e.config.AccessNodeHost, height)
 	if err != nil {
 		return nil, fmt.Errorf("could not create a remote ledger: %w", err)
 	}
@@ -394,6 +395,19 @@ func (e *EVM) GetStorageAt(
 	hash common.Hash,
 	evmHeight int64,
 ) (common.Hash, error) {
+	cadenceHeight, err := e.evmToCadenceHeight(evmHeight)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	if cadenceHeight == LatestBlockHeight {
+		h, err := e.client.GetLatestBlockHeader(ctx, true)
+		if err != nil {
+			return common.Hash{}, err
+		}
+		cadenceHeight = h.Height
+	}
+
 	stateDB, err := e.stateAt(evmHeight)
 	if err != nil {
 		return common.Hash{}, err


### PR DESCRIPTION
Relies on: #362 
Related: #351 

This builds on top of #362 and exposes the `eth_getStorageAt` API needed for inspecting the account storage.

Example:

```
curl -XPOST 'localhost:3000' --header 'Content-Type: application/json' --data-raw '{"jsonrpc":"2.0", "method": "eth_getStorageAt", "params": ["0x07C2006580b42cB35Bc4583fEB4904626CcdfA60", "0x0", "latest"], "id": 1}'

{"jsonrpc":"2.0","id":1,"result":"0x0000000000000000000000000000000000000000000000000000000000000064"}
```

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 