### PR TITLE
Fix calculation of `gasUsed` field returned on block endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -972,7 +972,7 @@ func (b *BlockChainAPI) prepareBlockResponse(
 			if err != nil {
 				return nil, err
 			}
-			totalGasUsed += tx.Gas
+			totalGasUsed += hexutil.Uint64(txReceipt.GasUsed)
 			logs = append(logs, txReceipt.Logs...)
 			blockSize += tx.Size()
 		}

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -37,7 +37,8 @@ it('get block', async () => {
     assert.equal(txCount, 3n)
     assert.equal(uncleCount, 0n)
 
-    // get block transactions
+    let gasUsed = 0n
+    // get block transactions & receipts
     for (const txIndex of [0, 1, 2]) {
         let tx = await web3.eth.getTransactionFromBlock(conf.startBlockHeight, txIndex)
         assert.isNotNull(tx)
@@ -45,7 +46,18 @@ it('get block', async () => {
         assert.equal(tx.blockHash, block.hash)
         assert.isString(tx.hash)
         assert.equal(tx.transactionIndex, txIndex)
+
+        let txReceipt = await web3.eth.getTransactionReceipt(tx.hash)
+        assert.isNotNull(txReceipt)
+        assert.equal(txReceipt.blockNumber, block.number)
+        assert.equal(txReceipt.blockHash, block.hash)
+        assert.isString(txReceipt.transactionHash)
+        assert.equal(txReceipt.transactionIndex, txIndex)
+
+        gasUsed += txReceipt.gasUsed
     }
+
+    assert.equal(block.gasUsed, gasUsed)
 
     // not existing transaction
     let no = await web3.eth.getTransactionFromBlock(conf.startBlockHeight, 5)


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/443

## Description

When calculating the block's `gasUsed`, we mistakenly used the `gas` limit set by the transaction author, and not the `gasUsed` from the transaction's receipt.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced gas calculation by utilizing transaction receipts for improved accuracy in block preparation.
  - Expanded testing framework to validate both transactions and their receipts, ensuring data integrity and robustness.

- **Bug Fixes**
  - Improved accuracy in total gas used calculations during block preparation, potentially resolving discrepancies in gas reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->