### PR TITLE
Response returned from `eth_getBlockReceipts` endpoint is not properly marshalled

### DIFF
--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -1,6 +1,7 @@
 const web3Utils = require('web3-utils')
 const { assert } = require('chai')
 const conf = require('./config')
+const helpers = require('./helpers')
 const web3 = conf.web3
 
 it('get chain ID', async () => {
@@ -82,6 +83,29 @@ it('get block', async () => {
     // not existing transaction
     let no = await web3.eth.getTransactionFromBlock(conf.startBlockHeight, 5)
     assert.isNull(no)
+})
+
+it('should get block receipts', async () => {
+    let height = await web3.eth.getBlockNumber()
+    assert.equal(height, conf.startBlockHeight)
+
+    let block = await web3.eth.getBlock(height)
+    let response = await helpers.callRPCMethod('eth_getBlockReceipts', [block.hash])
+    assert.equal(response.status, 200)
+
+    let blockReceipts = response.body.result
+    assert.lengthOf(blockReceipts, 3)
+
+    for (let blockReceipt of blockReceipts) {
+        let response = await helpers.callRPCMethod(
+            'eth_getTransactionReceipt',
+            [blockReceipt.transactionHash]
+        )
+        assert.equal(response.status, 200)
+
+        let txReceipt = response.body.result
+        assert.deepEqual(blockReceipt, txReceipt)
+    }
 })
 
 it('should get block transaction count', async () => {

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -2,6 +2,7 @@ const web3Utils = require('web3-utils')
 const { assert } = require('chai')
 const conf = require('./config')
 const helpers = require('./helpers')
+const web3types = require('web3-types')
 const web3 = conf.web3
 
 it('get chain ID', async () => {
@@ -97,13 +98,18 @@ it('should get block receipts', async () => {
     assert.lengthOf(blockReceipts, 3)
 
     for (let blockReceipt of blockReceipts) {
-        let response = await helpers.callRPCMethod(
-            'eth_getTransactionReceipt',
-            [blockReceipt.transactionHash]
+        let txReceipt = await web3.eth.getTransactionReceipt(
+            blockReceipt.transactionHash,
+            web3types.ETH_DATA_FORMAT
         )
-        assert.equal(response.status, 200)
+        // normalize missing fields from transaction receipt
+        if (txReceipt.to === undefined) {
+            txReceipt.to = null
+        }
+        if (txReceipt.contractAddress === undefined) {
+            txReceipt.contractAddress = null
+        }
 
-        let txReceipt = response.body.result
         assert.deepEqual(blockReceipt, txReceipt)
     }
 })


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/531

## Description

We were not using the `MarshalReceipt` method, which is used for `eth_getTransactionReceipt`, and the various fields had inconsistent representations.
The proper representation can be found in: https://docs.infura.io/api/networks/ethereum/json-rpc-methods/eth_getblockreceipts

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `GetBlockReceipts` method to improve data representation and flexibility in API responses.
	- Introduced a new test case to validate the retrieval and consistency of block receipts and their corresponding transaction receipts.

- **Bug Fixes**
	- Improved error handling and logic for fetching transaction details within the `GetBlockReceipts` method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->