### PR TITLE
Event recovery from a missing block

### DIFF
--- a/models/errors/errors.go
+++ b/models/errors/errors.go
@@ -19,10 +19,12 @@ var (
 
 	// General errors
 
-	ErrInternal     = errors.New("internal error")
-	ErrInvalid      = errors.New("invalid")
-	ErrRecoverable  = errors.New("recoverable")
-	ErrDisconnected = NewRecoverableError(errors.New("disconnected"))
+	ErrInternal            = errors.New("internal error")
+	ErrInvalid             = errors.New("invalid")
+	ErrRecoverable         = errors.New("recoverable")
+	ErrDisconnected        = NewRecoverableError(errors.New("disconnected"))
+	ErrMissingBlock        = errors.New("missing block")
+	ErrMissingTransactions = errors.New("missing transactions")
 
 	// Transaction errors
 

--- a/services/ingestion/subscriber.go
+++ b/services/ingestion/subscriber.go
@@ -267,12 +267,12 @@ func (r *RPCSubscriber) blocksFilter() flow.EventFilter {
 	}
 }
 
-// fetchBlockEvents is used as a backup mechanism for fetching EVM-related
+// fetchMissingData is used as a backup mechanism for fetching EVM-related
 // events, when the event streaming API returns an inconsistent response.
 // An inconsistent response could be an EVM block that references EVM
 // transactions which are not present in the response. It falls back
 // to using grpc requests instead of streaming.
