### PR TITLE
Add special case in `eth_getBlockByNumber` to return genesis block on `earliest` block tag

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -405,6 +405,19 @@ func (b *BlockChainAPI) GetBlockByNumber(
 	}
 
 	block, err := b.blocks.GetByHeight(height)
+
+	// TEMP(m-Peter): Remove after PreviewNet
+	// This is a workaround to make available the Genesis Block.
+	if block == nil && blockNumber == rpc.EarliestBlockNumber {
+		block = models.GenesisBlock
+		apiBlock, err := b.prepareBlockResponse(ctx, block, fullTx)
+		if err != nil {
+			return handleError[*Block](err, l)
+		}
+
+		return apiBlock, nil
+	}
+
 	if err != nil {
 		return handleError[*Block](err, l)
 	}


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/371

## Description

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the blockchain API to return the Genesis Block when a requested block is not found, improving robustness in handling requests for the earliest blockchain data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->