### PR TITLE
Increase `batchRequestLimit` and `batchResponseMaxSize` constants

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -60,7 +60,7 @@ type Server struct {
 const (
 	shutdownTimeout      = 5 * time.Second
 	batchRequestLimit    = 50
-	batchResponseMaxSize = 10 * 1000 * 1000 // 5 MB
+	batchResponseMaxSize = 10 * 1000 * 1000 // 10 MB
 )
 
 func NewServer(

--- a/api/server.go
+++ b/api/server.go
@@ -59,8 +59,8 @@ type Server struct {
 
 const (
 	shutdownTimeout      = 5 * time.Second
-	batchRequestLimit    = 5
-	batchResponseMaxSize = 5 * 1000 * 1000 // 5 MB
+	batchRequestLimit    = 50
+	batchResponseMaxSize = 10 * 1000 * 1000 // 5 MB
 )
 
 func NewServer(

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -300,22 +300,25 @@ it('can make batch requests', async () => {
         { jsonrpc: '2.0', id: 5, result: '0x3' }
     )
 
-    // The maximum number of batch requests is 5,
-    // so this next batch should fail.
-    let getTransactionCount = {
-        jsonrpc: '2.0',
-        id: 6,
-        method: 'eth_getTransactionCount',
-        params: ['0x658Bdf435d810C91414eC09147DAA6DB62406379', 'latest'],
+    for (let i = 0; i <= 50; i++) {
+        let getTransactionCount = {
+            jsonrpc: '2.0',
+            id: 6 + i,
+            method: 'eth_getTransactionCount',
+            params: ['0x658Bdf435d810C91414eC09147DAA6DB62406379', 'latest'],
+        }
+        batch.add(getTransactionCount)
     }
 
-    batch.add(getTransactionCount)
-
+    let error = null
     try {
+        // The maximum number of batch requests is 25,
+        // so this next batch should fail.
         results = await batch.execute()
-    } catch (error) {
-        assert.equal(error.innerError[0].message, 'batch too large')
+    } catch (err) {
+        error = err
     }
+    assert.equal(error.innerError[0].message, 'batch too large')
 })
 
 it('get fee history', async () => {


### PR DESCRIPTION
## Description

The Flow Wallet Team mentioned that they do **25+** calls in a batch request.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Increased batch request limit from 5 to 50, allowing for more requests to be processed simultaneously.
	- Expanded maximum batch response size from 5 MB to 10 MB, enhancing data transfer capabilities.

- **Bug Fixes**
	- Improved test coverage for batch request handling, ensuring proper error handling when exceeding the new request limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->