### PR TITLE
Update to Cadence v1.0.0-preview.49

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onflow/atree v0.8.0-rc.6
 	github.com/onflow/cadence v1.0.0-preview.49
-	github.com/onflow/flow-go v0.37.6
+	github.com/onflow/flow-go v0.37.7-0.20240822174309-8b4fff2114d4
 	github.com/onflow/flow-go-sdk v1.0.0-preview.51
 	github.com/onflow/flow/protobuf/go/flow v0.4.5
 	github.com/onflow/go-ethereum v1.14.7

--- a/go.sum
+++ b/go.sum
@@ -1862,8 +1862,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0 h1:mToacZ5NWqtlWwk/7RgIl/jeKB/
 github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.37.6 h1:bB2Z0siLlN6ueATaWYp0BdOb/YaCC9CRfLOGeujW6hk=
-github.com/onflow/flow-go v0.37.6/go.mod h1:T+VZEc92OEgGOF+6daVevGrokFNXA/XZkHw81DDsa/k=
+github.com/onflow/flow-go v0.37.7-0.20240822174309-8b4fff2114d4 h1:DpC/WAaNDHTbKN/L8HhSwGMGZWPi+C6fUPAYeUjwImc=
+github.com/onflow/flow-go v0.37.7-0.20240822174309-8b4fff2114d4/go.mod h1:iZG3ofIPrPAChSdZxByDGrsBAC5CVDw2hyo4akoQ1NY=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
 github.com/onflow/flow-go-sdk v1.0.0-preview.51 h1:rsvjyEdiot4oKwx2YsEqV2hsXqDrakuVmSUexsU/lSI=
 github.com/onflow/flow-go-sdk v1.0.0-preview.51/go.mod h1:yXinctVJY1VlpQaJhkCUMiC5lvv2kYCCMdMo+FdSV5A=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/goccy/go-json v0.10.2
 	github.com/onflow/cadence v1.0.0-preview.49
 	github.com/onflow/crypto v0.25.2
-	github.com/onflow/flow-emulator v1.0.0-preview.39
+	github.com/onflow/flow-emulator v1.0.0-preview.40
 	github.com/onflow/flow-evm-gateway v0.0.0-20240201154855-4d4d3d3f19c7
 	github.com/onflow/flow-go v0.37.7-0.20240822174309-8b4fff2114d4
 	github.com/onflow/flow-go-sdk v1.0.0-preview.51

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -2085,8 +2085,8 @@ github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.1 h1:q9tXLIALwQ76bO4
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.1/go.mod h1:u/mkP/B+PbV33tEG3qfkhhBlydSvAKxfLZSfB4lsJHg=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1 h1:FfhMBAb78p6VAWkJ+iqdKLErGQVQgxk5w6DP5ZruWX8=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1/go.mod h1:NgbMOYnMh0GN48VsNKZuiwK7uyk38Wyo8jN9+C9QE30=
-github.com/onflow/flow-emulator v1.0.0-preview.39 h1:5z/jKUrU3YB/Lqvr1bNTDW2BGIcCJocLdw06Rk87r+U=
-github.com/onflow/flow-emulator v1.0.0-preview.39/go.mod h1:0mXSq9eSwkAmGgvn/8aCBNgXiJM6MHKETFgPSk6f9NA=
+github.com/onflow/flow-emulator v1.0.0-preview.40 h1:VoblJbxqz6xTzgTL1LbbWhuWJ8isONdH8pwQ3Cy1ObM=
+github.com/onflow/flow-emulator v1.0.0-preview.40/go.mod h1:AjbLv8TSsT2hrKF+XudEohbdKNdWomHjH2RlreuxrdU=
 github.com/onflow/flow-ft/lib/go/contracts v1.0.0 h1:mToacZ5NWqtlWwk/7RgIl/jeKB/Sy/tIXdw90yKHcV0=
 github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.49](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.49)
- [onflow/flow-go-sdk v1.0.0-preview.51](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.51)
- [onflow/flow-go 8b4fff2114d4](https://github.com/onflow/flow-go/commit/8b4fff2114d4)
- [onflow/flow-emulator v1.0.0-preview.40](https://github.com/onflow/flow-emulator/releases/tag/v1.0.0-preview.40)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
	- Updated the `flow-go` package to a newer version, potentially improving performance and fixing bugs.
	- Updated the `flow-emulator` package to a newer version, which may enhance test reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->