### PR TITLE
Receipts for deployments with COAs have `contractAddress` and `to` fields present

### DIFF
--- a/models/transaction.go
+++ b/models/transaction.go
@@ -69,6 +69,11 @@ func (dc DirectCall) From() (common.Address, error) {
 }
 
 func (dc DirectCall) To() *common.Address {
+	// for contract deployments, `to` should always be `nil`
+	if dc.SubType == types.DeployCallSubType {
+		return nil
+	}
+
 	var to *common.Address
 	if !dc.DirectCall.EmptyToField() {
 		ct := dc.DirectCall.To.ToCommon()

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -62,6 +62,17 @@ it('get block', async () => {
         assert.equal(txReceipt.blockHash, block.hash)
         assert.isString(txReceipt.transactionHash)
         assert.equal(txReceipt.transactionIndex, txIndex)
+        assert.isNotNull(txReceipt.from)
+
+        // first transaction is the COA resource creation,
+        // which also does the contract deployment
+        if (txIndex == 0) {
+            assert.isNotNull(txReceipt.contractAddress)
+            assert.isUndefined(txReceipt.to)
+        } else {
+            assert.isUndefined(txReceipt.contractAddress)
+            assert.isNotNull(txReceipt.to)
+        }
 
         gasUsed += txReceipt.gasUsed
     }


### PR DESCRIPTION
## Description

When the `contractAddress` field is present, the `to` field should be absent, as per the JSON-RPC API specification for transaction receipts.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 