### PR TITLE
Index only mode

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -174,6 +174,10 @@ func (b *BlockChainAPI) SendRawTransaction(
 	ctx context.Context,
 	input hexutil.Bytes,
 ) (common.Hash, error) {
+	if b.config.IndexOnly {
+		return common.Hash{}, errs.ErrNotSupported
+	}
+
 	l := b.logger.With().
 		Str("endpoint", "sendRawTransaction").
 		Str("input", input.String()).

--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,8 @@ type Config struct {
 	HashCalculationHeightChange uint64
 	// PrometheusConfigFilePath is a path to a prometheus config file
 	PrometheusConfigFilePath string
+	// IndexOnly configures the gateway to not accept any transactions but only queries of the state
+	IndexOnly bool
 }
 
 func FromFlags() (*Config, error) {
@@ -158,6 +160,7 @@ func FromFlags() (*Config, error) {
 	// hash calculation change has been successfully deployed.
 	flag.Uint64Var(&cfg.HashCalculationHeightChange, "hash-calc-height-change", 0, "Cadence height at which the direct call hash calculation changed")
 	flag.StringVar(&cfg.PrometheusConfigFilePath, "prometheus-config-file-path", "./metrics/prometheus.yml", "Path to the prometheus config file")
+	flag.BoolVar(&cfg.IndexOnly, "index-only", false, "Run the gateway in index-only mode which only allows querying the state and indexing, but disallows sending transactions.")
 	flag.Parse()
 
 	if coinbase == "" {


### PR DESCRIPTION
Allow for gateway to be configured in index-only mode. This won't accept submitting transactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option `IndexOnly` allowing the gateway to operate in a mode that only accepts state queries, preventing transaction submissions.
	- Added a command-line flag `--index-only` for users to enable the index-only mode easily.

- **Bug Fixes**
	- Improved robustness with a guard clause in the transaction sending method, ensuring that unsupported configurations are clearly handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->