### PR TITLE
Update constant for block gas limit

### DIFF
--- a/api/encode_transaction.go
+++ b/api/encode_transaction.go
@@ -9,7 +9,7 @@ import (
 	errs "github.com/onflow/flow-evm-gateway/models/errors"
 )
 
-const blockGasLimit uint64 = 15_000_000
+const blockGasLimit uint64 = 120_000_000
 
 // encodeTxFromArgs will create a transaction from the given arguments.
 // The resulting unsigned transaction is only supposed to be used through

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -28,6 +28,7 @@ it('get block', async () => {
         '0x0000000000000000000000000000000000000000000000000000000000000000'
     )
     assert.equal(block.size, 3995n)
+    assert.equal(block.gasLimit, 120000000n)
     assert.equal(block.miner, '0x0000000000000000000000030000000000000000')
     assert.equal(
         block.sha3Uncles,
@@ -379,7 +380,7 @@ it('get fee history', async () => {
             oldestBlock: 1n,
             reward: [['0x96'], ['0x96']], // gas price is 150 during testing
             baseFeePerGas: [0n, 0n],
-            gasUsedRatio: [0, 0.04964366666666667]
+            gasUsedRatio: [0, 0.006205458333333334]
         }
     )
 })


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/558

## Description

Update the constant's value to `120M`, as that is the theoretical block gas limit.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased the `blockGasLimit` to support larger transactions.
  
- **Bug Fixes**
	- Enhanced test cases to ensure accurate block retrieval and fee history, including gas limit assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->