### PR TITLE
Fix error logging

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -470,9 +470,12 @@ func (w *responseHandler) Write(data []byte) (int, error) {
 		}
 	}
 
-	// log all responses
-	r, _ := message.Result.MarshalJSON()
-	log.Str("result", string(r)).Msg("API response")
+	// log all response results of successful requests,
+	// as errors are logged with error log level.
+	if message.Error == nil {
+		r, _ := message.Result.MarshalJSON()
+		log.Str("result", string(r)).Msg("API response")
+	}
 
 	return w.ResponseWriter.Write(data)
 }

--- a/api/server.go
+++ b/api/server.go
@@ -62,9 +62,16 @@ const (
 	batchResponseMaxSize = 5 * 1000 * 1000 // 5 MB
 )
 
-func NewHTTPServer(logger zerolog.Logger, collector metrics.Collector, cfg *config.Config) *httpServer {
-	zeroSlog := slogzerolog.Option{Logger: &logger}.NewZerologHandler()
-	gethLog.SetDefault(gethLog.NewLogger(slog.New(zeroSlog).Handler()))
+func NewHTTPServer(
+	logger zerolog.Logger,
+	collector metrics.Collector,
+	cfg *config.Config,
+) *httpServer {
+	zeroSlog := slogzerolog.Option{
+		Logger: &logger,
+		Level:  slog.LevelError,
+	}.NewZerologHandler()
+	gethLog.SetDefault(gethLog.NewLogger(zeroSlog))
 
 	return &httpServer{
 		logger:    logger,

--- a/api/server.go
+++ b/api/server.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	gethVM "github.com/onflow/go-ethereum/core/vm"
 	gethLog "github.com/onflow/go-ethereum/log"
 	"github.com/onflow/go-ethereum/rpc"
 	"github.com/rs/cors"
@@ -463,9 +464,10 @@ func (w *responseHandler) Write(data []byte) (int, error) {
 			if !errorIs(errMsg, errs.ErrRateLimit) &&
 				!errorIs(errMsg, errs.ErrInvalid) &&
 				!errorIs(errMsg, errs.ErrFailedTransaction) &&
-				!errorIs(errMsg, errs.ErrNotSupported) {
-				// set logging level to error
-				log = l.Error().Err(errors.New(errMsg))
+				!errorIs(errMsg, errs.ErrNotSupported) &&
+				!errorIs(errMsg, gethVM.ErrExecutionReverted) {
+				// log the error
+				l.Error().Err(errors.New(errMsg)).Msg("API response")
 			}
 		}
 	}


### PR DESCRIPTION
## Description

The way we previously set-up the geth log, for catching method handler crashes, resulted in logs with `warn` logging level as well, as can be seen below:
```bash
3:44PM ERR RPC method eth_feeHistory crashed: runtime error: index out of range [0] with length 0
goroutine 148 [running]:
github.com/onflow/go-ethereum/rpc.(*callback).call.func1()
...
 component=API
3:44PM WRN Served eth_feeHistory component=API conn=[::1]:58018 duration=0.34816 err="method handler crashed" reqid=9
3:44PM DBG API response component=API method= params=null result=null
```
It's the lines that have `WRN` level, and the `reqid` field.

We also avoid logging debug lines for API responses which have errored out, hence they do not have a result anyway:
```bash
3:44PM DBG API response component=API method= params=null result=null
```

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging functionality to include error level specification for better log clarity.
	- Improved response logging to only capture successful API responses, reducing log noise.

- **Bug Fixes**
	- Refined control flow to ensure logging captures meaningful data.

- **Refactor**
	- Code formatting changes for improved readability in function parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->