### PR TITLE
Calculate and return block size for block-related JSON-RPC API calls

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/onflow/go-ethereum/common/math"
 	"github.com/onflow/go-ethereum/core/types"
 	"github.com/onflow/go-ethereum/eth/filters"
+	"github.com/onflow/go-ethereum/rlp"
 	"github.com/onflow/go-ethereum/rpc"
 	"github.com/rs/zerolog"
 	"github.com/sethvargo/go-limiter"
@@ -914,10 +915,17 @@ func (b *BlockChainAPI) prepareBlockResponse(
 		blockResponse.Timestamp = hexutil.Uint64(timestamp)
 	}
 
+	blockBytes, err := block.ToBytes()
+	if err != nil {
+		return nil, err
+	}
+	blockSize := rlp.ListSize(uint64(len(blockBytes)))
+
 	transactions, err := b.fetchBlockTransactions(ctx, block)
 	if err != nil {
 		return nil, err
 	}
+
 	if len(transactions) > 0 {
 		totalGasUsed := hexutil.Uint64(0)
 		logs := make([]*types.Log, 0)
@@ -928,11 +936,13 @@ func (b *BlockChainAPI) prepareBlockResponse(
 			}
 			totalGasUsed += tx.Gas
 			logs = append(logs, txReceipt.Logs...)
+			blockSize += tx.Size()
 		}
 		blockResponse.GasUsed = totalGasUsed
 		// TODO(m-Peter): Consider if its worthwhile to move this in storage.
 		blockResponse.LogsBloom = types.LogsBloom(logs)
 	}
+	blockResponse.Size = hexutil.Uint64(rlp.ListSize(blockSize))
 
 	if fullTx {
 		blockResponse.Transactions = transactions

--- a/api/models.go
+++ b/api/models.go
@@ -139,6 +139,12 @@ type Transaction struct {
 	R                   *hexutil.Big             `json:"r"`
 	S                   *hexutil.Big             `json:"s"`
 	YParity             *hexutil.Uint64          `json:"yParity,omitempty"`
+
+	size uint64
+}
+
+func (tx *Transaction) Size() uint64 {
+	return tx.size
 }
 
 func NewTransactionResult(
@@ -191,6 +197,7 @@ func NewTransaction(
 		R:        (*hexutil.Big)(r),
 		S:        (*hexutil.Big)(s),
 		ChainID:  (*hexutil.Big)(networkID),
+		size:     tx.Size(),
 	}
 
 	if tx.Type() > types.LegacyTxType {

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -149,7 +149,7 @@ func (dc DirectCall) Size() uint64 {
 	if err != nil {
 		return 0
 	}
-	return uint64(len(encoded))
+	return rlp.ListSize(uint64(len(encoded)))
 }
 
 func (dc DirectCall) AccessList() gethTypes.AccessList {

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -168,7 +168,7 @@ func Test_DecodeDirectCall(t *testing.T) {
 	assert.Equal(t, uint64(23_300), decTx.Gas())
 	assert.Equal(t, big.NewInt(0), decTx.GasPrice())
 	assert.Equal(t, uint64(0), decTx.BlobGas())
-	assert.Equal(t, uint64(59), decTx.Size())
+	assert.Equal(t, uint64(61), decTx.Size())
 }
 
 func Test_UnmarshalTransaction(t *testing.T) {
@@ -275,7 +275,7 @@ func Test_UnmarshalTransaction(t *testing.T) {
 		assert.Equal(t, uint64(23_300), decTx.Gas())
 		assert.Equal(t, big.NewInt(0), decTx.GasPrice())
 		assert.Equal(t, uint64(0), decTx.BlobGas())
-		assert.Equal(t, uint64(59), decTx.Size())
+		assert.Equal(t, uint64(61), decTx.Size())
 	})
 
 	t.Run("with DirectCall hash calculation change", func(t *testing.T) {

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -21,7 +21,7 @@ it('get block', async () => {
     assert.lengthOf(block.logsBloom, 514)
     assert.isDefined(block.timestamp)
     assert.isTrue(block.timestamp >= 1714413860n)
-    assert.equal(block.size, 189n)
+    assert.equal(block.size, 3960n)
 
     let blockHash = await web3.eth.getBlock(block.hash)
     assert.deepEqual(block, blockHash)

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -21,6 +21,7 @@ it('get block', async () => {
     assert.lengthOf(block.logsBloom, 514)
     assert.isDefined(block.timestamp)
     assert.isTrue(block.timestamp >= 1714413860n)
+    assert.equal(block.size, 189n)
 
     let blockHash = await web3.eth.getBlock(block.hash)
     assert.deepEqual(block, blockHash)


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/375

## Description

This is needed for endpoints such as `eth_getBlockByNumber` & `eth_getBlockByHash`.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



- **New Features**
  - Enhanced block response now includes the size of the block and transactions, providing additional metadata.

- **Tests**
  - Added assertions to validate the new `size` property of blocks, increasing test coverage for block attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->