### PR TITLE
Add evm_account_calls_total metrics

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -135,6 +135,7 @@ func Start(ctx context.Context, cfg *config.Config) error {
 		transactionsPublisher,
 		logsPublisher,
 		logger,
+		collector,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to start event ingestion: %w", err)
@@ -164,6 +165,7 @@ func startIngestion(
 	transactionsPublisher *models.Publisher,
 	logsPublisher *models.Publisher,
 	logger zerolog.Logger,
+	collector metrics.Collector,
 ) error {
 	logger.Info().Msg("starting up event ingestion")
 
@@ -236,6 +238,7 @@ func startIngestion(
 		blocksPublisher,
 		logsPublisher,
 		logger,
+		collector,
 	)
 	const retries = 15
 	restartableEventEngine := models.NewRestartableEngine(eventEngine, retries, logger)
@@ -307,6 +310,7 @@ func startServer(
 		logger,
 		blocks,
 		txPool,
+		collector,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create EVM requester: %w", err)

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -9,13 +9,15 @@ import (
 
 type Collector interface {
 	ApiErrorOccurred()
+	EvmAccountCalled(labels prometheus.Labels)
 	MeasureRequestDuration(start time.Time, labels prometheus.Labels)
 }
 
 type DefaultCollector struct {
 	// TODO: for now we cannot differentiate which api request failed number of times
-	apiErrorsCounter prometheus.Counter
-	requestDurations *prometheus.HistogramVec
+	apiErrorsCounter       prometheus.Counter
+	evmAccountCallCounters *prometheus.CounterVec
+	requestDurations       *prometheus.HistogramVec
 }
 
 func NewCollector(logger zerolog.Logger) Collector {
@@ -23,6 +25,11 @@ func NewCollector(logger zerolog.Logger) Collector {
 		Name: "api_errors_total",
 		Help: "Total number of errors returned by the endpoint resolvers",
 	})
+
+	evmAccountCallCounters := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "evm_account_calls_total",
+		Help: "Total number of calls to specific evm account",
+	}, []string{"address"})
 
 	// TODO: Think of adding 'status_code'
 	requestDurations := prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -32,14 +39,15 @@ func NewCollector(logger zerolog.Logger) Collector {
 	},
 		[]string{"method"})
 
-	if err := registerMetrics(logger, apiErrors, requestDurations); err != nil {
+	if err := registerMetrics(logger, apiErrors, evmAccountCallCounters, requestDurations); err != nil {
 		logger.Info().Msg("Using noop collector as metric register failed")
 		return &NoopCollector{}
 	}
 
 	return &DefaultCollector{
-		apiErrorsCounter: apiErrors,
-		requestDurations: requestDurations,
+		apiErrorsCounter:       apiErrors,
+		evmAccountCallCounters: evmAccountCallCounters,
+		requestDurations:       requestDurations,
 	}
 }
 
@@ -56,6 +64,10 @@ func registerMetrics(logger zerolog.Logger, metrics ...prometheus.Collector) err
 
 func (c *DefaultCollector) ApiErrorOccurred() {
 	c.apiErrorsCounter.Inc()
+}
+
+func (c *DefaultCollector) EvmAccountCalled(labels prometheus.Labels) {
+	c.evmAccountCallCounters.With(labels).Inc()
 }
 
 func (c *DefaultCollector) MeasureRequestDuration(start time.Time, labels prometheus.Labels) {

--- a/metrics/noop_collector.go
+++ b/metrics/noop_collector.go
@@ -8,5 +8,10 @@ import (
 
 type NoopCollector struct{}
 
+func NewNoopCollector() *NoopCollector {
+	return &NoopCollector{}
+}
+
 func (c *NoopCollector) ApiErrorOccurred()                                   {}
+func (c *NoopCollector) EvmAccountCalled(prometheus.Labels)                  {}
 func (c *NoopCollector) MeasureRequestDuration(time.Time, prometheus.Labels) {}

--- a/services/ingestion/engine.go
+++ b/services/ingestion/engine.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onflow/flow-go-sdk"
 	"github.com/rs/zerolog"
 
+	"github.com/onflow/flow-evm-gateway/metrics"
 	"github.com/onflow/flow-evm-gateway/models"
 	"github.com/onflow/flow-evm-gateway/storage"
 	"github.com/onflow/flow-evm-gateway/storage/pebble"
@@ -27,6 +28,7 @@ type Engine struct {
 	status          *models.EngineStatus
 	blocksPublisher *models.Publisher
 	logsPublisher   *models.Publisher
+	collector       metrics.Collector
 }
 
 func NewEventIngestionEngine(
@@ -39,6 +41,7 @@ func NewEventIngestionEngine(
 	blocksPublisher *models.Publisher,
 	logsPublisher *models.Publisher,
 	log zerolog.Logger,
+	collector metrics.Collector,
 ) *Engine {
 	log = log.With().Str("component", "ingestion").Logger()
 
@@ -53,6 +56,7 @@ func NewEventIngestionEngine(
 		status:          models.NewEngineStatus(),
 		blocksPublisher: blocksPublisher,
 		logsPublisher:   logsPublisher,
+		collector:       collector,
 	}
 }
 

--- a/services/ingestion/engine_test.go
+++ b/services/ingestion/engine_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onflow/flow-go/fvm/evm/events"
 	flowGo "github.com/onflow/flow-go/model/flow"
 
+	"github.com/onflow/flow-evm-gateway/metrics"
 	"github.com/onflow/flow-evm-gateway/services/ingestion/mocks"
 	"github.com/onflow/flow-evm-gateway/storage/pebble"
 
@@ -70,6 +71,7 @@ func TestSerialBlockIngestion(t *testing.T) {
 			models.NewPublisher(),
 			models.NewPublisher(),
 			zerolog.Nop(),
+			metrics.NewNoopCollector(),
 		)
 
 		done := make(chan struct{})
@@ -149,6 +151,7 @@ func TestSerialBlockIngestion(t *testing.T) {
 			models.NewPublisher(),
 			models.NewPublisher(),
 			zerolog.Nop(),
+			metrics.NewNoopCollector(),
 		)
 
 		waitErr := make(chan struct{})
@@ -264,6 +267,7 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 			models.NewPublisher(),
 			models.NewPublisher(),
 			zerolog.Nop(),
+			metrics.NewNoopCollector(),
 		)
 
 		done := make(chan struct{})
@@ -362,6 +366,7 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 			models.NewPublisher(),
 			models.NewPublisher(),
 			zerolog.Nop(),
+			metrics.NewNoopCollector(),
 		)
 
 		done := make(chan struct{})
@@ -456,6 +461,7 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 			models.NewPublisher(),
 			models.NewPublisher(),
 			zerolog.Nop(),
+			metrics.NewNoopCollector(),
 		)
 
 		done := make(chan struct{})


### PR DESCRIPTION
This covers "Metric for users EVM contract addresses which are being called". We can track how many times a specific (or all) account is called  