### PR TITLE
Revert "Revert "Decode legacy block event""

### DIFF
--- a/models/block.go
+++ b/models/block.go
@@ -61,6 +61,10 @@ func (b *Block) Hash() (gethCommon.Hash, error) {
 func decodeBlockEvent(event cadence.Event) (*Block, error) {
 	payload, err := events.DecodeBlockEventPayload(event)
 	if err != nil {
+		if block, err := decodeLegacyBlockEvent(event); err == nil {
+			return block, nil
+		}
+
 		return nil, fmt.Errorf("failed to cadence decode block [%s]: %w", event.String(), err)
 	}
 
@@ -74,6 +78,39 @@ func decodeBlockEvent(event cadence.Event) (*Block, error) {
 			TransactionHashRoot: payload.TransactionHashRoot,
 			TotalGasUsed:        payload.TotalGasUsed,
 			PrevRandao:          payload.PrevRandao,
+		},
+	}, nil
+}
+
+// todo remove this after updated in flow-go
+type blockEventPayloadV0 struct {
+	Height              uint64          `cadence:"height"`
+	Hash                gethCommon.Hash `cadence:"hash"`
+	Timestamp           uint64          `cadence:"timestamp"`
+	TotalSupply         cadence.Int     `cadence:"totalSupply"`
+	TotalGasUsed        uint64          `cadence:"totalGasUsed"`
+	ParentBlockHash     gethCommon.Hash `cadence:"parentHash"`
+	ReceiptRoot         gethCommon.Hash `cadence:"receiptRoot"`
+	TransactionHashRoot gethCommon.Hash `cadence:"transactionHashRoot"`
+}
+
+// DecodeBlockEventPayload decodes Cadence event into block event payload.
+func decodeLegacyBlockEvent(event cadence.Event) (*Block, error) {
+	var block blockEventPayloadV0
+	err := cadence.DecodeFields(event, &block)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Block{
+		Block: &types.Block{
+			ParentBlockHash:     block.ParentBlockHash,
+			Height:              block.Height,
+			Timestamp:           block.Timestamp,
+			TotalSupply:         block.TotalSupply.Value,
+			ReceiptRoot:         block.ReceiptRoot,
+			TransactionHashRoot: block.TransactionHashRoot,
+			TotalGasUsed:        block.TotalGasUsed,
 		},
 	}, nil
 }


### PR DESCRIPTION
This was merged too early, the original PR was not released under flow-go v0.37.0. We need to wait for next flow-go release before merging.


Reverts onflow/flow-evm-gateway#476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for decoding legacy block events, enhancing backward compatibility.
	- Added a new function to handle legacy block event decoding.
	- Defined a new struct to represent the legacy block event payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->