### PR TITLE
Populate `LogsBloom` field with its default fault for block responses

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -728,6 +728,7 @@ func (b *BlockChainAPI) prepareBlockResponse(
 		Nonce:         types.BlockNonce{0x1},
 		Timestamp:     hexutil.Uint64(block.Timestamp),
 		BaseFeePerGas: hexutil.Big(*big.NewInt(0)),
+		LogsBloom:     types.LogsBloom([]*types.Log{}),
 	}
 
 	// todo remove after previewnet, temp fix to mock some of the timestamps

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -43,6 +43,19 @@ it('get block', async () => {
     assert.isNull(no)
 })
 
+it('get earliest/genesis block', async () => {
+    let block = await web3.eth.getBlock('earliest')
+
+    assert.notDeepEqual(block, {})
+    assert.equal(block.number, 0n)
+    assert.isString(block.hash)
+    assert.isString(block.parentHash)
+    assert.lengthOf(block.logsBloom, 514)
+    assert.isDefined(block.timestamp)
+    assert.isTrue(block.timestamp >= 1714090657n)
+    assert.isUndefined(block.transactions)
+})
+
 it('get block and transactions with COA interactions', async () => {
     // First 2 blocks are formed from COA deployment and fund.
     const blockNumbers = [1, 2]


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/372
Related: https://github.com/onflow/flow-evm-gateway/issues/371

## Description

One such example is the genesis block, which does not have any transactions, but even so, the `LogsBloom` field should be the 256-byte empty bloom, instead of `0x`. This breaks the serialization for many tools.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 