### PR TITLE
Remove `--evm-enabled` flag in README.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Operating an EVM Gateway is straightforward. It can either be deployed locally a
 
 To run the gateway locally you need to start the emulator with EVM enabled:
 ```
-flow emulator --evm-enabled
+flow emulator
 ```
 _Make sure flow.json has the emulator account configured to address and private key we will use for starting gateway bellow._
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Operating an EVM Gateway is straightforward. It can either be deployed locally a
 ### Running Locally
 **Start Emulator**
 
-To run the gateway locally you need to start the emulator with EVM enabled:
+To run the gateway locally you need to start the Flow Emulator:
 ```
 flow emulator
 ```


### PR DESCRIPTION
## Description

The `--evm-enabled` flag has been removed from the flow emulator

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated instructions for running the EVM Gateway locally, simplifying the command to start the emulator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->