### PR TITLE
Revert "bug, hardcode version"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,5 +36,5 @@ jobs:
       - name: Docker Auth
         run: |-
           gcloud auth configure-docker ${{ vars.GAR_LOCATION }}-docker.pkg.dev
-          docker build -t ${{ env.DOCKER_IMAGE_URL }} --build-arg GATEWAY_VERSION="v0.25.0" --file Dockerfile .
+          docker build -t ${{ env.DOCKER_IMAGE_URL }} --build-arg GATEWAY_VERSION=$(git describe --tags --abbrev=0 2>/dev/null) --file Dockerfile .
           docker push ${{ env.DOCKER_IMAGE_URL }}


### PR DESCRIPTION
This reverts commit 80112d0eb8702e535ec533b6440d3c3f93130e3e.

## Description

The bug was actually coming from the Golang version in the Dockerfile: https://github.com/onflow/flow-evm-gateway/pull/386
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Implemented a dynamic versioning system for Docker image builds, ensuring the latest version tag is automatically used.

- **Chores**
	- Updated the build workflow to enhance flexibility and maintainability of the Docker build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->