### PR TITLE
Fix flaky E2E test for EVM state building

### DIFF
--- a/tests/web3js/build_evm_state_test.js
+++ b/tests/web3js/build_evm_state_test.js
@@ -41,7 +41,10 @@ it('should handle a large number of EVM interactions', async () => {
     let senderBalance = await web3.eth.getBalance(conf.eoa.address)
     assert.equal(senderBalance, 1999999999937000000n)
 
-    let transferAmounts = ['0.01', '0.03', '0.05']
+    // Each EOA has a 0.15 ether, so the below transfer amounts
+    // should never add up to that, or the transfer transaction
+    // will revert.
+    let transferAmounts = ['0.01', '0.02', '0.04']
     for (let i = 0; i < eoaCount; i++) {
         let sender = accounts[i]
 


### PR DESCRIPTION
## Description

The random values for the transfer amount, cannot be equal to `0.15` ether, as that is the balance of the test EOAs, and it will cause the transfer transaction to be reverted.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted transfer amounts in the EVM interaction test to prevent exceeding account balances, ensuring test validity.
  
- **Tests**
	- Updated test case to reflect new transfer amounts, maintaining the integrity of the simulation for Ethereum transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->