### PR TITLE
Initialize `TransactionHashes` field for `GenesisBlock`

### DIFF
--- a/models/block.go
+++ b/models/block.go
@@ -20,7 +20,10 @@ var (
 	EarliestBlockNumber  = big.NewInt(0)
 )
 
-var GenesisBlock = &Block{Block: types.GenesisBlock}
+var GenesisBlock = &Block{
+	Block:             types.GenesisBlock,
+	TransactionHashes: []gethCommon.Hash{},
+}
 
 func NewBlockFromBytes(data []byte) (*Block, error) {
 	var b *Block


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/371

## Description

This needs to be always initialized as the default value for `interface{}` is `null` (https://github.com/onflow/flow-evm-gateway/blob/main/api/models.go#L281).

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Genesis Block structure to include transaction hashes, improving how transaction data is stored and utilized.
  
- **Impact**
  - This change may influence the logic and flow of block handling, allowing for better transaction management at the genesis level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->