### PR TITLE
Bugfix to avoid decoding empty blooms

### DIFF
--- a/storage/pebble/receipts.go
+++ b/storage/pebble/receipts.go
@@ -1,6 +1,7 @@
 package pebble
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -254,6 +255,12 @@ func (r *Receipts) BloomsForBlockRange(start, end *big.Int) ([]*models.BloomsHei
 		}
 
 		var bloomsHeight []*gethTypes.Bloom
+
+		// if empty skip it, workaround for empty blooms stored, todo investigate why we store empty blooms
+		if bytes.Equal(val, make([]byte, len(val))) {
+			continue
+		}
+
 		if err := rlp.DecodeBytes(val, &bloomsHeight); err != nil {
 			return nil, fmt.Errorf("failed to decode blooms: %w", err)
 		}


### PR DESCRIPTION
Don't decode empty blooms. For some reason empty blooms were indexed (possibly due to a past bug). This skips decoding to avoid internal error. This should be further investigated so it doesn't keep appearing, and we shouldn't index empty bloms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of empty bloom data in receipt processing, preventing potential issues related to storing empty blooms.
	- Enhanced method robustness to ensure it skips empty bloom values during processing.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->