### PR TITLE
Special block tags not supported for some endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -259,7 +259,7 @@ func (b *BlockChainAPI) GetTransactionByBlockHashAndIndex(
 	index hexutil.Uint,
 ) (*Transaction, error) {
 	l := b.logger.With().
-		Str("endpoint", "getTransactionByHashAndIndex").
+		Str("endpoint", "getTransactionByBlockHashAndIndex").
 		Str("hash", blockHash.String()).
 		Str("index", index.String()).
 		Logger()

--- a/api/api.go
+++ b/api/api.go
@@ -287,7 +287,8 @@ func (b *BlockChainAPI) GetTransactionByBlockHashAndIndex(
 	return tx, nil
 }
 
-// GetTransactionByBlockNumberAndIndex returns the transaction for the given block number and index.
+// GetTransactionByBlockNumberAndIndex returns the transaction
+// for the given block number and index.
 func (b *BlockChainAPI) GetTransactionByBlockNumberAndIndex(
 	ctx context.Context,
 	blockNumber rpc.BlockNumber,
@@ -301,6 +302,14 @@ func (b *BlockChainAPI) GetTransactionByBlockNumberAndIndex(
 
 	if err := rateLimit(ctx, b.limiter, l); err != nil {
 		return nil, err
+	}
+
+	if blockNumber < rpc.EarliestBlockNumber {
+		latestBlockNumber, err := b.blocks.LatestEVMHeight()
+		if err != nil {
+			return handleError[*Transaction](err, l, b.collector)
+		}
+		blockNumber = rpc.BlockNumber(latestBlockNumber)
 	}
 
 	block, err := b.blocks.GetByHeight(uint64(blockNumber))
@@ -483,7 +492,8 @@ func (b *BlockChainAPI) GetBlockReceipts(
 	return receipts, nil
 }
 
-// GetBlockTransactionCountByHash returns the number of transactions in the block with the given hash.
+// GetBlockTransactionCountByHash returns the number of transactions
+// in the block with the given hash.
 func (b *BlockChainAPI) GetBlockTransactionCountByHash(
 	ctx context.Context,
 	blockHash common.Hash,
@@ -506,7 +516,8 @@ func (b *BlockChainAPI) GetBlockTransactionCountByHash(
 	return &count, nil
 }
 
-// GetBlockTransactionCountByNumber returns the number of transactions in the block with the given block number.
+// GetBlockTransactionCountByNumber returns the number of transactions
+// in the block with the given block number.
 func (b *BlockChainAPI) GetBlockTransactionCountByNumber(
 	ctx context.Context,
 	blockNumber rpc.BlockNumber,
@@ -521,9 +532,11 @@ func (b *BlockChainAPI) GetBlockTransactionCountByNumber(
 	}
 
 	if blockNumber < rpc.EarliestBlockNumber {
-		// todo handle block number for negative special values in all APIs
-		b.collector.ApiErrorOccurred()
-		return nil, errs.ErrNotSupported
+		latestBlockNumber, err := b.blocks.LatestEVMHeight()
+		if err != nil {
+			return handleError[*hexutil.Uint](err, l, b.collector)
+		}
+		blockNumber = rpc.BlockNumber(latestBlockNumber)
 	}
 
 	block, err := b.blocks.GetByHeight(uint64(blockNumber))

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -52,6 +52,57 @@ it('get block', async () => {
     assert.isNull(no)
 })
 
+it('should get block transaction count', async () => {
+    // call endpoint with block number
+    let txCount = await web3.eth.getBlockTransactionCount(conf.startBlockHeight)
+    assert.equal(txCount, 3n)
+
+    // call endpoint with block hash
+    let block = await web3.eth.getBlock(conf.startBlockHeight)
+    txCount = await web3.eth.getBlockTransactionCount(block.hash)
+    assert.equal(txCount, 3n)
+
+    // call endpoint with 'earliest'
+    txCount = await web3.eth.getBlockTransactionCount('earliest')
+    assert.equal(txCount, 0n)
+
+    // call endpoint with 'latest'
+    txCount = await web3.eth.getBlockTransactionCount('latest')
+    assert.equal(txCount, 3n)
+})
+
+it('should get transactions from block', async () => {
+    // call endpoint with block number
+    for (const txIndex of [0, 1, 2]) {
+        let tx = await web3.eth.getTransactionFromBlock(conf.startBlockHeight, txIndex)
+        assert.isNotNull(tx)
+        assert.equal(tx.blockNumber, conf.startBlockHeight)
+        assert.equal(tx.transactionIndex, txIndex)
+    }
+
+    // call endpoint with block hash
+    let block = await web3.eth.getBlock(conf.startBlockHeight)
+    for (const txIndex of [0, 1, 2]) {
+        let tx = await web3.eth.getTransactionFromBlock(block.hash, txIndex)
+        assert.isNotNull(tx)
+        assert.equal(tx.blockHash, block.hash)
+        assert.equal(tx.transactionIndex, txIndex)
+    }
+
+    // call endpoint with 'earliest'
+    let tx = await web3.eth.getTransactionFromBlock('earliest', 0)
+    assert.isNull(tx)
+
+    // call endpoint with 'latest'
+    for (const txIndex of [0, 1, 2]) {
+        let tx = await web3.eth.getTransactionFromBlock('latest', txIndex)
+        assert.isNotNull(tx)
+        assert.equal(tx.blockNumber, conf.startBlockHeight)
+        assert.equal(tx.blockHash, block.hash)
+        assert.equal(tx.transactionIndex, txIndex)
+    }
+})
+
 it('get earliest/genesis block', async () => {
     let block = await web3.eth.getBlock('earliest')
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/419
Closes: https://github.com/onflow/flow-evm-gateway/issues/418

## Description

The special block tags (`earliest`, `latest` etc) were not supported for these endpoints:
- `eth_getTransactionByBlockNumberAndIndex`
- `eth_getBlockTransactionCountByNumber`

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced error handling for retrieving transactions and block counts, ensuring robustness against invalid block numbers.
  - Improved logic to automatically retrieve the latest block number when provided with outdated or negative values.

- **Bug Fixes**
  - Resolved issues related to the handling of edge cases for block numbers, improving overall API reliability.

- **Tests**
  - Added new test cases to validate transaction count retrieval and transactions from blocks, enhancing test coverage for the Ethereum Web3 API functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->