### PR TITLE
Bugfix log range filter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ The binary can then be run using the correct flags (see the table below or the e
 # Running
 Operating an EVM Gateway is straightforward. It can either be deployed locally alongside the Flow emulator or configured to connect with any active Flow networks supporting EVM. Given that the EVM Gateway depends solely on [Access Node APIs](https://developers.flow.com/networks/node-ops/access-onchain-data/access-nodes/accessing-data/access-api), it is compatible with any networks offering this API access.
 
-**Example Configuration for Previewnet**
+**Example Configuration for Testnet**
 ```
 ./evm-gateway
---access-node-grpc-host https://previewnet.evm.nodes.onflow.org \
---flow-network-id flow-previewnet \
+--access-node-grpc-host https://testnet.evm.nodes.onflow.org \
+--flow-network-id flow-testnet \
 --coinbase {EVM-account} \
 --coa-address {funded Flow account address} \
 --coa-key-file {file containing private keys for coa-address, KMS should be used on live networks} \
@@ -122,8 +122,8 @@ The application can be configured using the following flags at runtime:
 | `ws-enabled`                 | `false`                         | Enable websocket connections                                                                                                                                         |
 | `access-node-grpc-host`      | `localhost:3569`                | Host to the flow access node gRPC API                                                                                                                                |
 | `access-node-spork-hosts`    | `""`                            | Previous spork AN hosts, defined as a comma-separated list (e.g. `"host-1.com,host2.com"`)                                                                             |
-| `evm-network-id`             | `previewnet`                    | EVM network ID (options: `previewnet`, `testnet`, `mainnet`)                                                                                                         |
-| `flow-network-id`            | `flow-emulator`                 | Flow network ID (options: `flow-emulator`, `flow-previewnet`, `flow-testnet`)                                                                                       |
+| `evm-network-id`             | `testnet   `                    | EVM network ID (options: `testnet`, `mainnet`)                                                                                                         |
+| `flow-network-id`            | `flow-emulator`                 | Flow network ID (options: `flow-emulator`, `flow-testnet`, `flow-mainnet`)                                                                                       |
 | `coinbase`                   | `""`                            | Coinbase address to use for fee collection                                                                                                                           |
 | `init-cadence-height`        | `0`                             | Cadence block height to start indexing; avoid using on a new network                                                                                                 |
 | `gas-price`                  | `1`                             | Static gas price for EVM transactions                                                                                                                                |

--- a/api/api.go
+++ b/api/api.go
@@ -649,7 +649,7 @@ func (b *BlockChainAPI) GetLogs(
 		to = latest
 	}
 
-	f, err := logs.NewRangeFilter(*from, *to, filter, b.receipts)
+	f, err := logs.NewRangeFilter(from.Uint64(), to.Uint64(), filter, b.receipts)
 	if err != nil {
 		return handleError[[]*types.Log](err, l, b.collector)
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -659,6 +659,11 @@ func (b *BlockChainAPI) GetLogs(
 		return handleError[[]*types.Log](err, l, b.collector)
 	}
 
+	// makes sure the response is correctly serialized
+	if res == nil {
+		return []*types.Log{}, nil
+	}
+
 	return res, nil
 }
 

--- a/models/receipt.go
+++ b/models/receipt.go
@@ -15,11 +15,10 @@ import (
 // geth node has the data locally, but we don't in evm gateway, so we can not reproduce those values
 // and we need to store them
 type StorageReceipt struct {
-	Type              uint8  `json:"type,omitempty"`
-	PostState         []byte `json:"root"`
-	Status            uint64 `json:"status"`
-	CumulativeGasUsed uint64 `json:"cumulativeGasUsed"`
-	// todo we could skip bloom to optimize storage and dynamically recalculate it
+	Type              uint8            `json:"type,omitempty"`
+	PostState         []byte           `json:"root"`
+	Status            uint64           `json:"status"`
+	CumulativeGasUsed uint64           `json:"cumulativeGasUsed"`
 	Bloom             gethTypes.Bloom  `json:"logsBloom"`
 	Logs              []*gethTypes.Log `json:"logs"`
 	TxHash            common.Hash      `json:"transactionHash"`

--- a/models/receipt.go
+++ b/models/receipt.go
@@ -133,5 +133,5 @@ func MarshalReceipt(
 
 type BloomsHeight struct {
 	Blooms []*gethTypes.Bloom
-	Height *big.Int
+	Height uint64
 }

--- a/services/logs/filter.go
+++ b/services/logs/filter.go
@@ -91,10 +91,12 @@ func (r *RangeFilter) Match() ([]*gethTypes.Log, error) {
 	// if bloom matches we fetch only that height later and do exact match
 	for _, bloomHeight := range bloomsHeight {
 		for _, bloom := range bloomHeight.Blooms {
-			if !bloomMatch(*bloom, r.criteria) {
-				continue
+			if bloomMatch(*bloom, r.criteria) {
+				bloomHeightMatches = append(bloomHeightMatches, bloomHeight.Height)
+				// if there's a match we add the height and skip to next height
+				// even if there would be multiple matches for height we just want to have unique heights
+				break
 			}
-			bloomHeightMatches = append(bloomHeightMatches, bloomHeight.Height)
 		}
 	}
 

--- a/services/logs/filter_test.go
+++ b/services/logs/filter_test.go
@@ -321,7 +321,7 @@ func TestRangeFilter(t *testing.T) {
 		criteria: FilterCriteria{
 			Addresses: []common.Address{common.HexToAddress("0x123")},
 		},
-		expectLogs: []*gethTypes.Log{},
+		expectLogs: nil,
 	}, {
 		desc:  "single address, non-existing range no match",
 		start: 5,
@@ -329,7 +329,7 @@ func TestRangeFilter(t *testing.T) {
 		criteria: FilterCriteria{
 			Addresses: []common.Address{logs[0][0].Address},
 		},
-		expectLogs: []*gethTypes.Log{},
+		expectLogs: nil,
 	}}
 
 	for _, tt := range tests {

--- a/services/logs/filter_test.go
+++ b/services/logs/filter_test.go
@@ -307,6 +307,15 @@ func TestRangeFilter(t *testing.T) {
 		},
 		expectLogs: []*gethTypes.Log{logs[0][0], logs[3][1]},
 	}, {
+		desc:  "single topic, single address, subset of blocks match single log",
+		start: 2,
+		end:   4,
+		criteria: FilterCriteria{
+			Addresses: []common.Address{logs[0][0].Address},
+			Topics:    [][]common.Hash{logs[0][0].Topics[:1]},
+		},
+		expectLogs: []*gethTypes.Log{logs[3][1]},
+	}, {
 		desc:  "single address, all blocks match multiple logs",
 		start: 0,
 		end:   4,

--- a/services/logs/filter_test.go
+++ b/services/logs/filter_test.go
@@ -119,10 +119,10 @@ func receiptStorage() storage.ReceiptIndexer {
 	receiptStorage := &mocks.ReceiptIndexer{}
 	receiptStorage.
 		On("GetByBlockHeight", mock.AnythingOfType("uint64")).
-		Return(func(height *big.Int) ([]*models.StorageReceipt, error) {
+		Return(func(height uint64) ([]*models.StorageReceipt, error) {
 			rcps := make([]*models.StorageReceipt, 0)
 			for _, r := range receipts {
-				if r.BlockNumber.Cmp(height) == 0 {
+				if r.BlockNumber.Uint64() == height {
 					rcps = append(rcps, r)
 				}
 			}
@@ -136,12 +136,12 @@ func receiptStorage() storage.ReceiptIndexer {
 
 	receiptStorage.
 		On("BloomsForBlockRange", mock.AnythingOfType("uint64"), mock.AnythingOfType("uint64")).
-		Return(func(start, end *big.Int) ([]*models.BloomsHeight, error) {
+		Return(func(start, end uint64) ([]*models.BloomsHeight, error) {
 			blooms := make([]*gethTypes.Bloom, 0)
 			bloomsHeight := make([]*models.BloomsHeight, 0)
 
 			for _, r := range receipts {
-				if r.BlockNumber.Cmp(start) >= 0 && r.BlockNumber.Cmp(end) <= 0 {
+				if r.BlockNumber.Uint64() >= start && r.BlockNumber.Uint64() <= end {
 					blooms = append(blooms, &r.Bloom)
 					bloomsHeight = append(bloomsHeight, &models.BloomsHeight{
 						Blooms: blooms,

--- a/storage/index.go
+++ b/storage/index.go
@@ -45,20 +45,20 @@ type BlockIndexer interface {
 
 	// SetLatestCadenceHeight sets the latest Cadence height.
 	// Batch is required to batch multiple indexer operations, skipped if nil.
-	SetLatestCadenceHeight(height uint64, batch *pebble.Batch) error
+	SetLatestCadenceHeight(cadenceHeight uint64, batch *pebble.Batch) error
 
 	// GetCadenceHeight returns the Cadence height that matches the
 	// provided EVM height. Each EVM block indexed contains a link
 	// to the Cadence height.
 	// - errors.NotFound if the height is not found
-	GetCadenceHeight(evmHeight uint64) (uint64, error)
+	GetCadenceHeight(height uint64) (uint64, error)
 
 	// GetCadenceID returns the Cadence block ID that matches the
 	// provided EVM height. Each EVM block indexed contains a link to the
 	// Cadence block ID. Multiple EVM heights can point to the same
 	// Cadence block ID.
 	// - errors.NotFound if the height is not found
-	GetCadenceID(evmHeight uint64) (flow.Identifier, error)
+	GetCadenceID(height uint64) (flow.Identifier, error)
 }
 
 type ReceiptIndexer interface {
@@ -66,7 +66,7 @@ type ReceiptIndexer interface {
 	// Batch is required to batch multiple indexer operations, skipped if nil.
 	// Expected errors:
 	// - errors.Duplicate if the block already exists.
-	Store(receipts []*models.StorageReceipt, evmHeight uint64, batch *pebble.Batch) error
+	Store(receipts []*models.StorageReceipt, height uint64, batch *pebble.Batch) error
 
 	// GetByTransactionID returns the receipt for the transaction ID.
 	// Expected errors:
@@ -76,14 +76,14 @@ type ReceiptIndexer interface {
 	// GetByBlockHeight returns the receipt for the block height.
 	// Expected errors:
 	// - errors.NotFound if the receipt is not found
-	GetByBlockHeight(height *big.Int) ([]*models.StorageReceipt, error)
+	GetByBlockHeight(height uint64) ([]*models.StorageReceipt, error)
 
 	// BloomsForBlockRange returns slice of bloom values and a slice of block heights
 	// corresponding to each item in the bloom slice. It only matches the blooms between
 	// inclusive start and end block height.
 	// Expected errors:
 	// - errors.InvalidRange if the block by the height was not indexed or if the end and start values are invalid.
-	BloomsForBlockRange(start, end *big.Int) ([]*models.BloomsHeight, error)
+	BloomsForBlockRange(start, end uint64) ([]*models.BloomsHeight, error)
 }
 
 type TransactionIndexer interface {

--- a/storage/index_testsuite.go
+++ b/storage/index_testsuite.go
@@ -258,6 +258,7 @@ func (s *ReceiptTestSuite) TestBloomsForBlockRange() {
 		bloomsHeights, err := s.ReceiptIndexer.BloomsForBlockRange(start, end)
 		s.Require().NoError(err)
 		s.Require().Len(bloomsHeights, len(testBlooms))
+
 		for i, bloomHeight := range bloomsHeights {
 			s.Require().Len(bloomHeight.Blooms, 1)
 			s.Require().Equal(bloomHeight.Blooms[0], testBlooms[i])
@@ -265,9 +266,14 @@ func (s *ReceiptTestSuite) TestBloomsForBlockRange() {
 		}
 
 		bloomsHeights, err = s.ReceiptIndexer.BloomsForBlockRange(start, big.NewInt(13))
+		subset := big.NewInt(13)
+		subsetSize := int(subset.Int64() - start.Int64() + 1) // +1 because it's inclusive
+
+		bloomsHeights, err = s.ReceiptIndexer.BloomsForBlockRange(start, subset)
 		s.Require().NoError(err)
-		s.Require().Len(bloomsHeights, 4)
-		for i := 0; i < 4; i++ {
+		s.Require().Len(bloomsHeights, subsetSize)
+
+		for i := 0; i < subsetSize; i++ {
 			s.Require().Len(bloomsHeights[i].Blooms, 1)
 			s.Require().Equal(bloomsHeights[i].Blooms[0], testBlooms[i])
 			s.Require().Equal(bloomsHeights[i].Height, testHeights[i])
@@ -291,8 +297,10 @@ func (s *ReceiptTestSuite) TestBloomsForBlockRange() {
 
 		bloomsHeights, err := s.ReceiptIndexer.BloomsForBlockRange(start, end)
 		s.Require().NoError(err)
-		s.Require().Len(bloomsHeights, len(testBlooms)/2)
+		s.Require().Equal(int64(len(bloomsHeights)), end.Int64()-start.Int64())
+
 		for i, bloomHeight := range bloomsHeights {
+			fmt.Println(bloomHeight.Height, bloomHeight.Blooms[0], bloomHeight.Blooms[1], testBlooms[i], testBlooms[i+1])
 			s.Require().Len(bloomHeight.Blooms, 2)
 			s.Require().Equal(bloomHeight.Blooms[0], testBlooms[i])
 			s.Require().Equal(bloomHeight.Blooms[1], testBlooms[i+1])

--- a/storage/index_testsuite.go
+++ b/storage/index_testsuite.go
@@ -333,14 +333,14 @@ func (s *ReceiptTestSuite) TestBloomsForBlockRange() {
 		end := uint64(270)
 		specific := uint64(260)
 
-		var expectedBloom types.Bloom
+		var expectedBloom *types.Bloom
 		for i := start; i < end; i++ {
 			r1 := mocks.NewReceipt(i, common.HexToHash(fmt.Sprintf("0x%d", i)))
 			receipts := []*models.StorageReceipt{r1}
 			s.Require().NoError(s.ReceiptIndexer.Store(receipts, i, nil))
 
 			if i == specific {
-				expectedBloom = r1.Bloom
+				expectedBloom = &r1.Bloom
 			}
 		}
 

--- a/storage/mocks/BlockIndexer.go
+++ b/storage/mocks/BlockIndexer.go
@@ -78,9 +78,9 @@ func (_m *BlockIndexer) GetByID(ID common.Hash) (*models.Block, error) {
 	return r0, r1
 }
 
-// GetCadenceHeight provides a mock function with given fields: evmHeight
-func (_m *BlockIndexer) GetCadenceHeight(evmHeight uint64) (uint64, error) {
-	ret := _m.Called(evmHeight)
+// GetCadenceHeight provides a mock function with given fields: height
+func (_m *BlockIndexer) GetCadenceHeight(height uint64) (uint64, error) {
+	ret := _m.Called(height)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCadenceHeight")
@@ -89,16 +89,16 @@ func (_m *BlockIndexer) GetCadenceHeight(evmHeight uint64) (uint64, error) {
 	var r0 uint64
 	var r1 error
 	if rf, ok := ret.Get(0).(func(uint64) (uint64, error)); ok {
-		return rf(evmHeight)
+		return rf(height)
 	}
 	if rf, ok := ret.Get(0).(func(uint64) uint64); ok {
-		r0 = rf(evmHeight)
+		r0 = rf(height)
 	} else {
 		r0 = ret.Get(0).(uint64)
 	}
 
 	if rf, ok := ret.Get(1).(func(uint64) error); ok {
-		r1 = rf(evmHeight)
+		r1 = rf(height)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -106,9 +106,9 @@ func (_m *BlockIndexer) GetCadenceHeight(evmHeight uint64) (uint64, error) {
 	return r0, r1
 }
 
-// GetCadenceID provides a mock function with given fields: evmHeight
-func (_m *BlockIndexer) GetCadenceID(evmHeight uint64) (flow.Identifier, error) {
-	ret := _m.Called(evmHeight)
+// GetCadenceID provides a mock function with given fields: height
+func (_m *BlockIndexer) GetCadenceID(height uint64) (flow.Identifier, error) {
+	ret := _m.Called(height)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCadenceID")
@@ -117,10 +117,10 @@ func (_m *BlockIndexer) GetCadenceID(evmHeight uint64) (flow.Identifier, error) 
 	var r0 flow.Identifier
 	var r1 error
 	if rf, ok := ret.Get(0).(func(uint64) (flow.Identifier, error)); ok {
-		return rf(evmHeight)
+		return rf(height)
 	}
 	if rf, ok := ret.Get(0).(func(uint64) flow.Identifier); ok {
-		r0 = rf(evmHeight)
+		r0 = rf(height)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(flow.Identifier)
@@ -128,7 +128,7 @@ func (_m *BlockIndexer) GetCadenceID(evmHeight uint64) (flow.Identifier, error) 
 	}
 
 	if rf, ok := ret.Get(1).(func(uint64) error); ok {
-		r1 = rf(evmHeight)
+		r1 = rf(height)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -220,9 +220,9 @@ func (_m *BlockIndexer) LatestEVMHeight() (uint64, error) {
 	return r0, r1
 }
 
-// SetLatestCadenceHeight provides a mock function with given fields: height, batch
-func (_m *BlockIndexer) SetLatestCadenceHeight(height uint64, batch *pebble.Batch) error {
-	ret := _m.Called(height, batch)
+// SetLatestCadenceHeight provides a mock function with given fields: cadenceHeight, batch
+func (_m *BlockIndexer) SetLatestCadenceHeight(cadenceHeight uint64, batch *pebble.Batch) error {
+	ret := _m.Called(cadenceHeight, batch)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetLatestCadenceHeight")
@@ -230,7 +230,7 @@ func (_m *BlockIndexer) SetLatestCadenceHeight(height uint64, batch *pebble.Batc
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(uint64, *pebble.Batch) error); ok {
-		r0 = rf(height, batch)
+		r0 = rf(cadenceHeight, batch)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/storage/mocks/ReceiptIndexer.go
+++ b/storage/mocks/ReceiptIndexer.go
@@ -3,8 +3,6 @@
 package mocks
 
 import (
-	big "math/big"
-
 	common "github.com/onflow/go-ethereum/common"
 	mock "github.com/stretchr/testify/mock"
 
@@ -19,7 +17,7 @@ type ReceiptIndexer struct {
 }
 
 // BloomsForBlockRange provides a mock function with given fields: start, end
-func (_m *ReceiptIndexer) BloomsForBlockRange(start *big.Int, end *big.Int) ([]*models.BloomsHeight, error) {
+func (_m *ReceiptIndexer) BloomsForBlockRange(start uint64, end uint64) ([]*models.BloomsHeight, error) {
 	ret := _m.Called(start, end)
 
 	if len(ret) == 0 {
@@ -28,10 +26,10 @@ func (_m *ReceiptIndexer) BloomsForBlockRange(start *big.Int, end *big.Int) ([]*
 
 	var r0 []*models.BloomsHeight
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*big.Int, *big.Int) ([]*models.BloomsHeight, error)); ok {
+	if rf, ok := ret.Get(0).(func(uint64, uint64) ([]*models.BloomsHeight, error)); ok {
 		return rf(start, end)
 	}
-	if rf, ok := ret.Get(0).(func(*big.Int, *big.Int) []*models.BloomsHeight); ok {
+	if rf, ok := ret.Get(0).(func(uint64, uint64) []*models.BloomsHeight); ok {
 		r0 = rf(start, end)
 	} else {
 		if ret.Get(0) != nil {
@@ -39,7 +37,7 @@ func (_m *ReceiptIndexer) BloomsForBlockRange(start *big.Int, end *big.Int) ([]*
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*big.Int, *big.Int) error); ok {
+	if rf, ok := ret.Get(1).(func(uint64, uint64) error); ok {
 		r1 = rf(start, end)
 	} else {
 		r1 = ret.Error(1)
@@ -49,7 +47,7 @@ func (_m *ReceiptIndexer) BloomsForBlockRange(start *big.Int, end *big.Int) ([]*
 }
 
 // GetByBlockHeight provides a mock function with given fields: height
-func (_m *ReceiptIndexer) GetByBlockHeight(height *big.Int) ([]*models.StorageReceipt, error) {
+func (_m *ReceiptIndexer) GetByBlockHeight(height uint64) ([]*models.StorageReceipt, error) {
 	ret := _m.Called(height)
 
 	if len(ret) == 0 {
@@ -58,10 +56,10 @@ func (_m *ReceiptIndexer) GetByBlockHeight(height *big.Int) ([]*models.StorageRe
 
 	var r0 []*models.StorageReceipt
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*big.Int) ([]*models.StorageReceipt, error)); ok {
+	if rf, ok := ret.Get(0).(func(uint64) ([]*models.StorageReceipt, error)); ok {
 		return rf(height)
 	}
-	if rf, ok := ret.Get(0).(func(*big.Int) []*models.StorageReceipt); ok {
+	if rf, ok := ret.Get(0).(func(uint64) []*models.StorageReceipt); ok {
 		r0 = rf(height)
 	} else {
 		if ret.Get(0) != nil {
@@ -69,7 +67,7 @@ func (_m *ReceiptIndexer) GetByBlockHeight(height *big.Int) ([]*models.StorageRe
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*big.Int) error); ok {
+	if rf, ok := ret.Get(1).(func(uint64) error); ok {
 		r1 = rf(height)
 	} else {
 		r1 = ret.Error(1)
@@ -108,9 +106,9 @@ func (_m *ReceiptIndexer) GetByTransactionID(ID common.Hash) (*models.StorageRec
 	return r0, r1
 }
 
-// Store provides a mock function with given fields: receipts, evmHeight, batch
-func (_m *ReceiptIndexer) Store(receipts []*models.StorageReceipt, evmHeight uint64, batch *pebble.Batch) error {
-	ret := _m.Called(receipts, evmHeight, batch)
+// Store provides a mock function with given fields: receipts, height, batch
+func (_m *ReceiptIndexer) Store(receipts []*models.StorageReceipt, height uint64, batch *pebble.Batch) error {
+	ret := _m.Called(receipts, height, batch)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Store")
@@ -118,7 +116,7 @@ func (_m *ReceiptIndexer) Store(receipts []*models.StorageReceipt, evmHeight uin
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]*models.StorageReceipt, uint64, *pebble.Batch) error); ok {
-		r0 = rf(receipts, evmHeight, batch)
+		r0 = rf(receipts, height, batch)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/storage/mocks/mocks.go
+++ b/storage/mocks/mocks.go
@@ -7,6 +7,7 @@ import (
 	"github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/go-ethereum/common"
 	gethTypes "github.com/onflow/go-ethereum/core/types"
+	"golang.org/x/exp/rand"
 
 	"github.com/onflow/flow-evm-gateway/models"
 )
@@ -61,6 +62,7 @@ func NewReceipt(height uint64, ID common.Hash) *models.StorageReceipt {
 		BlockHash:         ID,
 		BlockNumber:       big.NewInt(int64(height)),
 		TransactionIndex:  1,
+		Bloom:             gethTypes.Bloom{byte(height), byte(rand.Int())},
 	}
 }
 

--- a/storage/pebble/accounts.go
+++ b/storage/pebble/accounts.go
@@ -56,7 +56,7 @@ func (a *Accounts) Update(
 
 	nonce += 1
 
-	data := encodeNonce(nonce, receipt.BlockNumber.Uint64())
+	data := encodeNonce(nonce, txHeight)
 	return a.store.set(accountNonceKey, from.Bytes(), data, batch)
 }
 

--- a/storage/pebble/receipts.go
+++ b/storage/pebble/receipts.go
@@ -47,14 +47,19 @@ func (r *Receipts) Store(
 	var blooms []*gethTypes.Bloom
 
 	for _, receipt := range receipts {
-		if receipt.BlockNumber.Uint64() != evmHeight {
+		height := receipt.BlockNumber.Uint64()
+		if height != evmHeight {
 			return fmt.Errorf("receipt belongs to different block height: %d", receipt.BlockNumber.Uint64())
 		}
 
 		blooms = append(blooms, &receipt.Bloom)
-		height := receipt.BlockNumber.Bytes()
 
-		if err := r.store.set(receiptTxIDToHeightKey, receipt.TxHash.Bytes(), height, batch); err != nil {
+		if err := r.store.set(
+			receiptTxIDToHeightKey,
+			receipt.TxHash.Bytes(),
+			uint64Bytes(height),
+			batch,
+		); err != nil {
 			return fmt.Errorf("failed to store receipt tx height: %w", err)
 		}
 	}

--- a/storage/pebble/receipts.go
+++ b/storage/pebble/receipts.go
@@ -45,7 +45,7 @@ func (r *Receipts) Store(
 	r.mux.Lock()
 	defer r.mux.Unlock()
 
-	blooms := []*gethTypes.Bloom{}
+	var blooms []*gethTypes.Bloom
 
 	for _, receipt := range receipts {
 		if receipt.BlockNumber.Uint64() != evmHeight {

--- a/storage/pebble/storage_test.go
+++ b/storage/pebble/storage_test.go
@@ -37,7 +37,7 @@ func TestReceipts(t *testing.T) {
 		require.NoError(t, err)
 		err = bl.Store(30, flow.Identifier{0x1}, mocks.NewBlock(10), nil) // update first and latest height
 		require.NoError(t, err)
-		err = bl.Store(30, flow.Identifier{0x1}, mocks.NewBlock(30), nil) // update latest
+		err = bl.Store(30, flow.Identifier{0x1}, mocks.NewBlock(300), nil) // update latest
 		require.NoError(t, err)
 
 		suite.Run(t, &storage.ReceiptTestSuite{ReceiptIndexer: NewReceipts(db)})


### PR DESCRIPTION
Closes: #439 

## Description
The storage implementation for bloom filters incorrectly defined the range which resulted in additional logs being returned.

Because we've used `big.Int` type for heights, more specifically `big.Int.Bytes()` which returned byte array that only contained non-empty values in big-endian encoding, it allowed for multiple other values to match the pebble itteration upper/lower bound filter. 

Simply said, if we wanted to get height 1 when converted using `Bytes()` we got a slice `[]byte{0x1}` and that was used as boundary in iterations, but that also matched other values starting with same byte (like `[]byte{0x01, 0x02}` or `[]byte{0x01, 0xf, 0xa}`). We changed usage of `big.Int` to `uint64` since it doesn't really make sense in storage layer to use `big.Int`, and we changed to encoding of uint64 to fixed length of 8 bytes. So the above example of height 1 would be defined as `[]byte{0x1, 0x0, 0x0, 0x0}` thus no other value would match it.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of block heights and log retrieval with simplified data types (from `*big.Int` to `uint64`).
  - Enhanced filtering logic in the logs package to optimize receipt fetching based on block heights.
  
- **Bug Fixes**
  - Ensured consistent return types in log retrieval methods, preventing potential `nil` reference errors.

- **Documentation**
  - Updated method signatures and parameter names for clarity and consistency across interfaces.

- **Tests**
  - Revised test cases to reflect changes in data types, enhancing robustness and performance of unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->