### PR TITLE
Filter-related endpoints return `null` result instead of empty array

### DIFF
--- a/tests/web3js/eth_filter_endpoints_test.js
+++ b/tests/web3js/eth_filter_endpoints_test.js
@@ -39,14 +39,18 @@ describe('eth_uninstallFilter', async () => {
 })
 
 describe('eth_getFilterLogs', async () => {
-    it('should return null for missing filter', async () => {
+    it('should return an error for missing filter', async () => {
         let response = await helpers.callRPCMethod('eth_getFilterLogs', ['0xffa1'])
 
         assert.equal(response.status, 200)
-        assert.isNull(response.body.result)
+        assert.isDefined(response.body.error)
+        assert.equal(
+            response.body.error.message,
+            'filter by id 0xffa1 does not exist'
+        )
     })
 
-    it('should return null for expired filter', async () => {
+    it('should return an error for expired filter', async () => {
         let response = await helpers.callRPCMethod(
             'eth_newFilter',
             [{ 'address': contractAddress }]
@@ -63,7 +67,11 @@ describe('eth_getFilterLogs', async () => {
         response = await helpers.callRPCMethod('eth_getFilterLogs', [filterID])
 
         assert.equal(response.status, 200)
-        assert.isNull(response.body.result)
+        assert.isDefined(response.body.error)
+        assert.equal(
+            response.body.error.message,
+            'filter by id ' + filterID + ' has expired'
+        )
     })
 
     it('should return error message for non-logs filter', async () => {
@@ -157,14 +165,18 @@ describe('eth_getFilterLogs', async () => {
 })
 
 describe('eth_getFilterChanges', async () => {
-    it('should return null for missing filter', async () => {
+    it('should return an error for missing filter', async () => {
         let response = await helpers.callRPCMethod('eth_getFilterChanges', ['0xffa1'])
 
         assert.equal(response.status, 200)
-        assert.isNull(response.body.result)
+        assert.isDefined(response.body.error)
+        assert.equal(
+            response.body.error.message,
+            'filter by id 0xffa1 does not exist'
+        )
     })
 
-    it('should return null for expired filter', async () => {
+    it('should return an error for expired filter', async () => {
         let response = await helpers.callRPCMethod(
             'eth_newFilter',
             [{ 'address': contractAddress }]
@@ -181,7 +193,11 @@ describe('eth_getFilterChanges', async () => {
         response = await helpers.callRPCMethod('eth_getFilterChanges', [filterID])
 
         assert.equal(response.status, 200)
-        assert.isNull(response.body.result)
+        assert.isDefined(response.body.error)
+        assert.equal(
+            response.body.error.message,
+            'filter by id ' + filterID + ' has expired'
+        )
     })
 
     it('should return empty array when there are no logs', async () => {


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/545

## Description

When a filter does not exist or has expired, we should return a proper error message, instead of a `null` result.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved error handling for filter-related API methods, providing clearer feedback for users when filters are missing or expired.

- **Bug Fixes**
	- Updated tests to ensure accurate error responses are returned for missing or expired filters, enhancing the reliability of the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->