### PR TITLE
Bugfix locking on logs filters

### DIFF
--- a/api/pull.go
+++ b/api/pull.go
@@ -221,6 +221,10 @@ func (api *PullAPI) UninstallFilter(id rpc.ID) bool {
 	api.mux.Lock()
 	defer api.mux.Unlock()
 
+	return api.uninstallFilter(id)
+}
+
+func (api *PullAPI) uninstallFilter(id rpc.ID) bool {
 	if _, ok := api.filters[id]; !ok { // not found
 		return false
 	}
@@ -301,7 +305,7 @@ func (api *PullAPI) GetFilterLogs(
 	}
 
 	if filter.expired() {
-		api.UninstallFilter(id)
+		api.uninstallFilter(id)
 		return nil, fmt.Errorf("%w: filter by id %s has expired", errs.ErrEntityNotFound, id)
 	}
 
@@ -352,7 +356,7 @@ func (api *PullAPI) GetFilterChanges(ctx context.Context, id rpc.ID) (any, error
 	}
 
 	if f.expired() {
-		api.UninstallFilter(id)
+		api.uninstallFilter(id)
 		return nil, fmt.Errorf("%w: filter by id %s has expired", errs.ErrEntityNotFound, id)
 	}
 


### PR DESCRIPTION
Prevent dead-lock on the log filters
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of expired filters by ensuring the correct method is called for uninstallation.
  
- **Refactor**
	- Enhanced code organization by separating the locking mechanism from the filter removal logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->