### PR TITLE
Simplify usage of `FixedHash` field on `Block` type

### DIFF
--- a/models/block.go
+++ b/models/block.go
@@ -28,8 +28,7 @@ func GenesisBlock(chainID flow.ChainID) *Block {
 
 func NewBlockFromBytes(data []byte) (*Block, error) {
 	var b *Block
-	err := rlp.DecodeBytes(data, &b)
-	if err != nil {
+	if err := rlp.DecodeBytes(data, &b); err != nil {
 		pastBlock, err := decodeBlockBreakingChanges(data)
 		if err != nil {
 			return nil, err
@@ -37,10 +36,6 @@ func NewBlockFromBytes(data []byte) (*Block, error) {
 		b = pastBlock
 	}
 
-	// this is added because RLP decoding will decode into an empty string
-	if b.FixedHash != nil && *b.FixedHash == "" {
-		b.FixedHash = nil
-	}
 	return b, nil
 }
 
@@ -51,10 +46,8 @@ type Block struct {
 	// will have more fields than before, so we make sure the hash we calculated
 	// with the previous format is fixed by assigning it to this field and then
 	// on hash calculation we check if this field is set we just return it.
-	// We must make the FixedHash exported so RLP encoding preserve it, and
-	// we must use string not common.Hash since RLP decoding has an issue
-	// with decoding into nil pointer slice.
-	FixedHash         *string
+	// We must make the FixedHash exported so RLP encoding preserves it.
+	FixedHash         gethCommon.Hash
 	TransactionHashes []gethCommon.Hash
 }
 
@@ -63,8 +56,8 @@ func (b *Block) ToBytes() ([]byte, error) {
 }
 
 func (b *Block) Hash() (gethCommon.Hash, error) {
-	if b.FixedHash != nil && *b.FixedHash != "" {
-		return gethCommon.HexToHash(*b.FixedHash), nil
+	if b.FixedHash != zeroGethHash {
+		return b.FixedHash, nil
 	}
 	return b.Block.Hash()
 }
@@ -81,13 +74,12 @@ func decodeBlockEvent(event cadence.Event) (*Block, *events.BlockEventPayload, e
 		)
 	}
 
-	var fixedHash *string
+	fixedHash := gethCommon.Hash{}
 	// If the `PrevRandao` field is the zero hash, we know that
 	// this is a block with the legacy format, and we need to
 	// fix its hash, due to the hash calculation breaking change.
 	if payload.PrevRandao == zeroGethHash {
-		hash := payload.Hash.String()
-		fixedHash = &hash
+		fixedHash = payload.Hash
 	}
 
 	return &Block{
@@ -115,7 +107,10 @@ type blockV0 struct {
 // the fields from the blockV0Fields type.
 func (b *blockV0) Hash() (gethCommon.Hash, error) {
 	data, err := b.Block.ToBytes()
-	return gethCrypto.Keccak256Hash(data), err
+	if err != nil {
+		return gethCommon.Hash{}, err
+	}
+	return gethCrypto.Keccak256Hash(data), nil
 }
 
 // blockV0Fields needed for decoding & computing the hash of blocks
@@ -136,12 +131,11 @@ func (b *blockV0Fields) ToBytes() ([]byte, error) {
 }
 
 // decodeBlockBreakingChanges will try to decode the bytes into all
-// previous versions of block type, if it succeeds it will return the
+// previous versions of block type. If it succeeds it will return the
 // migrated block, otherwise it will return the decoding error.
 func decodeBlockBreakingChanges(encoded []byte) (*Block, error) {
 	b0 := &blockV0{}
-	err := rlp.DecodeBytes(encoded, b0)
-	if err != nil {
+	if err := rlp.DecodeBytes(encoded, b0); err != nil {
 		return nil, err
 	}
 
@@ -149,7 +143,6 @@ func decodeBlockBreakingChanges(encoded []byte) (*Block, error) {
 	if err != nil {
 		return nil, err
 	}
-	h := blockHash.String()
 
 	return &Block{
 		Block: &types.Block{
@@ -161,7 +154,7 @@ func decodeBlockBreakingChanges(encoded []byte) (*Block, error) {
 			TransactionHashRoot: b0.Block.TransactionHashRoot,
 			TotalGasUsed:        b0.Block.TotalGasUsed,
 		},
-		FixedHash:         &h,
+		FixedHash:         blockHash,
 		TransactionHashes: b0.TransactionHashes,
 	}, nil
 }

--- a/models/block_test.go
+++ b/models/block_test.go
@@ -32,6 +32,14 @@ func Test_DecodePastBlockFormat(t *testing.T) {
 	block, err := NewBlockFromBytes(blockBytes)
 	require.NoError(t, err)
 
+	blockHash, err := block.Hash()
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		gethCommon.HexToHash("0xcad79e3019da8014f623f351f01c88d1bcb4613352d4801548c6b07992fd1393"),
+		blockHash,
+	)
 	assert.Equal(
 		t,
 		gethCommon.HexToHash("0x05aa4a6edbcf6fa81178566596be1c7fff7b721615c8b3bbd14ff76d9c81ec9b"),
@@ -66,12 +74,12 @@ func Test_DecodePastBlockFormat(t *testing.T) {
 }
 
 func Test_FixedHashBlock(t *testing.T) {
-	fixed := gethCommon.HexToHash("0x2").String()
+	fixed := gethCommon.HexToHash("0x2")
 	block := Block{
 		Block: &types.Block{
 			Height: 1,
 		},
-		FixedHash: &fixed,
+		FixedHash: fixed,
 		TransactionHashes: []gethCommon.Hash{
 			gethCommon.HexToHash("0x3"),
 			gethCommon.HexToHash("0x4"),
@@ -80,7 +88,7 @@ func Test_FixedHashBlock(t *testing.T) {
 
 	h, err := block.Hash()
 	require.NoError(t, err)
-	assert.Equal(t, fixed, h.String())
+	assert.Equal(t, fixed, h)
 
 	data, err := block.ToBytes()
 	require.NoError(t, err)
@@ -91,7 +99,7 @@ func Test_FixedHashBlock(t *testing.T) {
 	// make sure fixed hash and transaction hashes persists after decoding
 	h, err = decoded.Hash()
 	require.NoError(t, err)
-	require.Equal(t, fixed, h.String())
+	require.Equal(t, fixed, h)
 	require.Equal(t, block.TransactionHashes, decoded.TransactionHashes)
 }
 

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -27,7 +27,7 @@ it('get block', async () => {
         block.transactionsRoot,
         '0x0000000000000000000000000000000000000000000000000000000000000000'
     )
-    assert.equal(block.size, 3995n)
+    assert.equal(block.size, 4028n)
     assert.equal(block.gasLimit, 120000000n)
     assert.equal(block.miner, '0x0000000000000000000000030000000000000000')
     assert.equal(


### PR DESCRIPTION
## Description

It is safer/simpler to use the `gethCommon.Hash` type for `FixedHash`, instead of a `*string`.
All we have to do is check that `FixedHash` is not the empty hash.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved handling of block hashes, enhancing performance and clarity.
	- Updated block size assertions in tests to reflect changes in blockchain data.
	- Enhanced event handling capabilities by allowing storage and retrieval of additional payload information related to block and transaction events.
	- Introduced functionality for managing and providing access to blockchain block snapshots within the replayer service.

- **Bug Fixes**
	- Enhanced validation of block hashes in test functions to ensure accuracy and reliability.
	- Streamlined error handling and configuration parsing logic for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->