### PR TITLE
Ingestion index health metric

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -135,6 +135,7 @@ func Start(ctx context.Context, cfg *config.Config) error {
 		transactionsPublisher,
 		logsPublisher,
 		logger,
+		collector,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to start event ingestion: %w", err)
@@ -164,6 +165,7 @@ func startIngestion(
 	transactionsPublisher *models.Publisher,
 	logsPublisher *models.Publisher,
 	logger zerolog.Logger,
+	collector metrics.Collector,
 ) error {
 	logger.Info().Msg("starting up event ingestion")
 
@@ -236,6 +238,7 @@ func startIngestion(
 		blocksPublisher,
 		logsPublisher,
 		logger,
+		collector,
 	)
 	const retries = 15
 	restartableEventEngine := models.NewRestartableEngine(eventEngine, retries, logger)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -382,6 +382,10 @@ func startServer(
 		cfg,
 	)
 
+	// Start ingestion index health tracker
+	tracker := metrics.NewIngestionIndexHealthTracker(logger, collector, evm, cfg.IngestionIndexHealthMaxDifference, cfg.IngestionIndexHealthUpdateInterval)
+	tracker.Start(ctx)
+
 	if err := srv.EnableRPC(supportedAPIs); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/onflow/flow/protobuf/go/flow v0.4.5
 	github.com/onflow/go-ethereum v1.14.7
 	github.com/prometheus/client_golang v1.18.0
+	github.com/prometheus/client_model v0.5.0
 	github.com/rs/cors v1.8.0
 	github.com/rs/zerolog v1.31.0
 	github.com/samber/slog-zerolog v1.0.0
@@ -150,7 +151,6 @@ require (
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/psiemens/sconfig v0.1.0 // indirect

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -16,7 +16,7 @@ type Collector interface {
 type DefaultCollector struct {
 	// TODO: for now we cannot differentiate which api request failed number of times
 	apiErrorsCounter prometheus.Counter
-	evmBlockHeight   prometheus.Gauge
+	evmBlockHeight   prometheus.Counter
 	requestDurations *prometheus.HistogramVec
 }
 
@@ -26,7 +26,7 @@ func NewCollector(logger zerolog.Logger) Collector {
 		Help: "Total number of errors returned by the endpoint resolvers",
 	})
 
-	evmBlockHeight := prometheus.NewGauge(prometheus.GaugeOpts{
+	evmBlockHeight := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "evm_block_height",
 		Help: "Current EVM block height",
 	})

--- a/metrics/ingestion_index_health_tracker.go
+++ b/metrics/ingestion_index_health_tracker.go
@@ -1,0 +1,71 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-evm-gateway/services/requester"
+)
+
+type IngestionIndexHealthTracker struct {
+	collector           Collector
+	evm                 *requester.EVM
+	logger              zerolog.Logger
+	maxHeightDifference uint64
+	interval            time.Duration
+}
+
+func NewIngestionIndexHealthTracker(logger zerolog.Logger, collector Collector, evm *requester.EVM, maxHeightDiff uint64, interval time.Duration) *IngestionIndexHealthTracker {
+	return &IngestionIndexHealthTracker{
+		collector:           collector,
+		evm:                 evm,
+		logger:              logger,
+		maxHeightDifference: maxHeightDiff,
+		interval:            interval,
+	}
+}
+
+func (c *IngestionIndexHealthTracker) Start(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(c.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				c.logger.Info().Msg("shutting down block height collector")
+				return
+			case <-ticker.C:
+				err := c.updateIndexHealth(ctx)
+				if err != nil {
+					c.logger.Error().Err(err).Msg("error updating index health")
+				}
+			}
+		}
+	}()
+}
+
+func (c *IngestionIndexHealthTracker) updateIndexHealth(ctx context.Context) error {
+	indexedHeight, err := c.collector.EvmBlockIndex()
+	if err != nil {
+		c.logger.Error().Err(err).Msg("error getting indexed evm height")
+		return err
+	}
+
+	expectedHeight, err := c.evm.GetLatestEVMHeight(ctx)
+	if err != nil {
+		c.logger.Error().Err(err).Msg("error getting latest evm height from access node")
+		return err
+	}
+
+	healthy := true
+	diff := expectedHeight - indexedHeight
+	if diff > c.maxHeightDifference {
+		healthy = false
+	}
+
+	c.collector.IngestionIndexHealthUpdated(healthy)
+	return nil
+}

