### PR TITLE
`EVMHeightIndexed` metric incorrectly tracks Cadence height instead of EVM height

### DIFF
--- a/services/ingestion/engine.go
+++ b/services/ingestion/engine.go
@@ -191,7 +191,7 @@ func (e *Engine) processEvents(events *models.CadenceEvents) error {
 		}
 	}
 
-	e.collector.EVMHeightIndexed(events.CadenceHeight())
+	e.collector.EVMHeightIndexed(events.Block().Height)
 	return nil
 }
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/455

## Description



______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved event processing accuracy by updating the method for retrieving height values.
	- Ensured consistent error handling in event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->