### PR TITLE
EVM script execution caching

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -95,7 +95,7 @@ type Config struct {
 	MetricsPort int
 	// IndexOnly configures the gateway to not accept any transactions but only queries of the state
 	IndexOnly bool
-	// Cache size
+	// Cache size in units of items in cache, one unit in cache takes approximately 64 bytes
 	CacheSize uint
 }
 
@@ -147,7 +147,7 @@ func FromFlags() (*Config, error) {
 	flag.Uint64Var(&cfg.RateLimit, "rate-limit", 50, "Rate-limit requests per second made by the client over any protocol (ws/http)")
 	flag.StringVar(&cfg.AddressHeader, "address-header", "", "Address header that contains the client IP, this is useful when the server is behind a proxy that sets the source IP of the client. Leave empty if no proxy is used.")
 	flag.Uint64Var(&cfg.HeartbeatInterval, "heartbeat-interval", 100, "Heartbeat interval for AN event subscription")
-	flag.UintVar(&cfg.CacheSize, "script-cache-size", 1000, "Cache size used for script execution in items kept in cache")
+	flag.UintVar(&cfg.CacheSize, "script-cache-size", 10000, "Cache size used for script execution in items kept in cache")
 	flag.IntVar(&streamTimeout, "stream-timeout", 3, "Defines the timeout in seconds the server waits for the event to be sent to the client")
 	flag.Uint64Var(&forceStartHeight, "force-start-height", 0, "Force set starting Cadence height. WARNING: This should only be used locally or for testing, never in production.")
 	flag.StringVar(&filterExpiry, "filter-expiry", "5m", "Filter defines the time it takes for an idle filter to expire")

--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,8 @@ type Config struct {
 	MetricsPort int
 	// IndexOnly configures the gateway to not accept any transactions but only queries of the state
 	IndexOnly bool
+	// Cache size
+	CacheSize uint
 }
 
 func FromFlags() (*Config, error) {
@@ -145,6 +147,7 @@ func FromFlags() (*Config, error) {
 	flag.Uint64Var(&cfg.RateLimit, "rate-limit", 50, "Rate-limit requests per second made by the client over any protocol (ws/http)")
 	flag.StringVar(&cfg.AddressHeader, "address-header", "", "Address header that contains the client IP, this is useful when the server is behind a proxy that sets the source IP of the client. Leave empty if no proxy is used.")
 	flag.Uint64Var(&cfg.HeartbeatInterval, "heartbeat-interval", 100, "Heartbeat interval for AN event subscription")
+	flag.UintVar(&cfg.CacheSize, "script-cache-size", 1000, "Cache size used for script execution in items kept in cache")
 	flag.IntVar(&streamTimeout, "stream-timeout", 3, "Defines the timeout in seconds the server waits for the event to be sent to the client")
 	flag.Uint64Var(&forceStartHeight, "force-start-height", 0, "Force set starting Cadence height. WARNING: This should only be used locally or for testing, never in production.")
 	flag.StringVar(&filterExpiry, "filter-expiry", "5m", "Filter defines the time it takes for an idle filter to expire")

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cockroachdb/pebble v1.1.1
 	github.com/goccy/go-json v0.10.2
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/onflow/atree v0.8.0-rc.6
 	github.com/onflow/cadence v1.0.0-preview.52
 	github.com/onflow/flow-go v0.37.10
@@ -88,7 +89,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/holiman/uint256 v1.3.0 // indirect

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -849,12 +849,14 @@ func cacheKey(scriptType scriptType, height uint64, args []cadence.Value) string
 		if len(args) != 1 {
 			return ""
 		}
-		key = fmt.Sprintf("%s%s", key, args[0].String())
+		v := args[0].(cadence.String)
+		key = fmt.Sprintf("%s%s", key, string(v))
 	case getNonce:
 		if len(args) != 1 {
 			return ""
 		}
-		key = fmt.Sprintf("%s%s", key, args[0].String())
+		v := args[0].(cadence.String)
+		key = fmt.Sprintf("%s%s", key, string(v))
 	case getLatest:
 		// no additional arguments
 	default:

--- a/services/requester/requester_test.go
+++ b/services/requester/requester_test.go
@@ -106,7 +106,7 @@ func Test_Caching(t *testing.T) {
 		}
 
 		// wait for cache expiry
-		time.Sleep(cacheExpiry)
+		time.Sleep(cacheExpiry + 100*time.Millisecond)
 
 		require.Equal(t, 0, cache.Len()) // make sure cache is empty
 

--- a/services/requester/requester_test.go
+++ b/services/requester/requester_test.go
@@ -1,12 +1,187 @@
 package requester
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/onflow/cadence"
+	"github.com/onflow/flow-go-sdk/access/mocks"
+	flowGo "github.com/onflow/flow-go/model/flow"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-evm-gateway/config"
 )
+
+func Test_Caching(t *testing.T) {
+	t.Run("Get balance at height cached", func(t *testing.T) {
+		mockClient := &mocks.Client{}
+
+		cache := expirable.NewLRU[string, cadence.Value](1000, nil, time.Second)
+		e := createEVM(t, cache, mockClient)
+
+		height := uint64(100)
+		address, _ := cadence.NewString("123")
+		balance := cadence.NewInt(1)
+
+		mockClient.
+			On("ExecuteScriptAtBlockHeight", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(balance, nil).
+			Once()
+
+		require.Equal(t, 0, cache.Len()) // empty cache
+
+		// first request goes through the above mock client,
+		// additional requests should be processed with cache, note the above mock client
+		// is only set to once, so if cache is a miss it would fail to call the client again
+		for i := 0; i < 5; i++ {
+			val, err := e.executeScriptAtHeight(context.Background(), getBalance, height, []cadence.Value{address})
+			require.NoError(t, err)
+			require.Equal(t, balance, val)
+			// cache should be filled
+			require.Equal(t, 1, cache.Len())
+		}
+	})
+
+	t.Run("Get balance at latest height cached", func(t *testing.T) {
+		mockClient := &mocks.Client{}
+
+		cache := expirable.NewLRU[string, cadence.Value](1000, nil, time.Second)
+		e := createEVM(t, cache, mockClient)
+
+		height := LatestBlockHeight
+		address, _ := cadence.NewString("123")
+		balance := cadence.NewInt(1)
+
+		mockClient.
+			On("ExecuteScriptAtLatestBlock", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(balance, nil).
+			Once()
+
+		require.Equal(t, 0, cache.Len()) // empty cache
+
+		// first request goes through the above mock client,
+		// additional requests should be processed with cache, note the above mock client
+		// is only set to once, so if cache is a miss it would fail to call the client again
+		for i := 0; i < 5; i++ {
+			val, err := e.executeScriptAtHeight(context.Background(), getBalance, height, []cadence.Value{address})
+			require.NoError(t, err)
+			require.Equal(t, balance, val)
+			// cache should be filled
+			require.Equal(t, 1, cache.Len())
+		}
+	})
+
+	t.Run("Get balance cache expires and is added again", func(t *testing.T) {
+		mockClient := &mocks.Client{}
+
+		cacheExpiry := time.Millisecond * 100
+		cache := expirable.NewLRU[string, cadence.Value](1000, nil, cacheExpiry)
+		e := createEVM(t, cache, mockClient)
+
+		height := LatestBlockHeight
+		address, _ := cadence.NewString("123")
+		balance := cadence.NewInt(1)
+
+		mockClient.
+			On("ExecuteScriptAtLatestBlock", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(balance, nil).
+			Once()
+
+		require.Equal(t, 0, cache.Len()) // empty cache
+
+		// first request goes through the above mock client,
+		// additional requests should be processed with cache, note the above mock client
+		// is only set to once, so if cache is a miss it would fail to call the client again
+		for i := 0; i < 5; i++ {
+			val, err := e.executeScriptAtHeight(context.Background(), getBalance, height, []cadence.Value{address})
+			require.NoError(t, err)
+			require.Equal(t, balance, val)
+			// cache should be filled
+			require.Equal(t, 1, cache.Len())
+		}
+
+		// wait for cache expiry
+		time.Sleep(cacheExpiry)
+
+		require.Equal(t, 0, cache.Len()) // make sure cache is empty
+
+		// re-set the mock
+		mockClient.
+			On("ExecuteScriptAtLatestBlock", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(balance, nil).
+			Once()
+		val, err := e.executeScriptAtHeight(context.Background(), getBalance, height, []cadence.Value{address})
+		require.NoError(t, err)
+		require.Equal(t, balance, val)
+		require.Equal(t, 1, cache.Len())
+	})
+
+	t.Run("Get balance multiple addresses and heights", func(t *testing.T) {
+		mockClient := &mocks.Client{}
+
+		cache := expirable.NewLRU[string, cadence.Value](1000, nil, time.Second)
+		e := createEVM(t, cache, mockClient)
+
+		type acc struct {
+			height  uint64
+			address cadence.String
+			balance cadence.Int
+		}
+
+		tests := []acc{{
+			height:  100,
+			address: cadence.String("123"),
+			balance: cadence.NewInt(2),
+		}, {
+			height:  101,
+			address: cadence.String("222"),
+			balance: cadence.NewInt(1),
+		}, {
+			height:  102,
+			address: cadence.String("333"),
+			balance: cadence.NewInt(4),
+		}, {
+			height:  104,
+			address: cadence.String("444"),
+			balance: cadence.NewInt(3),
+		}, {
+			height:  105,
+			address: cadence.String("555"),
+			balance: cadence.NewInt(5),
+		}}
+
+		for i, test := range tests {
+			mockClient.
+				On("ExecuteScriptAtBlockHeight", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				Return(test.balance, nil).
+				Once()
+
+			val, err := e.executeScriptAtHeight(context.Background(), getBalance, test.height, []cadence.Value{test.address})
+			require.NoError(t, err)
+			require.Equal(t, test.balance, val)
+			// cache should be filled
+			require.Equal(t, i+1, cache.Len())
+		}
+
+		require.Equal(t, len(tests), cache.Len())
+
+		// first request goes through the above mock client,
+		// additional requests should be processed with cache, note the above mock client
+		// is only set to once, so if cache is a miss it would fail to call the client again
+		for _, test := range tests {
+			val, err := e.executeScriptAtHeight(context.Background(), getBalance, test.height, []cadence.Value{test.address})
+			require.NoError(t, err)
+			require.Equal(t, test.balance, val)
+			// cache should be filled
+			require.Equal(t, len(tests), cache.Len())
+		}
+	})
+}
 
 func Test_CacheKey(t *testing.T) {
 	addr, _ := cadence.NewString("0x1")
@@ -33,4 +208,21 @@ func Test_CacheKey(t *testing.T) {
 	key = cacheKey(getBalance, LatestBlockHeight, []cadence.Value{addr, addr})
 	require.Equal(t, "", key)
 
+}
+
+func createEVM(t *testing.T, cache *expirable.LRU[string, cadence.Value], mockClient *mocks.Client) *EVM {
+	networkID := flowGo.Emulator
+	log := zerolog.New(zerolog.NewTestWriter(t))
+
+	client, err := NewCrossSporkClient(mockClient, nil, log, networkID)
+	require.NoError(t, err)
+
+	return &EVM{
+		client:      client,
+		logger:      log,
+		scriptCache: cache,
+		config: &config.Config{
+			FlowNetworkID: networkID,
+		},
+	}
 }

--- a/services/requester/requester_test.go
+++ b/services/requester/requester_test.go
@@ -134,24 +134,24 @@ func Test_Caching(t *testing.T) {
 		}
 
 		tests := []acc{{
-			height:  100,
-			address: cadence.String("123"),
-			balance: cadence.NewInt(2),
+			height:  1002233,
+			address: cadence.String("1AC87F33D10b76E8BDd4fb501445A5ec413eb121"),
+			balance: cadence.NewInt(23958395),
 		}, {
-			height:  101,
-			address: cadence.String("222"),
+			height:  2002233,
+			address: cadence.String("A3014d9F6162a162BAD9Ff15346A4B82A56F841f"),
 			balance: cadence.NewInt(1),
 		}, {
-			height:  102,
-			address: cadence.String("333"),
+			height:  3002233,
+			address: cadence.String("53e6A4b36a56CB68fe54661416Be2c5b3Ee193c9"),
 			balance: cadence.NewInt(4),
 		}, {
-			height:  104,
-			address: cadence.String("444"),
+			height:  4002233,
+			address: cadence.String("839fEfa0750798B3A0BD9c925871e3f5027a5d44"),
 			balance: cadence.NewInt(3),
 		}, {
-			height:  105,
-			address: cadence.String("555"),
+			height:  7002233,
+			address: cadence.String("243a064089cF765E1F270B90913Db31cdDf299F5"),
 			balance: cadence.NewInt(5),
 		}}
 

--- a/services/requester/requester_test.go
+++ b/services/requester/requester_test.go
@@ -1,0 +1,36 @@
+package requester
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/onflow/cadence"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CacheKey(t *testing.T) {
+	addr, _ := cadence.NewString("0x1")
+	h := uint64(100)
+
+	key := cacheKey(getBalance, h, []cadence.Value{addr})
+	require.Equal(t, fmt.Sprintf("%d%d%s", getBalance, h, string(addr)), key)
+
+	key = cacheKey(getBalance, LatestBlockHeight, []cadence.Value{addr})
+	require.Equal(t, fmt.Sprintf("%d%d%s", getBalance, LatestBlockHeight, string(addr)), key)
+
+	key = cacheKey(getNonce, LatestBlockHeight, []cadence.Value{addr})
+	require.Equal(t, fmt.Sprintf("%d%d%s", getNonce, LatestBlockHeight, string(addr)), key)
+
+	key = cacheKey(getNonce, h, []cadence.Value{addr})
+	require.Equal(t, fmt.Sprintf("%d%d%s", getNonce, h, string(addr)), key)
+
+	key = cacheKey(getLatest, LatestBlockHeight, nil)
+	require.Equal(t, fmt.Sprintf("%d%d", getLatest, LatestBlockHeight), key)
+
+	key = cacheKey(getCode, LatestBlockHeight, nil)
+	require.Equal(t, "", key)
+
+	key = cacheKey(getBalance, LatestBlockHeight, []cadence.Value{addr, addr})
+	require.Equal(t, "", key)
+
+}


### PR DESCRIPTION
## Description
Add support for caching on the EVM requester so it offloads the ANs.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a caching mechanism for script execution results, improving performance and reducing redundant executions.
  - Added a new categorization for script operations to streamline handling of different script types.
  - Enhanced configuration capabilities by allowing users to specify cache size through command-line arguments.

- **Bug Fixes**
  - Enhanced error handling within the script execution process to ensure successful results are cached.

- **Tests**
  - Implemented a comprehensive suite of unit tests to validate the new caching functionality and ensure robust performance across various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->