### PR TITLE
Monitor operator balance

### DIFF
--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -16,7 +16,7 @@ type Collector interface {
 	EVMHeightIndexed(height uint64)
 	EVMAccountInteraction(address string)
 	MeasureRequestDuration(start time.Time, method string)
-	OperatorBalance(account flow.Account)
+	OperatorBalance(account *flow.Account)
 }
 
 var _ Collector = &DefaultCollector{}
@@ -126,7 +126,7 @@ func (c *DefaultCollector) EVMAccountInteraction(address string) {
 
 }
 
-func (c *DefaultCollector) OperatorBalance(account flow.Account) {
+func (c *DefaultCollector) OperatorBalance(account *flow.Account) {
 	c.operatorBalance.Set(float64(account.Balance))
 }
 

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -16,6 +16,7 @@ type Collector interface {
 	EVMHeightIndexed(height uint64)
 	EVMAccountInteraction(address string)
 	MeasureRequestDuration(start time.Time, method string)
+	OperatorBalance(account flow.Account)
 }
 
 var _ Collector = &DefaultCollector{}

--- a/metrics/nop.go
+++ b/metrics/nop.go
@@ -2,6 +2,8 @@ package metrics
 
 import (
 	"time"
+
+	"github.com/onflow/flow-go-sdk"
 )
 
 type nopCollector struct{}
@@ -16,3 +18,4 @@ func (c *nopCollector) ServerPanicked(string)                    {}
 func (c *nopCollector) EVMHeightIndexed(uint64)                  {}
 func (c *nopCollector) EVMAccountInteraction(string)             {}
 func (c *nopCollector) MeasureRequestDuration(time.Time, string) {}
+func (c *nopCollector) OperatorBalance(account flow.Account)     {}

--- a/metrics/nop.go
+++ b/metrics/nop.go
@@ -18,4 +18,4 @@ func (c *nopCollector) ServerPanicked(string)                    {}
 func (c *nopCollector) EVMHeightIndexed(uint64)                  {}
 func (c *nopCollector) EVMAccountInteraction(string)             {}
 func (c *nopCollector) MeasureRequestDuration(time.Time, string) {}
-func (c *nopCollector) OperatorBalance(account flow.Account)     {}
+func (c *nopCollector) OperatorBalance(*flow.Account)            {}

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -632,6 +632,8 @@ func (e *EVM) getSignerNetworkInfo(ctx context.Context) (uint32, uint64, error) 
 		)
 	}
 
+	e.collector.OperatorBalance(account)
+
 	signerPub := e.signer.PublicKey()
 	for _, k := range account.Keys {
 		if k.PublicKey.Equals(signerPub) {


### PR DESCRIPTION
## Description
Monitor operator wallet balance and report metrics. It should be configured to an alarm so the balance doesn't fall too low. 
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to track the operator's balance in the collector interface, enhancing monitoring capabilities.
	- Added functionality to the `nopCollector` for handling operator balance related to Flow accounts.
	- Updated the `getSignerNetworkInfo` method to incorporate operator balance retrieval.

- **Bug Fixes**
	- Improved control flow in the `getSignerNetworkInfo` method to ensure operator balance is updated before key retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->