### PR TITLE
Incorrect hash value for empty `sha3Uncles` block field

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -968,6 +968,7 @@ func (b *BlockChainAPI) prepareBlockResponse(
 		BaseFeePerGas:    hexutil.Big(*big.NewInt(0)),
 		LogsBloom:        types.LogsBloom([]*types.Log{}),
 		Miner:            evmTypes.CoinbaseAddress.ToCommon(),
+		Sha3Uncles:       types.EmptyUncleHash,
 	}
 
 	blockBytes, err := block.ToBytes()

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/go-ethereum/common"
 	"github.com/onflow/go-ethereum/crypto"
+	"github.com/onflow/go-ethereum/ethclient"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -129,6 +130,73 @@ func Test_ConcurrentTransactionSubmission(t *testing.T) {
 
 		return true
 	}, time.Second*30, time.Second*1, "all transactions were not executed")
+}
+
+func Test_EthClientTest(t *testing.T) {
+	srv, err := startEmulator(true)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		srv.Stop()
+	}()
+
+	grpcHost := "localhost:3569"
+	emu := srv.Emulator()
+	service := emu.ServiceKey()
+
+	client, err := grpc.NewClient(grpcHost)
+	require.NoError(t, err)
+
+	time.Sleep(500 * time.Millisecond) // some time to startup
+
+	// create new account with keys used for key-rotation
+	keyCount := 5
+	createdAddr, keys, err := bootstrap.CreateMultiKeyAccount(
+		client,
+		keyCount,
+		service.Address,
+		"0xee82856bf20e2aa6",
+		"0x0ae53cb6e3f42a79",
+		service.PrivateKey,
+	)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		DatabaseDir:       t.TempDir(),
+		AccessNodeHost:    grpcHost,
+		RPCPort:           8545,
+		RPCHost:           "127.0.0.1",
+		FlowNetworkID:     "flow-emulator",
+		EVMNetworkID:      types.FlowEVMPreviewNetChainID,
+		Coinbase:          eoaTestAccount,
+		COAAddress:        *createdAddr,
+		COAKeys:           keys,
+		CreateCOAResource: true,
+		GasPrice:          new(big.Int).SetUint64(150),
+		LogLevel:          zerolog.DebugLevel,
+		LogWriter:         testLogWriter(),
+	}
+
+	ready := make(chan struct{})
+	go func() {
+		err := bootstrap.Run(ctx, cfg, ready)
+		require.NoError(t, err)
+	}()
+
+	<-ready
+
+	ethClient, err := ethclient.Dial("http://127.0.0.1:8545")
+	require.NoError(t, err)
+
+	blockNumber, err := ethClient.BlockNumber(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(3), blockNumber)
+
+	block, err := ethClient.BlockByNumber(context.Background(), big.NewInt(3))
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(3), block.Number())
 }
 
 func Test_CloudKMSConcurrentTransactionSubmission(t *testing.T) {

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -27,6 +27,14 @@ it('get block', async () => {
     )
     assert.equal(block.size, 3994n)
     assert.equal(block.miner, '0x0000000000000000000000030000000000000000')
+    assert.equal(
+        block.sha3Uncles,
+        '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'
+    )
+    assert.equal(
+        block.stateRoot,
+        '0x0000000000000000000000000000000000000000000000000000000000000000'
+    )
 
     let blockHash = await web3.eth.getBlock(block.hash)
     assert.deepEqual(block, blockHash)


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/503

## Description

The empty hash value for this field can be found here: [EmptyUncleHash](https://github.com/ethereum/go-ethereum/blob/ab3ee99ca9aa46163f1dfbaf10260718d8de9e10/core/types/hashes.go#L29-L30)

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced API response for block retrieval by including additional fields: `Sha3Uncles` and `StateRoot`, providing more comprehensive blockchain state information.
  
- **Tests**
	- Improved test coverage by adding assertions to validate the new `sha3Uncles` and `stateRoot` fields in block retrieval tests.
	- Added a new integration test to validate interaction with the Ethereum client, ensuring correct block retrieval and state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->