### PR TITLE
Update check for empty `RemoteAddr` in `rateLimit` function

### DIFF
--- a/api/ratelimiter.go
+++ b/api/ratelimiter.go
@@ -3,11 +3,11 @@ package api
 import (
 	"context"
 
-	"github.com/onflow/go-ethereum/rpc"
 	"github.com/rs/zerolog"
 	"github.com/sethvargo/go-limiter"
 
 	errs "github.com/onflow/flow-evm-gateway/api/errors"
+	"github.com/onflow/go-ethereum/rpc"
 )
 
 // rateLimit will limit requests with the provider limiter, in case the limit
@@ -20,7 +20,7 @@ func rateLimit(ctx context.Context, limiter limiter.Store, logger zerolog.Logger
 	// websocket requests.
 
 	remote := rpc.PeerInfoFromContext(ctx).RemoteAddr
-	if remote == "NA" {
+	if remote == "" {
 		return nil // if no client identifier disable limit
 	}
 


### PR DESCRIPTION
## Description

The regression occurred in https://github.com/onflow/flow-evm-gateway/commit/2eb7ada78de926eddb52f9753e7c6ce89db7b233.
Previously,

```go
remote := core.MetadataFromContext(ctx).Remote
```

would return `"NA"`, for an empty `Remote`.
See: https://github.com/onflow/go-ethereum/blob/master/signer/core/api.go#L196

But the new version:

```go
remote := rpc.PeerInfoFromContext(ctx).RemoteAddr
```

simply returns `""` for an empty `Remote`.

So we need to check:

```go
if remote == ""
```


______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced client identification for rate limiting using the HTTP origin.
  - Introduced structured error handling in rate limit tests to improve clarity and reliability.

- **Bug Fixes**
  - Improved handling of rate limit responses in tests by focusing on failed requests.

- **Chores**
  - Added an `Origin` HTTP header in test requests to comply with CORS policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->