### PR TITLE
Add metric for indexed cadence block height

### DIFF
--- a/metrics/nop.go
+++ b/metrics/nop.go
@@ -15,6 +15,7 @@ var NopCollector = &nopCollector{}
 func (c *nopCollector) ApiErrorOccurred()                        {}
 func (c *nopCollector) TraceDownloadFailed()                     {}
 func (c *nopCollector) ServerPanicked(string)                    {}
+func (c *nopCollector) CadenceHeightIndexed(uint64)              {}
 func (c *nopCollector) EVMHeightIndexed(uint64)                  {}
 func (c *nopCollector) EVMAccountInteraction(string)             {}
 func (c *nopCollector) MeasureRequestDuration(time.Time, string) {}

--- a/services/ingestion/engine.go
+++ b/services/ingestion/engine.go
@@ -206,6 +206,7 @@ func (e *Engine) processEvents(events *models.CadenceEvents) error {
 	}
 
 	e.collector.EVMHeightIndexed(events.Block().Height)
+	e.collector.CadenceHeightIndexed(events.CadenceHeight())
 	return nil
 }
 


### PR DESCRIPTION
Closes: #570

## Description

Add metric for latest cadence block height

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to index Cadence block heights, enhancing metrics collection capabilities.
	- Added functionality to the event processing engine to track Cadence heights alongside existing metrics.
  
- **Bug Fixes**
	- Improved the handling of Cadence height events in the metrics collector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->