### PR TITLE
Inject configured coinbase address for transaction submission

### DIFF
--- a/services/requester/cadence/run.cdc
+++ b/services/requester/cadence/run.cdc
@@ -1,6 +1,6 @@
 import EVM
 
-transaction(hexEncodedTx: String) {
+transaction(hexEncodedTx: String, coinbase: String) {
     let coa: &EVM.CadenceOwnedAccount
 
     prepare(signer: auth(Storage) &Account) {
@@ -12,7 +12,7 @@ transaction(hexEncodedTx: String) {
     execute {
         let txResult = EVM.run(
             tx: hexEncodedTx.decodeHex(),
-            coinbase: self.coa.address()
+            coinbase: EVM.addressFromString(coinbase)
         )
         assert(
             txResult.status == EVM.Status.failed || txResult.status == EVM.Status.successful,

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -222,9 +222,13 @@ func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash,
 	if err != nil {
 		return common.Hash{}, err
 	}
+	coinbaseAddress, err := cadence.NewString(e.config.Coinbase.Hex())
+	if err != nil {
+		return common.Hash{}, err
+	}
 
 	script := e.replaceAddresses(runTxScript)
-	flowTx, err := e.buildTransaction(ctx, script, hexEncodedTx)
+	flowTx, err := e.buildTransaction(ctx, script, hexEncodedTx, coinbaseAddress)
 	if err != nil {
 		e.logger.Error().Err(err).Str("data", txData).Msg("failed to build transaction")
 		return common.Hash{}, err

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -52,6 +52,7 @@ const (
 	// this is a test eoa account created on account setup
 	eoaTestAddress    = "0xFACF71692421039876a5BB4F10EF7A439D8ef61E"
 	eoaTestPrivateKey = "f6d5333177711e562cabf1f311916196ee6ffc2a07966d9d4628094073bd5442"
+	coinbaseAddress   = "0x658Bdf435d810C91414eC09147DAA6DB62406379"
 	eoaFundAmount     = 5.0
 	coaFundAmount     = 10.0
 )
@@ -137,24 +138,24 @@ func servicesSetup(t *testing.T) (emulator.Emulator, func()) {
 
 	// default config
 	cfg := &config.Config{
-		DatabaseDir:              t.TempDir(),
-		AccessNodeHost:           "localhost:3569", // emulator
-		RPCPort:                  8545,
-		RPCHost:                  "127.0.0.1",
-		FlowNetworkID:            "flow-emulator",
-		EVMNetworkID:             evmTypes.FlowEVMPreviewNetChainID,
-		Coinbase:                 common.HexToAddress(eoaTestAddress),
-		COAAddress:               service.Address,
-		COAKey:                   service.PrivateKey,
-		CreateCOAResource:        false,
-		GasPrice:                 new(big.Int).SetUint64(150),
-		LogLevel:                 zerolog.DebugLevel,
-		LogWriter:                testLogWriter(),
-		StreamTimeout:            time.Second * 30,
-		StreamLimit:              10,
-		RateLimit:                50,
-		WSEnabled:                true,
-		MetricsPort:                 8443,
+		DatabaseDir:       t.TempDir(),
+		AccessNodeHost:    "localhost:3569", // emulator
+		RPCPort:           8545,
+		RPCHost:           "127.0.0.1",
+		FlowNetworkID:     "flow-emulator",
+		EVMNetworkID:      evmTypes.FlowEVMPreviewNetChainID,
+		Coinbase:          common.HexToAddress(coinbaseAddress),
+		COAAddress:        service.Address,
+		COAKey:            service.PrivateKey,
+		CreateCOAResource: false,
+		GasPrice:          new(big.Int).SetUint64(150),
+		LogLevel:          zerolog.DebugLevel,
+		LogWriter:         testLogWriter(),
+		StreamTimeout:     time.Second * 30,
+		StreamLimit:       10,
+		RateLimit:         50,
+		WSEnabled:         true,
+		MetricsPort:       8443,
 	}
 
 	go func() {

--- a/tests/web3js/config.js
+++ b/tests/web3js/config.js
@@ -7,7 +7,7 @@ module.exports = {
     eoa: web3.eth.accounts.privateKeyToAccount("0xf6d5333177711e562cabf1f311916196ee6ffc2a07966d9d4628094073bd5442"),
     fundedAmount: 5.0,
     startBlockHeight: 2n, // start block height after setup accounts
-    serviceEOA: "0xfacf71692421039876a5bb4f10ef7a439d8ef61e", // configured account as gw service
+    serviceEOA: "0x658bdf435d810c91414ec09147daa6db62406379", // configured account as gw service
     successStatus: 1n,
     minGasPrice: 150n
 }

--- a/tests/web3js/eth_transaction_type_fees_test.js
+++ b/tests/web3js/eth_transaction_type_fees_test.js
@@ -1,4 +1,3 @@
-const utils = require('web3-utils')
 const { assert } = require('chai')
 const conf = require('./config')
 const helpers = require('./helpers')
@@ -66,6 +65,9 @@ it('calculates fees for legacy tx type', async () => {
     } catch (e) {
         assert.include(e.message, "the minimum accepted gas price for transactions is: 150")
     }
+
+    let coinbaseBalance = await web3.eth.getBalance(conf.serviceEOA)
+    assert.equal(coinbaseBalance, 55585700n)
 })
 
 it('calculates fees for access list tx type', async () => {
@@ -120,6 +122,9 @@ it('calculates fees for access list tx type', async () => {
     } catch (e) {
         assert.include(e.message, "the minimum accepted gas price for transactions is: 150")
     }
+
+    let coinbaseBalance = await web3.eth.getBalance(conf.serviceEOA)
+    assert.equal(coinbaseBalance, 60085350n)
 })
 
 it('calculates fees for dynamic fees tx type', async () => {
@@ -215,4 +220,7 @@ it('calculates fees for dynamic fees tx type', async () => {
     } catch (e) {
         assert.include(e.message, "the minimum accepted gas price for transactions is: 150")
     }
+
+    let coinbaseBalance = await web3.eth.getBalance(conf.serviceEOA)
+    assert.equal(coinbaseBalance, 70093350n)
 })


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/490

## Description

Right now, although we have the `--coinbase` config flag, which is returned in `eth_coinbase`, we keep using the COA's address in `EVM.run`.
The EVM Gateway operators should have the ability to specify whatever address they want for the `--coinbase` flag, this could be an EOA, or they can even choose the use the COA's address.
Furthermore, there is a chance that some tool out there might complain about the fact that `eth_coinbase` is not the address collecting the fees.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 