### PR TITLE
The `height` in some log lines is displayed as a byte-array instead of numeric value

### DIFF
--- a/storage/pebble/blocks.go
+++ b/storage/pebble/blocks.go
@@ -148,7 +148,11 @@ func (b *Blocks) GetByID(ID common.Hash) (*models.Block, error) {
 
 	blk, err := b.getBlock(blockHeightKey, height)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get EVM block by height: %d, with: %w", height, err)
+		return nil, fmt.Errorf(
+			"failed to get EVM block by height: %d, with: %w",
+			binary.BigEndian.Uint64(height),
+			err,
+		)
 	}
 
 	return blk, nil

--- a/storage/pebble/receipts.go
+++ b/storage/pebble/receipts.go
@@ -101,7 +101,11 @@ func (r *Receipts) GetByTransactionID(ID common.Hash) (*models.Receipt, error) {
 
 	receipts, err := r.getByBlockHeight(height, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get receipt by height: %d, with: %w", height, err)
+		return nil, fmt.Errorf(
+			"failed to get receipt by height: %d, with: %w",
+			binary.BigEndian.Uint64(height),
+			err,
+		)
 	}
 
 	for _, rcp := range receipts {
@@ -224,7 +228,7 @@ func (r *Receipts) BloomsForBlockRange(start, end uint64) ([]*models.BloomsHeigh
 			return nil, fmt.Errorf(
 				"failed to RLP-decode blooms for range [%x] at height: %d, with: %w",
 				val,
-				height,
+				binary.BigEndian.Uint64(height),
 				err,
 			)
 		}


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/496

## Description


______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 