### PR TITLE
API panic handler metric

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -251,22 +251,23 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Body.Close()
 	}
 
+	// additional response handling
+	logW := &responseHandler{
+		ResponseWriter: w,
+		log:            h.logger,
+		metrics:        h.collector,
+	}
+
 	ws := h.wsHandler
 	if ws != nil && isWebSocket(r) {
-		ws.ServeHTTP(w, r)
+		ws.ServeHTTP(logW, r)
 		return
 	}
 
-	// enable logging responses
-	logW := &loggingResponseWriter{
-		ResponseWriter: w,
-		logger:         h.logger,
-	}
-
-	rpc := recoverHandler(h.logger, h.collector, h.httpHandler)
-	if rpc != nil {
+	handler := h.httpHandler
+	if handler != nil {
 		if checkPath(r, "") {
-			rpc.ServeHTTP(logW, r)
+			handler.ServeHTTP(logW, r)
 			return
 		}
 	}
@@ -394,61 +395,74 @@ func corsHandler(srv http.Handler, allowedOrigins []string) http.Handler {
 	return c.Handler(srv)
 }
 
-// recoverHandler adds a wrapper to handle panics
-func recoverHandler(logger zerolog.Logger, collector metrics.Collector, h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer func() {
-			r := recover()
-			if r != nil {
-				var err error
-				switch t := r.(type) {
-				case string:
-					err = errors.New(t)
-				case error:
-					err = t
-				}
+var _ http.ResponseWriter = &responseHandler{}
 
-				logger.Error().Err(err).Msg("panic in the http server")
-				collector.ServerPanicked(err)
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-		}()
-		h.ServeHTTP(w, r)
-	})
-}
-
-var _ http.ResponseWriter = &loggingResponseWriter{}
-
-type loggingResponseWriter struct {
+// responseHandler handles server responses.
+// Since we reuse go-ethereum server implementation we don't have access to handler logic,
+// so we rely on parsing responses and triggering actions to add our logic.
+// todo we should replace go-ethereum server implementation with our own so we have more control
+type responseHandler struct {
 	http.ResponseWriter
-	logger zerolog.Logger
+	log     zerolog.Logger
+	metrics metrics.Collector
 }
 
-func (w *loggingResponseWriter) Write(data []byte) (int, error) {
-	body := make(map[string]string)
-	_ = json.Unmarshal(data, &body)
-	delete(body, "jsonrpc")
+const errCodePanic = -32603
 
-	l := w.logger.Debug()
+type jsonError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
 
-	err := body["error"]
-	// only set error level if error is present in response
-	if err != "" {
-		// don't error log known handled errors
-		if !errorIs(err, errs.ErrRateLimit) &&
-			!errorIs(err, errs.ErrInvalid) &&
-			!errorIs(err, errs.ErrFailedTransaction) &&
-			!errorIs(err, errs.ErrNotSupported) {
-			l = w.logger.Error()
+type jsonMessage struct {
+	Version string          `json:"jsonrpc,omitempty"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Error   *jsonError      `json:"error,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+}
+
+func (w *responseHandler) Write(data []byte) (int, error) {
+	var message *jsonMessage
+	err := json.Unmarshal(data, &message)
+	// if we couldn't parse response just return it as fallback
+	if err != nil {
+		return w.ResponseWriter.Write(data)
+	}
+
+	l := w.log.Debug()
+
+	// handle possible error
+	if message.Error != nil {
+		errMsg := message.Error.Message
+		switch message.Error.Code {
+		case errCodePanic:
+			w.metrics.ServerPanicked(errMsg)
+		default:
+			if errMsg == "" {
+				break
+			}
+
+			// don't error log known handled errors
+			if !errorIs(errMsg, errs.ErrRateLimit) &&
+				!errorIs(errMsg, errs.ErrInvalid) &&
+				!errorIs(errMsg, errs.ErrFailedTransaction) &&
+				!errorIs(errMsg, errs.ErrNotSupported) {
+				// set logging level to error
+				l = w.log.Error()
+			}
 		}
 	}
 
-	l.Fields(body).Msg("API response")
+	// log all responses
+	l.Fields(message.Result).Msg("API response")
 
 	return w.ResponseWriter.Write(data)
 }
 
-func (w *loggingResponseWriter) WriteHeader(statusCode int) {
+func (w *responseHandler) WriteHeader(statusCode int) {
 	w.ResponseWriter.WriteHeader(statusCode)
 }
 

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -11,7 +11,7 @@ import (
 type Collector interface {
 	ApiErrorOccurred()
 	TraceDownloadFailed()
-	ServerPanicked(err error)
+	ServerPanicked(reason string)
 	EVMHeightIndexed(height uint64)
 	EVMAccountInteraction(address string)
 	MeasureRequestDuration(start time.Time, method string)
@@ -43,7 +43,7 @@ func NewCollector(logger zerolog.Logger) Collector {
 	serverPanicsCounters := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prefixedName("api_server_panics_total"),
 		Help: "Total number of panics in the API server",
-	}, []string{"error"})
+	}, []string{"reason"})
 
 	evmBlockHeight := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: prefixedName("evm_block_height"),
@@ -104,8 +104,8 @@ func (c *DefaultCollector) TraceDownloadFailed() {
 	c.traceDownloadErrorCounter.Inc()
 }
 
-func (c *DefaultCollector) ServerPanicked(err error) {
-	c.serverPanicsCounters.With(prometheus.Labels{"error": err.Error()}).Inc()
+func (c *DefaultCollector) ServerPanicked(reason string) {
+	c.serverPanicsCounters.With(prometheus.Labels{"reason": reason}).Inc()
 }
 
 func (c *DefaultCollector) EVMHeightIndexed(height uint64) {

--- a/metrics/nop.go
+++ b/metrics/nop.go
@@ -12,7 +12,7 @@ var NopCollector = &nopCollector{}
 
 func (c *nopCollector) ApiErrorOccurred()                        {}
 func (c *nopCollector) TraceDownloadFailed()                     {}
-func (c *nopCollector) ServerPanicked(error)                     {}
+func (c *nopCollector) ServerPanicked(string)                    {}
 func (c *nopCollector) EVMHeightIndexed(uint64)                  {}
 func (c *nopCollector) EVMAccountInteraction(string)             {}
 func (c *nopCollector) MeasureRequestDuration(time.Time, string) {}

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -155,7 +155,7 @@ func servicesSetup(t *testing.T) (emulator.Emulator, func()) {
 		RateLimit:                   50,
 		WSEnabled:                   true,
 		HashCalculationHeightChange: 0,
-		PrometheusConfigFilePath:    "./metrics/prometheus.yml",
+		MetricsPort:                 8080,
 	}
 
 	go func() {


### PR DESCRIPTION
Closes: #384 

## Description
This PR implements reporting panics as well as improves the response handler. Unfortunatelly until we implement our own server this is the best approach we can take at handling panics as they are recovered inside the go-ethereum server implementation.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 