### PR TITLE
Crasher on validation of args for `eth_estimateGas`

### DIFF
--- a/api/models.go
+++ b/api/models.go
@@ -63,7 +63,7 @@ func (txArgs TransactionArgs) Validate() error {
 		// e.g. https://github.com/onflow/go-ethereum/issues/16106.
 		if txDataLen == 0 {
 			// Prevent sending ether into black hole (show stopper)
-			if txArgs.Value.ToInt().Cmp(big.NewInt(0)) > 0 {
+			if txArgs.Value != nil && txArgs.Value.ToInt().Cmp(big.NewInt(0)) > 0 {
 				return errs.NewInvalidTransactionError(
 					errors.New("transaction will create a contract with value but empty code"),
 				)

--- a/api/models_test.go
+++ b/api/models_test.go
@@ -80,6 +80,18 @@ func TestValidateTransaction(t *testing.T) {
 			valid:  false,
 			errMsg: "transaction will create a contract with empty code",
 		},
+		"create empty contract (nil value)": {
+			txArgs: TransactionArgs{
+				Nonce:    (*hexutil.Uint64)(&nonce),
+				To:       nil,
+				Value:    nil,
+				Gas:      (*hexutil.Uint64)(&gasLimit),
+				GasPrice: (*hexutil.Big)(big.NewInt(0)),
+				Data:     &hexutil.Bytes{},
+			},
+			valid:  false,
+			errMsg: "transaction will create a contract with empty code",
+		},
 		"create empty contract (with value)": {
 			txArgs: TransactionArgs{
 				Nonce:    (*hexutil.Uint64)(&nonce),

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -331,6 +331,20 @@ func TestValidateTransaction(t *testing.T) {
 			valid:  false,
 			errMsg: "transaction will create a contract with empty code",
 		},
+		"create empty contract (nil value)": {
+			tx: gethTypes.NewTx(
+				&gethTypes.LegacyTx{
+					Nonce:    1,
+					To:       nil,
+					Value:    nil,
+					Gas:      53_000,
+					GasPrice: big.NewInt(0),
+					Data:     []byte{},
+				},
+			),
+			valid:  false,
+			errMsg: "transaction will create a contract with empty code",
+		},
 		"create empty contract (with value)": {
 			tx: gethTypes.NewTx(
 				&gethTypes.LegacyTx{


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/525

## Description

Add `nil` check for transaction `Value` field.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation logic to prevent transactions from being sent to invalid addresses, improving overall transaction safety.
  
- **Bug Fixes**
	- Added safeguards against nil values in transaction arguments to prevent potential runtime errors.

- **Tests**
	- Introduced new test cases to validate handling of transactions with nil values, ensuring robust error messaging and validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->