### PR TITLE
Add the `TransactionsRoot` field on block response APIs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -889,17 +889,18 @@ func (b *BlockChainAPI) prepareBlockResponse(
 	}
 
 	blockResponse := &Block{
-		Hash:          h,
-		Number:        hexutil.Uint64(block.Height),
-		ParentHash:    block.ParentBlockHash,
-		ReceiptsRoot:  block.ReceiptRoot,
-		Transactions:  block.TransactionHashes,
-		Uncles:        []common.Hash{},
-		GasLimit:      hexutil.Uint64(blockGasLimit),
-		Nonce:         types.BlockNonce{0x1},
-		Timestamp:     hexutil.Uint64(block.Timestamp),
-		BaseFeePerGas: hexutil.Big(*big.NewInt(0)),
-		LogsBloom:     types.LogsBloom([]*types.Log{}),
+		Hash:             h,
+		Number:           hexutil.Uint64(block.Height),
+		ParentHash:       block.ParentBlockHash,
+		ReceiptsRoot:     block.ReceiptRoot,
+		TransactionsRoot: block.TransactionHashRoot,
+		Transactions:     block.TransactionHashes,
+		Uncles:           []common.Hash{},
+		GasLimit:         hexutil.Uint64(blockGasLimit),
+		Nonce:            types.BlockNonce{0x1},
+		Timestamp:        hexutil.Uint64(block.Timestamp),
+		BaseFeePerGas:    hexutil.Big(*big.NewInt(0)),
+		LogsBloom:        types.LogsBloom([]*types.Log{}),
 	}
 
 	// todo remove after previewnet, temp fix to mock some of the timestamps

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -21,6 +21,10 @@ it('get block', async () => {
     assert.lengthOf(block.logsBloom, 514)
     assert.isDefined(block.timestamp)
     assert.isTrue(block.timestamp >= 1714413860n)
+    assert.notEqual(
+        block.transactionsRoot,
+        '0x0000000000000000000000000000000000000000000000000000000000000000'
+    )
 
     let blockHash = await web3.eth.getBlock(block.hash)
     assert.deepEqual(block, blockHash)


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/389

## Description

This field has now a non-zero value, so we should return the correct value in the related block APIs.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced block response to include a TransactionsRoot field for improved data integrity and verification.
  
- **Bug Fixes**
	- Added a validation check in tests to ensure the transactionsRoot is not empty, confirming that blocks contain valid transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->