### PR TITLE
Decode legacy block event

### DIFF
--- a/models/block.go
+++ b/models/block.go
@@ -61,6 +61,10 @@ func (b *Block) Hash() (gethCommon.Hash, error) {
 func decodeBlockEvent(event cadence.Event) (*Block, error) {
 	payload, err := events.DecodeBlockEventPayload(event)
 	if err != nil {
+		if block, err := decodeLegacyBlockEvent(event); err == nil {
+			return block, nil
+		}
+
 		return nil, fmt.Errorf("failed to cadence decode block [%s]: %w", event.String(), err)
 	}
 

--- a/models/block.go
+++ b/models/block.go
@@ -78,6 +78,39 @@ func decodeBlockEvent(event cadence.Event) (*Block, error) {
 	}, nil
 }
 
+// todo remove this after updated in flow-go
+type blockEventPayloadV0 struct {
+	Height              uint64          `cadence:"height"`
+	Hash                gethCommon.Hash `cadence:"hash"`
+	Timestamp           uint64          `cadence:"timestamp"`
+	TotalSupply         cadence.Int     `cadence:"totalSupply"`
+	TotalGasUsed        uint64          `cadence:"totalGasUsed"`
+	ParentBlockHash     gethCommon.Hash `cadence:"parentHash"`
+	ReceiptRoot         gethCommon.Hash `cadence:"receiptRoot"`
+	TransactionHashRoot gethCommon.Hash `cadence:"transactionHashRoot"`
+}
+
+// DecodeBlockEventPayload decodes Cadence event into block event payload.
+func decodeLegacyBlockEvent(event cadence.Event) (*Block, error) {
+	var block blockEventPayloadV0
+	err := cadence.DecodeFields(event, &block)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Block{
+		Block: &types.Block{
+			ParentBlockHash:     block.ParentBlockHash,
+			Height:              block.Height,
+			Timestamp:           block.Timestamp,
+			TotalSupply:         block.TotalSupply.Value,
+			ReceiptRoot:         block.ReceiptRoot,
+			TransactionHashRoot: block.TransactionHashRoot,
+			TotalGasUsed:        block.TotalGasUsed,
+		},
+	}, nil
+}
+
 // blockV0 is the block format, prior to adding the PrevRandao field.
 type blockV0 struct {
 	Block             *blockV0Fields


### PR DESCRIPTION
## Description
Decode legacy block event not including the prevrandao.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a fallback mechanism for decoding legacy block events, enhancing compatibility with older event formats.
  - Added a new structure to handle legacy block event payloads, ensuring smooth processing of historical data.

- **Bug Fixes**
  - Improved robustness in the event decoding process, preventing errors when handling various block event versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->