### PR TITLE
Update default block parameter JSON-RPC APIs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -29,6 +29,8 @@ import (
 
 const maxFeeHistoryBlockCount = 1024
 
+var latestBlockNumberOrHash = rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+
 func SupportedAPIs(
 	blockChainAPI *BlockChainAPI,
 	streamAPI *StreamAPI,
@@ -534,8 +536,7 @@ func (b *BlockChainAPI) Call(
 
 	// Default to "latest" block tag
 	if blockNumberOrHash == nil {
-		latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
-		blockNumberOrHash = &latest
+		blockNumberOrHash = &latestBlockNumberOrHash
 	}
 
 	evmHeight, err := b.getBlockNumber(blockNumberOrHash)
@@ -706,8 +707,7 @@ func (b *BlockChainAPI) EstimateGas(
 	}
 
 	if blockNumberOrHash == nil {
-		latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
-		blockNumberOrHash = &latest
+		blockNumberOrHash = &latestBlockNumberOrHash
 	}
 
 	evmHeight, err := b.getBlockNumber(blockNumberOrHash)

--- a/api/api.go
+++ b/api/api.go
@@ -705,7 +705,17 @@ func (b *BlockChainAPI) EstimateGas(
 		from = *args.From
 	}
 
-	estimatedGas, err := b.evm.EstimateGas(ctx, tx, from)
+	if blockNumberOrHash == nil {
+		latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+		blockNumberOrHash = &latest
+	}
+
+	evmHeight, err := b.getBlockNumber(blockNumberOrHash)
+	if err != nil {
+		return handleError[hexutil.Uint64](err, l)
+	}
+
+	estimatedGas, err := b.evm.EstimateGas(ctx, tx, from, evmHeight)
 	if err != nil {
 		return handleError[hexutil.Uint64](err, l)
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -187,7 +187,7 @@ func (b *BlockChainAPI) SendRawTransaction(
 func (b *BlockChainAPI) GetBalance(
 	ctx context.Context,
 	address common.Address,
-	blockNumberOrHash *rpc.BlockNumberOrHash,
+	blockNumberOrHash rpc.BlockNumberOrHash,
 ) (*hexutil.Big, error) {
 	l := b.logger.With().
 		Str("endpoint", "getBalance").
@@ -198,7 +198,7 @@ func (b *BlockChainAPI) GetBalance(
 		return nil, err
 	}
 
-	evmHeight, err := b.getBlockNumber(blockNumberOrHash)
+	evmHeight, err := b.getBlockNumber(&blockNumberOrHash)
 	if err != nil {
 		return handleError[*hexutil.Big](err, l)
 	}
@@ -532,6 +532,12 @@ func (b *BlockChainAPI) Call(
 		return nil, err
 	}
 
+	// Default to "latest" block tag
+	if blockNumberOrHash == nil {
+		latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+		blockNumberOrHash = &latest
+	}
+
 	evmHeight, err := b.getBlockNumber(blockNumberOrHash)
 	if err != nil {
 		return handleError[hexutil.Bytes](err, l)
@@ -626,7 +632,7 @@ func (b *BlockChainAPI) GetLogs(
 func (b *BlockChainAPI) GetTransactionCount(
 	ctx context.Context,
 	address common.Address,
-	blockNumberOrHash *rpc.BlockNumberOrHash,
+	blockNumberOrHash rpc.BlockNumberOrHash,
 ) (*hexutil.Uint64, error) {
 	l := b.logger.With().
 		Str("endpoint", "getTransactionCount").
@@ -637,7 +643,7 @@ func (b *BlockChainAPI) GetTransactionCount(
 		return nil, err
 	}
 
-	evmHeight, err := b.getBlockNumber(blockNumberOrHash)
+	evmHeight, err := b.getBlockNumber(&blockNumberOrHash)
 	if err != nil {
 		return handleError[*hexutil.Uint64](err, l)
 	}
@@ -712,7 +718,7 @@ func (b *BlockChainAPI) EstimateGas(
 func (b *BlockChainAPI) GetCode(
 	ctx context.Context,
 	address common.Address,
-	blockNumberOrHash *rpc.BlockNumberOrHash,
+	blockNumberOrHash rpc.BlockNumberOrHash,
 ) (hexutil.Bytes, error) {
 	l := b.logger.With().
 		Str("endpoint", "getCode").
@@ -723,7 +729,7 @@ func (b *BlockChainAPI) GetCode(
 		return nil, err
 	}
 
-	evmHeight, err := b.getBlockNumber(blockNumberOrHash)
+	evmHeight, err := b.getBlockNumber(&blockNumberOrHash)
 	if err != nil {
 		return handleError[hexutil.Bytes](err, l)
 	}
@@ -824,7 +830,7 @@ func (b *BlockChainAPI) GetStorageAt(
 	ctx context.Context,
 	address common.Address,
 	storageSlot string,
-	blockNumberOrHash *rpc.BlockNumberOrHash,
+	blockNumberOrHash rpc.BlockNumberOrHash,
 ) (hexutil.Bytes, error) {
 	l := b.logger.With().
 		Str("endpoint", "getStorageAt").
@@ -840,7 +846,7 @@ func (b *BlockChainAPI) GetStorageAt(
 		return handleError[hexutil.Bytes](errors.Join(errs.ErrInvalid, err), l)
 	}
 
-	evmHeight, err := b.getBlockNumber(blockNumberOrHash)
+	evmHeight, err := b.getBlockNumber(&blockNumberOrHash)
 	if err != nil {
 		return handleError[hexutil.Bytes](err, l)
 	}

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -86,7 +86,7 @@ func (w *WalletAPI) SignTransaction(
 		nonce = uint64(*args.Nonce)
 	} else {
 		num := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
-		n, err := w.net.GetTransactionCount(ctx, from, &num)
+		n, err := w.net.GetTransactionCount(ctx, from, num)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/web3js/eth_deploy_contract_and_interact_test.js
+++ b/tests/web3js/eth_deploy_contract_and_interact_test.js
@@ -211,4 +211,28 @@ it('deploy contract and interact', async () => {
         )
     }
 
+    let gasEstimate = await web3.eth.estimateGas(
+        {
+            from: conf.eoa.address,
+            to: contractAddress,
+            data: deployed.contract.methods.sum(100, 200).encodeABI(),
+            gas: 1_000_000,
+            gasPrice: 0
+        },
+        '0x1'
+    )
+    assert.equal(gasEstimate, 23977n)
+
+    gasEstimate = await web3.eth.estimateGas(
+        {
+            from: conf.eoa.address,
+            to: contractAddress,
+            data: deployed.contract.methods.sum(100, 200).encodeABI(),
+            gas: 1_000_000,
+            gasPrice: 0
+        },
+        'latest'
+    )
+    assert.equal(gasEstimate, 27374n)
+
 })


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/398
Closes: https://github.com/onflow/flow-evm-gateway/issues/380

## Description

- Make the `rpc.BlockNumberOrHash` required, for the respective JSON-RPC APIs
- Update `eth_estimateGas` to accept a `rpc.BlockNumberOrHash` parameter 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced gas estimation functionality by incorporating specific EVM block height for more accurate calculations.
  
- **Bug Fixes**
	- Improved error handling for blockchain interactions by ensuring valid block numbers are utilized.

- **Tests**
	- Added tests for gas estimation when deploying and interacting with a smart contract, validating expected gas consumption.

- **Refactor**
	- Simplified parameter handling in the API methods for improved usability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->