### PR TITLE
Update `eth_syncing` endpoint to return `false` when the Gateway has caught up syncing all EVM blocks

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -146,9 +146,13 @@ func (b *BlockChainAPI) Syncing(ctx context.Context) (interface{}, error) {
 		return handleError[any](err, b.logger)
 	}
 
-	highestBlock, err := b.evm.GetLatestEVMHeight(context.Background())
+	highestBlock, err := b.evm.GetLatestEVMHeight(ctx)
 	if err != nil {
 		return handleError[any](err, b.logger)
+	}
+
+	if currentBlock == highestBlock {
+		return false, nil
 	}
 
 	return SyncStatus{

--- a/tests/e2e_web3js_test.go
+++ b/tests/e2e_web3js_test.go
@@ -26,6 +26,10 @@ func TestWeb3_E2E(t *testing.T) {
 		runWeb3Test(t, "eth_non_interactive_test")
 	})
 
+	t.Run("retrieve syncing status", func(t *testing.T) {
+		runWeb3Test(t, "eth_syncing_status_test")
+	})
+
 	t.Run("deploy contract and call methods", func(t *testing.T) {
 		runWeb3Test(t, "eth_deploy_contract_and_interact_test")
 	})

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -162,14 +162,8 @@ it('get mining status', async () => {
 })
 
 it('get syncing status', async () => {
-    let height = await web3.eth.getBlockNumber()
-    assert.equal(height, conf.startBlockHeight)
-
-    let syncInfo = await web3.eth.isSyncing()
-    // conf.startBlockHeight = 2n
-    assert.equal(syncInfo.startingBlock, height)
-    assert.equal(syncInfo.currentBlock, height)
-    assert.equal(syncInfo.highestBlock, height)
+    let isSyncing = await web3.eth.isSyncing()
+    assert.isFalse(isSyncing)
 })
 
 it('can make batch requests', async () => {
@@ -226,7 +220,7 @@ it('can make batch requests', async () => {
         {
             jsonrpc: '2.0',
             id: 3,
-            result: { startingBlock: '0x2', currentBlock: '0x2', highestBlock: '0x2' }
+            result: false
         }
     )
     assert.deepEqual(

--- a/tests/web3js/eth_syncing_status_test.js
+++ b/tests/web3js/eth_syncing_status_test.js
@@ -1,0 +1,48 @@
+const utils = require('web3-utils')
+const { assert } = require('chai')
+const conf = require('./config')
+const helpers = require('./helpers')
+const web3 = conf.web3
+
+it('should retrieve syncing status', async () => {
+    let receiver = web3.eth.accounts.create()
+
+    // make sure receiver balance is initially 0
+    let receiverWei = await web3.eth.getBalance(receiver.address)
+    assert.equal(receiverWei, 0n)
+
+    // get sender balance
+    let senderBalance = await web3.eth.getBalance(conf.eoa.address)
+    assert.equal(senderBalance, utils.toWei(conf.fundedAmount, "ether"))
+
+    // Make sure that we are not currently syncing
+    let syncInfo = await web3.eth.isSyncing()
+    assert.isFalse(syncInfo)
+
+    let transferValue = utils.toWei("0.5", "ether")
+    for (let index = 0; index < 10; index++) {
+        const signedTx = await conf.eoa.signTransaction(
+            {
+                from: conf.eoa.address,
+                to: receiver.address,
+                value: transferValue,
+                gasPrice: '0',
+                gasLimit: 55000,
+            }
+        )
+
+        // Send many transactions, without waiting for the result
+        // so the ingestion will lag behind.
+        web3.eth.sendSignedTransaction(signedTx.rawTransaction)
+
+        syncInfo = await web3.eth.isSyncing()
+        if (syncInfo != false) {
+            assert.isDefined(syncInfo.startingBlock)
+            assert.isDefined(syncInfo.currentBlock)
+            assert.isDefined(syncInfo.highestBlock)
+            assert.isBelow(Number(syncInfo.currentBlock), Number(syncInfo.highestBlock))
+
+            return
+        }
+    }
+})


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/376

## Description

As per the JSON-RPC API Specification, when the current indexed block and the highest network block are equal, `eth_syncing` should return `false`, instead of the syncing status object.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced API for improved context management in the syncing process, allowing for more efficient operation and early termination when already synchronized.
	- Introduced a new end-to-end test for verifying the synchronization status of the Ethereum node, improving test coverage.
	- New test suite created to validate Ethereum node syncing behavior during transaction loads.

- **Bug Fixes**
	- Simplified syncing status tests to focus on binary state verification, improving clarity and reducing complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->