### PR TITLE
Increase trace download retry limit

### DIFF
--- a/services/traces/downloader.go
+++ b/services/traces/downloader.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-const downloadTimeout = 5 * time.Minute
+const downloadTimeout = 15 * time.Minute
 
 type Downloader interface {
 	// Download traces or returning an error with the failure

--- a/services/traces/downloader.go
+++ b/services/traces/downloader.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-const downloadTimeout = 15 * time.Minute
+const downloadTimeout = 60 * time.Minute
 
 type Downloader interface {
 	// Download traces or returning an error with the failure


### PR DESCRIPTION
Increase trace download retry limit, there were some issues with the network and we missed some traces because they were uploaded later. The retry sequence in seconds look like this right now: `1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased download timeout from 5 minutes to 60 minutes, enhancing reliability for trace downloads, especially under poor network conditions or with large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->