### PR TITLE
Add functionality for resetting the DB at a given `EVM` height

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -48,7 +48,7 @@ func Start(ctx context.Context, cfg *config.Config) error {
 	// this should only be used locally or for testing
 	if cfg.ForceStartCadenceHeight != 0 {
 		logger.Warn().Uint64("height", cfg.ForceStartCadenceHeight).Msg("force setting starting Cadence height!!!")
-		if err := blocks.SetLatestCadenceHeight(cfg.ForceStartCadenceHeight, nil); err != nil {
+		if err := store.ResetAtHeight(cfg.ForceStartCadenceHeight); err != nil {
 			return err
 		}
 	}

--- a/storage/pebble/blocks.go
+++ b/storage/pebble/blocks.go
@@ -68,6 +68,11 @@ func (b *Blocks) Store(
 		return fmt.Errorf("failed to store evm to cadence height: %w", err)
 	}
 
+	// set mapping of cadence block height to evm height
+	if err := b.store.set(cadenceHeightToEVMHeightKey, cadenceHeightBytes, evmHeightBytes, batch); err != nil {
+		return fmt.Errorf("failed to store evm to cadence height: %w", err)
+	}
+
 	// set mapping of evm height to cadence block id
 	if err := b.store.set(evmHeightToCadenceIDKey, evmHeightBytes, cadenceID.Bytes(), batch); err != nil {
 		return fmt.Errorf("failed to store evm to cadence id: %w", err)

--- a/storage/pebble/keys.go
+++ b/storage/pebble/keys.go
@@ -8,6 +8,7 @@ const (
 	blockIDToHeightKey          = byte(2)
 	evmHeightToCadenceHeightKey = byte(3)
 	evmHeightToCadenceIDKey     = byte(4)
+	cadenceHeightToEVMHeightKey = byte(5)
 
 	// transaction keys
 	txIDKey = byte(10)


### PR DESCRIPTION
Work towards: https://github.com/onflow/flow-evm-gateway/issues/400

## Description

This is used in combination with the `--force-start-height` flag.
When that flag is set, all DB entries starting at the given height, until the latest indexed height, will be deleted.
This will make sure that re-indexing from that height, will not have any unwanted side-effects in the DB.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 