### PR TITLE
`EffectiveGasPrice` is not properly set for all transaction types

### DIFF
--- a/api/models.go
+++ b/api/models.go
@@ -219,7 +219,9 @@ func NewTransaction(
 	if tx.Type() > types.AccessListTxType {
 		result.GasFeeCap = (*hexutil.Big)(tx.GasFeeCap())
 		result.GasTipCap = (*hexutil.Big)(tx.GasTipCap())
-		result.GasPrice = (*hexutil.Big)(tx.GasFeeCap()) // Since BaseFee is `0`, this is the effective gas price the sender is willing to pay.
+		// Since BaseFee is `0`, this is the max gas price
+		// the sender is willing to pay.
+		result.GasPrice = (*hexutil.Big)(tx.GasFeeCap())
 	}
 
 	if tx.Type() > types.DynamicFeeTxType {

--- a/tests/e2e_web3js_test.go
+++ b/tests/e2e_web3js_test.go
@@ -36,6 +36,10 @@ func TestWeb3_E2E(t *testing.T) {
 		runWeb3Test(t, "eth_non_interactive_test")
 	})
 
+	t.Run("test transaction type fees", func(t *testing.T) {
+		runWeb3Test(t, "eth_transaction_type_fees_test")
+	})
+
 	t.Run("retrieve syncing status", func(t *testing.T) {
 		runWeb3Test(t, "eth_syncing_status_test")
 	})

--- a/tests/web3js/eth_transaction_type_fees_test.js
+++ b/tests/web3js/eth_transaction_type_fees_test.js
@@ -1,0 +1,218 @@
+const utils = require('web3-utils')
+const { assert } = require('chai')
+const conf = require('./config')
+const helpers = require('./helpers')
+const web3 = conf.web3
+
+let deployed = null
+let contractAddress = null
+
+before(async () => {
+    deployed = await helpers.deployContract("storage")
+    contractAddress = deployed.receipt.contractAddress
+
+    // make sure deploy results are correct
+    assert.equal(deployed.receipt.status, conf.successStatus)
+    assert.isString(deployed.receipt.transactionHash)
+    assert.isString(contractAddress)
+    assert.equal(deployed.receipt.from, conf.eoa.address)
+    assert.isUndefined(deployed.receipt.to)
+
+    let rcp = await web3.eth.getTransactionReceipt(deployed.receipt.transactionHash)
+    assert.equal(rcp.contractAddress, contractAddress)
+    assert.equal(rcp.status, conf.successStatus)
+    assert.isUndefined(rcp.to)
+    assert.equal(rcp.gasUsed, 338798n)
+    assert.equal(rcp.gasUsed, rcp.cumulativeGasUsed)
+})
+
+it('calculates fees for legacy tx type', async () => {
+    let senderBalance = await web3.eth.getBalance(conf.eoa.address)
+    assert.equal(senderBalance, 4999999999949180300n)
+
+    let storeCallData = deployed.contract.methods.store(1337).encodeABI()
+    let gasPrice = conf.minGasPrice + 50n
+    let res = await helpers.signAndSend({
+        from: conf.eoa.address,
+        to: contractAddress,
+        data: storeCallData,
+        value: '0',
+        gasPrice: gasPrice
+    })
+    assert.equal(res.receipt.status, conf.successStatus)
+    assert.equal(res.receipt.type, 0n)
+    assert.equal(res.receipt.effectiveGasPrice, gasPrice)
+
+    // assert the transaction fees charged on sender EOA
+    let cost = res.receipt.gasUsed * gasPrice
+    let expectedBalance = senderBalance - cost
+    senderBalance = await web3.eth.getBalance(conf.eoa.address)
+    assert.equal(senderBalance, expectedBalance)
+
+    // assert the gasPrice field of the submitted tx
+    let latest = await web3.eth.getBlockNumber()
+    let tx = await web3.eth.getTransactionFromBlock(latest, 0)
+    assert.equal(tx.gasPrice, gasPrice)
+
+    // with insufficient gas price
+    try {
+        res = await helpers.signAndSend({
+            from: conf.eoa.address,
+            to: contractAddress,
+            data: storeCallData,
+            value: '0',
+            gasPrice: conf.minGasPrice - 50n
+        })
+    } catch (e) {
+        assert.include(e.message, "the minimum accepted gas price for transactions is: 150")
+    }
+})
+
+it('calculates fees for access list tx type', async () => {
+    let senderBalance = await web3.eth.getBalance(conf.eoa.address)
+    assert.equal(senderBalance, 4999999999944414300n)
+
+    let storeCallData = deployed.contract.methods.store(8250).encodeABI()
+    let gasPrice = conf.minGasPrice + 5n
+    let res = await helpers.signAndSend({
+        from: conf.eoa.address,
+        to: contractAddress,
+        data: storeCallData,
+        value: '0',
+        gasPrice: gasPrice,
+        accessList: [
+            {
+                address: contractAddress,
+                storageKeys: [],
+            },
+        ]
+    })
+    assert.equal(res.receipt.status, conf.successStatus)
+    assert.equal(res.receipt.type, 1n)
+    assert.equal(res.receipt.effectiveGasPrice, gasPrice)
+
+    // assert the transaction fees charged on sender EOA
+    let cost = res.receipt.gasUsed * gasPrice
+    let expectedBalance = senderBalance - cost
+    senderBalance = await web3.eth.getBalance(conf.eoa.address)
+    assert.equal(senderBalance, expectedBalance)
+
+    // assert the gasPrice field of the submitted tx
+    let latest = await web3.eth.getBlockNumber()
+    let tx = await web3.eth.getTransactionFromBlock(latest, 0)
+    assert.equal(tx.gasPrice, gasPrice)
+
+    // with insufficient gas price
+    try {
+        res = await helpers.signAndSend({
+            from: conf.eoa.address,
+            to: contractAddress,
+            data: storeCallData,
+            value: '0',
+            gasPrice: conf.minGasPrice - 50n,
+            accessList: [
+                {
+                    address: contractAddress,
+                    storageKeys: [],
+                },
+            ]
+        })
+    } catch (e) {
+        assert.include(e.message, "the minimum accepted gas price for transactions is: 150")
+    }
+})
+
+it('calculates fees for dynamic fees tx type', async () => {
+    let senderBalance = await web3.eth.getBalance(conf.eoa.address)
+    assert.equal(senderBalance, 4999999999939914650n)
+
+    // gasTipCap is less than gasFeeCap
+    // price = Min(GasTipCap, GasFeeCap) when baseFee = 0
+    let storeCallData = deployed.contract.methods.store(10007).encodeABI()
+    let gasTipCap = conf.minGasPrice + 20n
+    let gasFeeCap = conf.minGasPrice + 50n
+    let res = await helpers.signAndSend({
+        from: conf.eoa.address,
+        to: contractAddress,
+        data: storeCallData,
+        value: '0',
+        maxPriorityFeePerGas: gasTipCap,
+        maxFeePerGas: gasFeeCap,
+    })
+    assert.equal(res.receipt.status, conf.successStatus)
+    assert.equal(res.receipt.type, 2n)
+    assert.equal(res.receipt.effectiveGasPrice, gasTipCap)
+
+    // assert the transaction fees charged on sender EOA
+    let cost = res.receipt.gasUsed * gasTipCap
+    let expectedBalance = senderBalance - cost
+    senderBalance = await web3.eth.getBalance(conf.eoa.address)
+    assert.equal(senderBalance, expectedBalance)
+
+    // assert the gas price related fields of the submitted tx
+    let latest = await web3.eth.getBlockNumber()
+    let tx = await web3.eth.getTransactionFromBlock(latest, 0)
+    assert.equal(tx.maxPriorityFeePerGas, gasTipCap)
+    assert.equal(tx.maxFeePerGas, gasFeeCap)
+    assert.equal(tx.gasPrice, gasFeeCap)
+
+    // gasTipCap is equal to gasFeeCap
+    // price = Min(GasTipCap, GasFeeCap) when baseFee = 0
+    gasTipCap = conf.minGasPrice + 30n
+    gasFeeCap = conf.minGasPrice + 30n
+    res = await helpers.signAndSend({
+        from: conf.eoa.address,
+        to: contractAddress,
+        data: storeCallData,
+        value: '0',
+        maxPriorityFeePerGas: gasTipCap,
+        maxFeePerGas: gasFeeCap,
+    })
+    assert.equal(res.receipt.status, conf.successStatus)
+    assert.equal(res.receipt.type, 2n)
+    assert.equal(res.receipt.effectiveGasPrice, gasFeeCap)
+
+    // assert the transaction fees charged on sender EOA
+    cost = res.receipt.gasUsed * gasFeeCap
+    expectedBalance = senderBalance - cost
+    senderBalance = await web3.eth.getBalance(conf.eoa.address)
+    assert.equal(senderBalance, expectedBalance)
+
+    // assert the gas price related fields of the submitted tx
+    latest = await web3.eth.getBlockNumber()
+    tx = await web3.eth.getTransactionFromBlock(latest, 0)
+    assert.equal(tx.maxPriorityFeePerGas, gasTipCap)
+    assert.equal(tx.maxFeePerGas, gasFeeCap)
+    assert.equal(tx.gasPrice, gasFeeCap)
+
+    // gasTipCap cannot be greater than gasFeeCap, so we have covered
+    // all cases above.
+
+    // when GasTipCap(a.k.a maxPriorityFeePerGas) is below the required gas price
+    try {
+        res = await helpers.signAndSend({
+            from: conf.eoa.address,
+            to: contractAddress,
+            data: storeCallData,
+            value: '0',
+            maxPriorityFeePerGas: 50n,
+            maxFeePerGas: conf.minGasPrice + 50n,
+        })
+    } catch (e) {
+        assert.include(e.message, "the minimum accepted gas price for transactions is: 150")
+    }
+
+    // when GasFeeCap(a.k.a maxFeePerGas) is below the required gas price
+    try {
+        res = await helpers.signAndSend({
+            from: conf.eoa.address,
+            to: contractAddress,
+            data: storeCallData,
+            value: '0',
+            maxPriorityFeePerGas: conf.minGasPrice - 10n,
+            maxFeePerGas: conf.minGasPrice - 10n,
+        })
+    } catch (e) {
+        assert.include(e.message, "the minimum accepted gas price for transactions is: 150")
+    }
+})


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/355

## Description

There was a bug, with the `EffectiveGasPrice` field on receipts from dynamic fee transactions.
We fix this, and add plenty of test cases, to make sure that we use the proper value for this field, and that we correctly drop transactions which do not meet the minimum gas price set by EVM Gateway operators.
[EffectiveGasPrice](https://github.com/onflow/go-ethereum/blob/master/internal/ethapi/api.go#L1429-L1439) implementation from our fork of `go-ethereum`.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a method for calculating effective gas prices in transactions, enhancing transaction handling with varying gas fees.
	- Added a comprehensive test suite for evaluating transaction fee calculations across different Ethereum transaction types.

- **Bug Fixes**
	- Improved clarity in comments related to gas price assignments, aiding user understanding without altering functionality.

- **Tests**
	- Expanded end-to-end tests to cover transaction type fees, enhancing the overall test suite for Web3 functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->