--- a/metrics/noop_collector.go
+++ b/metrics/noop_collector.go
@@ -14,4 +14,6 @@ func NewNoopCollector() *NoopCollector {
 
 func (c *NoopCollector) ApiErrorOccurred()                                   {}
 func (c *NoopCollector) EvmBlockIndexed()                                    {}
+func (c *NoopCollector) EvmBlockIndex() (uint64, error)                      { return 0, nil }
+func (c *NoopCollector) IngestionIndexHealthUpdated(bool)                    {}
 func (c *NoopCollector) MeasureRequestDuration(time.Time, prometheus.Labels) {}

--- a/metrics/noop_collector.go
+++ b/metrics/noop_collector.go
@@ -8,5 +8,10 @@ import (
 
 type NoopCollector struct{}
 
+func NewNoopCollector() *NoopCollector {
+	return &NoopCollector{}
+}
+
 func (c *NoopCollector) ApiErrorOccurred()                                   {}
+func (c *NoopCollector) EvmBlockIndexed()                                    {}
 func (c *NoopCollector) MeasureRequestDuration(time.Time, prometheus.Labels) {}

--- a/services/ingestion/engine.go
+++ b/services/ingestion/engine.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onflow/flow-go-sdk"
 	"github.com/rs/zerolog"
 
+	"github.com/onflow/flow-evm-gateway/metrics"
 	"github.com/onflow/flow-evm-gateway/models"
 	"github.com/onflow/flow-evm-gateway/storage"
 	"github.com/onflow/flow-evm-gateway/storage/pebble"
@@ -27,6 +28,7 @@ type Engine struct {
 	status          *models.EngineStatus
 	blocksPublisher *models.Publisher
 	logsPublisher   *models.Publisher
+	collector       metrics.Collector
 }
 
 func NewEventIngestionEngine(
@@ -39,6 +41,7 @@ func NewEventIngestionEngine(
 	blocksPublisher *models.Publisher,
 	logsPublisher *models.Publisher,
 	log zerolog.Logger,
+	collector metrics.Collector,
 ) *Engine {
 	log = log.With().Str("component", "ingestion").Logger()
 
@@ -53,6 +56,7 @@ func NewEventIngestionEngine(
 		status:          models.NewEngineStatus(),
 		blocksPublisher: blocksPublisher,
 		logsPublisher:   logsPublisher,
+		collector:       collector,
 	}
 }
 
@@ -151,6 +155,7 @@ func (e *Engine) processEvents(events *models.CadenceEvents) error {
 	if err != nil {
 		return fmt.Errorf("failed to index block %d event: %w", events.Block().Height, err)
 	}
+	e.collector.EvmBlockIndexed()
 
 	for i, tx := range events.Transactions() {
 		receipt := events.Receipts()[i]

--- a/services/ingestion/engine_test.go
+++ b/services/ingestion/engine_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onflow/flow-go/fvm/evm/events"
 	flowGo "github.com/onflow/flow-go/model/flow"
 
+	"github.com/onflow/flow-evm-gateway/metrics"
 	"github.com/onflow/flow-evm-gateway/services/ingestion/mocks"
 	"github.com/onflow/flow-evm-gateway/storage/pebble"
 
@@ -70,6 +71,7 @@ func TestSerialBlockIngestion(t *testing.T) {
 			models.NewPublisher(),
 			models.NewPublisher(),
 			zerolog.Nop(),
+			metrics.NewNoopCollector(),
 		)
 
 		done := make(chan struct{})
@@ -149,6 +151,7 @@ func TestSerialBlockIngestion(t *testing.T) {
 			models.NewPublisher(),
 			models.NewPublisher(),
 			zerolog.Nop(),
+			metrics.NewNoopCollector(),
 		)
 
 		waitErr := make(chan struct{})
@@ -264,6 +267,7 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 			models.NewPublisher(),
 			models.NewPublisher(),
 			zerolog.Nop(),
+			metrics.NewNoopCollector(),
 		)
 
 		done := make(chan struct{})
@@ -362,6 +366,7 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 			models.NewPublisher(),
 			models.NewPublisher(),
 			zerolog.Nop(),
+			metrics.NewNoopCollector(),
 		)
 
 		done := make(chan struct{})
@@ -456,6 +461,7 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 			models.NewPublisher(),
 			models.NewPublisher(),
 			zerolog.Nop(),
+			metrics.NewNoopCollector(),
 		)
 
 		done := make(chan struct{})

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -137,25 +137,27 @@ func servicesSetup(t *testing.T) (emulator.Emulator, func()) {
 
 	// default config
 	cfg := &config.Config{
-		DatabaseDir:                 t.TempDir(),
-		AccessNodeHost:              "localhost:3569", // emulator
-		RPCPort:                     8545,
-		RPCHost:                     "127.0.0.1",
-		FlowNetworkID:               "flow-emulator",
-		EVMNetworkID:                evmTypes.FlowEVMPreviewNetChainID,
-		Coinbase:                    common.HexToAddress(eoaTestAddress),
-		COAAddress:                  service.Address,
-		COAKey:                      service.PrivateKey,
-		CreateCOAResource:           false,
-		GasPrice:                    new(big.Int).SetUint64(150),
-		LogLevel:                    zerolog.DebugLevel,
-		LogWriter:                   testLogWriter(),
-		StreamTimeout:               time.Second * 30,
-		StreamLimit:                 10,
-		RateLimit:                   50,
-		WSEnabled:                   true,
-		HashCalculationHeightChange: 0,
-		PrometheusConfigFilePath:    "./metrics/prometheus.yml",
+		DatabaseDir:                        t.TempDir(),
+		AccessNodeHost:                     "localhost:3569", // emulator
+		RPCPort:                            8545,
+		RPCHost:                            "127.0.0.1",
+		FlowNetworkID:                      "flow-emulator",
+		EVMNetworkID:                       evmTypes.FlowEVMPreviewNetChainID,
+		Coinbase:                           common.HexToAddress(eoaTestAddress),
+		COAAddress:                         service.Address,
+		COAKey:                             service.PrivateKey,
+		CreateCOAResource:                  false,
+		GasPrice:                           new(big.Int).SetUint64(150),
+		LogLevel:                           zerolog.DebugLevel,
+		LogWriter:                          testLogWriter(),
+		StreamTimeout:                      time.Second * 30,
+		StreamLimit:                        10,
+		RateLimit:                          50,
+		WSEnabled:                          true,
+		HashCalculationHeightChange:        0,
+		PrometheusConfigFilePath:           "./metrics/prometheus.yml",
+		IngestionIndexHealthMaxDifference:  50,
+		IngestionIndexHealthUpdateInterval: time.Second * 30,
 	}
 
 	go func() {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -59,20 +59,22 @@ func Test_ConcurrentTransactionSubmission(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &config.Config{
-		DatabaseDir:              t.TempDir(),
-		AccessNodeHost:           grpcHost,
-		RPCPort:                  8545,
-		RPCHost:                  "127.0.0.1",
-		FlowNetworkID:            "flow-emulator",
-		EVMNetworkID:             types.FlowEVMPreviewNetChainID,
-		Coinbase:                 eoaTestAccount,
-		COAAddress:               *createdAddr,
-		COAKeys:                  keys,
-		CreateCOAResource:        true,
-		GasPrice:                 new(big.Int).SetUint64(0),
-		LogLevel:                 zerolog.DebugLevel,
-		LogWriter:                testLogWriter(),
-		PrometheusConfigFilePath: "./metrics/prometheus.yml",
+		DatabaseDir:                        t.TempDir(),
+		AccessNodeHost:                     grpcHost,
+		RPCPort:                            8545,
+		RPCHost:                            "127.0.0.1",
+		FlowNetworkID:                      "flow-emulator",
+		EVMNetworkID:                       types.FlowEVMPreviewNetChainID,
+		Coinbase:                           eoaTestAccount,
+		COAAddress:                         *createdAddr,
+		COAKeys:                            keys,
+		CreateCOAResource:                  true,
+		GasPrice:                           new(big.Int).SetUint64(0),
+		LogLevel:                           zerolog.DebugLevel,
+		LogWriter:                          testLogWriter(),
+		PrometheusConfigFilePath:           "./metrics/prometheus.yml",
+		IngestionIndexHealthMaxDifference:  50,
+		IngestionIndexHealthUpdateInterval: time.Second * 30,
 	}
 
 	// todo change this test to use ingestion and emulator directly so we can completely remove
@@ -196,20 +198,22 @@ func Test_CloudKMSConcurrentTransactionSubmission(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &config.Config{
-		DatabaseDir:              t.TempDir(),
-		AccessNodeHost:           grpcHost,
-		RPCPort:                  8545,
-		RPCHost:                  "127.0.0.1",
-		FlowNetworkID:            "flow-emulator",
-		EVMNetworkID:             types.FlowEVMPreviewNetChainID,
-		Coinbase:                 eoaTestAccount,
-		COAAddress:               *createdAddr,
-		COACloudKMSKeys:          kmsKeys,
-		CreateCOAResource:        true,
-		GasPrice:                 new(big.Int).SetUint64(0),
-		LogLevel:                 zerolog.DebugLevel,
-		LogWriter:                testLogWriter(),
-		PrometheusConfigFilePath: "./metrics/prometheus.yml",
+		DatabaseDir:                        t.TempDir(),
+		AccessNodeHost:                     grpcHost,
+		RPCPort:                            8545,
+		RPCHost:                            "127.0.0.1",
+		FlowNetworkID:                      "flow-emulator",
+		EVMNetworkID:                       types.FlowEVMPreviewNetChainID,
+		Coinbase:                           eoaTestAccount,
+		COAAddress:                         *createdAddr,
+		COACloudKMSKeys:                    kmsKeys,
+		CreateCOAResource:                  true,
+		GasPrice:                           new(big.Int).SetUint64(0),
+		LogLevel:                           zerolog.DebugLevel,
+		LogWriter:                          testLogWriter(),
+		PrometheusConfigFilePath:           "./metrics/prometheus.yml",
+		IngestionIndexHealthMaxDifference:  50,
+		IngestionIndexHealthUpdateInterval: time.Second * 30,
 	}
 
 	// todo change this test to use ingestion and emulator directly so we can completely remove


### PR DESCRIPTION
This covers "Ingestion index health is a boolean value that is being set to false if the latest indexed EVM height falls behind the latest EVM height by X".

This PR is based on top of https://github.com/onflow/flow-evm-gateway/pull/406

I'm pushing a straightforward variation to keep things simple. However, the fact that I need to add a getter to a collector makes it look odd. I'm not sure if there's a way to avoid this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced metrics collection for event ingestion, enhancing monitoring capabilities.
  - Added configurable parameters for ingestion index health to improve operational oversight.

- **Bug Fixes**
  - Addressed issues related to ingestion index health monitoring, ensuring accurate status reporting.

- **Documentation**
  - Updated configuration documentation to reflect new ingestion index health settings.

- **Tests**
  - Enhanced test configurations to include new fields for ingestion index health monitoring.

- **Chores**
  - Updated dependencies to streamline metrics collection and improve performance monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->