-func (r *RPCSubscriber) fetchBlockEvents(
+func (r *RPCSubscriber) fetchMissingData(
 	ctx context.Context,
 	blockEvents flow.BlockEvents,
 ) models.BlockEvents {
@@ -337,7 +337,7 @@ func (r *RPCSubscriber) recover(ctx context.Context, events flow.BlockEvents, er
 
 	switch {
 	case errors.Is(err, errs.ErrMissingTransactions):
-		return r.fetchBlockEvents(ctx, events)
+		return r.fetchMissingData(ctx, events)
 	case errors.Is(err, errs.ErrMissingBlock):
 		return r.accumulateEventsMissingBlock(events)
 	}

--- a/services/ingestion/subscriber.go
+++ b/services/ingestion/subscriber.go
@@ -2,6 +2,7 @@ package ingestion
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/onflow/cadence/runtime/common"
@@ -33,6 +34,9 @@ type RPCSubscriber struct {
 	chain             flowGo.ChainID
 	heartbeatInterval uint64
 	logger            zerolog.Logger
+
+	recovery        bool
+	recoveredEvents []flow.Event
 }
 
 func NewRPCSubscriber(
@@ -107,26 +111,26 @@ func (r *RPCSubscriber) Subscribe(ctx context.Context, height uint64) <-chan mod
 // Subscribing to EVM specific events and handle any disconnection errors
 // as well as context cancellations.
 func (r *RPCSubscriber) subscribe(ctx context.Context, height uint64, opts ...access.SubscribeOption) <-chan models.BlockEvents {
-	events := make(chan models.BlockEvents)
+	eventsChan := make(chan models.BlockEvents)
 
 	_, err := r.client.GetBlockHeaderByHeight(ctx, height)
 	if err != nil {
 		err = fmt.Errorf("failed to subscribe for events, the block height %d doesn't exist: %w", height, err)
-		events <- models.NewBlockEventsError(err)
-		return events
+		eventsChan <- models.NewBlockEventsError(err)
+		return eventsChan
 	}
 
-	evs, errChan, err := r.client.SubscribeEventsByBlockHeight(ctx, height, r.blocksFilter(), opts...)
+	eventStream, errChan, err := r.client.SubscribeEventsByBlockHeight(ctx, height, r.blocksFilter(), opts...)
 	if err != nil {
-		events <- models.NewBlockEventsError(
+		eventsChan <- models.NewBlockEventsError(
 			fmt.Errorf("failed to subscribe to events by block height: %d, with: %w", height, err),
 		)
-		return events
+		return eventsChan
 	}
 
 	go func() {
 		defer func() {
-			close(events)
+			close(eventsChan)
 		}()
 
 		for ctx.Err() == nil {
@@ -135,30 +139,28 @@ func (r *RPCSubscriber) subscribe(ctx context.Context, height uint64, opts ...ac
 				r.logger.Info().Msg("event ingestion received done signal")
 				return
 
-			case blockEvents, ok := <-evs:
+			case blockEvents, ok := <-eventStream:
 				if !ok {
 					var err error
 					err = errs.ErrDisconnected
 					if ctx.Err() != nil {
 						err = ctx.Err()
 					}
-					events <- models.NewBlockEventsError(err)
+					eventsChan <- models.NewBlockEventsError(err)
 					return
 				}
 
-				evts := models.NewBlockEvents(blockEvents)
-				if evts.Err != nil {
-					r.logger.Warn().Err(err).Msgf(
-						"failed to parse EVM block events for Flow height: %d, retrying with gRPC API...",
-						blockEvents.Height,
-					)
-					// call the `GetEventsForHeightRange` gRPC API endpoint to fetch
-					// the EVM-related events, when event streaming returned an
-					// inconsistent response.
-					events <- r.fetchBlockEvents(ctx, blockEvents)
-				} else {
-					events <- models.NewBlockEvents(blockEvents)
+				evmEvents := models.NewBlockEvents(blockEvents)
+				// if events contain an error, or we are in a recovery mode
+				if evmEvents.Err != nil || r.recovery {
+					evmEvents = r.recover(ctx, blockEvents, evmEvents.Err)
+					// if we are still in recovery go to the next event
+					if r.recovery {
+						continue
+					}
 				}
+
+				eventsChan <- evmEvents
 
 			case err, ok := <-errChan:
 				if !ok {
@@ -167,17 +169,17 @@ func (r *RPCSubscriber) subscribe(ctx context.Context, height uint64, opts ...ac
 					if ctx.Err() != nil {
 						err = ctx.Err()
 					}
-					events <- models.NewBlockEventsError(err)
+					eventsChan <- models.NewBlockEventsError(err)
 					return
 				}
 
-				events <- models.NewBlockEventsError(fmt.Errorf("%w: %w", errs.ErrDisconnected, err))
+				eventsChan <- models.NewBlockEventsError(fmt.Errorf("%w: %w", errs.ErrDisconnected, err))
 				return
 			}
 		}
 	}()
 
-	return events
+	return eventsChan
 }
 
 // backfill will use the provided height and with the client for the provided spork will start backfilling
@@ -268,19 +270,15 @@ func (r *RPCSubscriber) blocksFilter() flow.EventFilter {
 // fetchBlockEvents is used as a backup mechanism for fetching EVM-related
 // events, when the event streaming API returns an inconsistent response.
 // An inconsistent response could be an EVM block that references EVM
-// transactions which are not present in the response.
-// Under the hood, it uses the `GetEventsForHeightRange` gRPC API endpoint,
-// making sure that we receive the expected events length for each event type
-// and Flow height.
+// transactions which are not present in the response. It falls back
+// to using grpc requests instead of streaming.
 func (r *RPCSubscriber) fetchBlockEvents(
 	ctx context.Context,
 	blockEvents flow.BlockEvents,
 ) models.BlockEvents {
-	blkEvents := flow.BlockEvents{
-		BlockID:        blockEvents.BlockID,
-		Height:         blockEvents.Height,
-		BlockTimestamp: blockEvents.BlockTimestamp,
-	}
+	// remove existing events
+	blockEvents.Events = nil
+
 	for _, eventType := range r.blocksFilter().EventTypes {
 		recoveredEvents, err := r.client.GetEventsForHeightRange(
 			ctx,
@@ -302,8 +300,47 @@ func (r *RPCSubscriber) fetchBlockEvents(
 			)
 		}
 
-		blkEvents.Events = append(blkEvents.Events, recoveredEvents[0].Events...)
+		blockEvents.Events = append(blockEvents.Events, recoveredEvents[0].Events...)
 	}
 
-	return models.NewBlockEvents(blkEvents)
+	return models.NewBlockEvents(blockEvents)
+}
+
+// accumulateEventsMissingBlock will keep receiving transaction events until it can produce a valid
+// EVM block event containing a block and transactions. At that point it will reset the recovery mode
+// and return the valid block events.
+func (r *RPCSubscriber) accumulateEventsMissingBlock(events flow.BlockEvents) models.BlockEvents {
+	r.recoveredEvents = append(r.recoveredEvents, events.Events...)
+	events.Events = r.recoveredEvents
+
+	recovered := models.NewBlockEvents(events)
+	r.recovery = recovered.Err != nil
+
+	if !r.recovery {
+		r.recoveredEvents = nil
+	}
+
+	return recovered
+}
+
+// recover tries to recover from an invalid data sent over the event stream.
+//
+// An invalid data can be a cause of corrupted index or network issue from the source,
+// in which case we might miss one of the events (missing transaction), or it can be
+// due to a failure from the system transaction which commits an EVM block, which results
+// in missing EVM block event but present transactions.
+func (r *RPCSubscriber) recover(ctx context.Context, events flow.BlockEvents, err error) models.BlockEvents {
+	r.logger.Error().Err(err).Msgf(
+		"failed to parse EVM block events for Flow height: %d, entering recovery",
+		events.Height,
+	)
+
+	switch {
+	case errors.Is(err, errs.ErrMissingTransactions):
+		return r.fetchBlockEvents(ctx, events)
+	case errors.Is(err, errs.ErrMissingBlock):
+		return r.accumulateEventsMissingBlock(events)
+	}
+
+	return models.NewBlockEventsError(err)
 }

--- a/services/ingestion/subscriber_test.go
+++ b/services/ingestion/subscriber_test.go
@@ -97,16 +97,17 @@ func Test_MissingBlockEvent(t *testing.T) {
 			blockCdc, _, blockEvent, _ := newBlock(i, []gethCommon.Hash{tx.Hash()})
 
 			if i == foundBlockHeight {
+				missingHashes = append(missingHashes, tx.Hash())
 				blockCdc, _, _, _ = newBlock(i, missingHashes)
 			}
 
 			blockEvents := []flow.Event{
-				{Value: blockCdc, Type: string(txEvent.Etype)},
-				{Value: txCdc, Type: string(blockEvent.Etype)},
+				{Value: txCdc, Type: string(txEvent.Etype)},
+				{Value: blockCdc, Type: string(blockEvent.Etype)},
 			}
 
 			if i > missingBlockHeight && i < foundBlockHeight {
-				blockEvents = blockEvents[1:] // remove block
+				blockEvents = blockEvents[:1] // remove block
 				missingHashes = append(missingHashes, tx.Hash())
 			}
 


### PR DESCRIPTION
## Description
Recover from a missing block in the event stream. This can happen due to issues with system transactions.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new error types for improved error handling: `ErrMissingBlock` and `ErrMissingTransactions`.
	- Enhanced `RPCSubscriber` functionality with recovery mechanisms for event subscription.
	- Added a new test case to validate subscriber behavior for missing block events.

- **Bug Fixes**
	- Improved error messages for better clarity and context in event decoding.

- **Refactor**
	- Renamed `fetchBlockEvents` to `fetchMissingData` for better clarity.
	- Added methods for accumulating and recovering missing events.
	- Streamlined event generation process in test utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->