### PR TITLE
Unsupported `mainnet` network ID for `--flow-network-id` CLI flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -100,7 +100,6 @@ type Config struct {
 func FromFlags() (*Config, error) {
 	cfg := &Config{}
 	var (
-		evmNetwork,
 		coinbase,
 		gas,
 		coa,
@@ -130,8 +129,7 @@ func FromFlags() (*Config, error) {
 	flag.BoolVar(&cfg.WSEnabled, "ws-enabled", false, "Enable websocket connections")
 	flag.StringVar(&cfg.AccessNodeHost, "access-node-grpc-host", "localhost:3569", "Host to the flow access node gRPC API")
 	flag.StringVar(&accessSporkHosts, "access-node-spork-hosts", "", `Previous spork AN hosts, defined following the schema: {host1},{host2} as a comma separated list (e.g. "host-1.com,host2.com")`)
-	flag.StringVar(&evmNetwork, "evm-network-id", "previewnet", "EVM network ID (previewnet, testnet, mainnet)")
-	flag.StringVar(&flowNetwork, "flow-network-id", "flow-emulator", "Flow network ID (flow-emulator, flow-previewnet, flow-testnet)")
+	flag.StringVar(&flowNetwork, "flow-network-id", "flow-emulator", "Flow network ID (flow-emulator, flow-previewnet, flow-testnet, flow-mainnet)")
 	flag.StringVar(&coinbase, "coinbase", "", "Coinbase address to use for fee collection")
 	flag.Uint64Var(&initHeight, "init-cadence-height", 0, "Define the Cadence block height at which to start the indexing, if starting on a new network this flag should not be used.")
 	flag.StringVar(&gas, "gas-price", "1", "Static gas price used for EVM transactions")
@@ -224,29 +222,28 @@ func FromFlags() (*Config, error) {
 		)
 	}
 
-	switch evmNetwork {
-	case "previewnet":
-		cfg.EVMNetworkID = types.FlowEVMPreviewNetChainID
-	case "testnet":
-		cfg.EVMNetworkID = types.FlowEVMTestNetChainID
-	case "mainnet":
-		cfg.EVMNetworkID = types.FlowEVMMainNetChainID
-	default:
-		return nil, fmt.Errorf("EVM network ID not supported")
-	}
-
 	switch flowNetwork {
 	case "flow-previewnet":
 		cfg.FlowNetworkID = flowGo.Previewnet
+		cfg.EVMNetworkID = types.FlowEVMPreviewNetChainID
 		cfg.InitCadenceHeight = LiveNetworkInitCadenceHeght
 	case "flow-emulator":
 		cfg.FlowNetworkID = flowGo.Emulator
+		cfg.EVMNetworkID = types.FlowEVMPreviewNetChainID
 		cfg.InitCadenceHeight = EmulatorInitCadenceHeight
 	case "flow-testnet":
 		cfg.FlowNetworkID = flowGo.Testnet
+		cfg.EVMNetworkID = types.FlowEVMTestNetChainID
+		cfg.InitCadenceHeight = LiveNetworkInitCadenceHeght
+	case "flow-mainnet":
+		cfg.FlowNetworkID = flowGo.Mainnet
+		cfg.EVMNetworkID = types.FlowEVMMainNetChainID
 		cfg.InitCadenceHeight = LiveNetworkInitCadenceHeght
 	default:
-		return nil, fmt.Errorf("flow network ID not supported, only possible to specify 'flow-previewnet' or 'flow-emulator'")
+		return nil, fmt.Errorf(
+			"flow network ID: %s not supported, valid values are ('flow-emulator', 'flow-previewnet', 'flow-testnet', 'flow-mainnet')",
+			flowNetwork,
+		)
 	}
 
 	// if a specific value was provided use it


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/456

## Description

The `--flow-network-id` CLI flag now accepts the the `flow-mainnet` value.
In addition to that, we remove the `--evm-network-id` CLI flag, as we can deduce this config value simply from the `--flow-network-id` flag.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration handling for EVM network selection, now including support for `flow-mainnet`.
  
- **Bug Fixes**
	- Improved error messages for unsupported flow network IDs, providing clearer guidance on valid options. 

- **Documentation**
	- Refined comments for better clarity and readability in the configuration handling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->