### PR TITLE
Add cadence mtric collection on empty block as well

### DIFF
--- a/services/ingestion/engine.go
+++ b/services/ingestion/engine.go
@@ -161,6 +161,7 @@ func (e *Engine) processEvents(events *models.CadenceEvents) error {
 				err,
 			)
 		}
+		e.collector.CadenceHeightIndexed(events.CadenceHeight())
 		return nil // nothing else to do this was heartbeat event with not event payloads
 	}
 


### PR DESCRIPTION
Closes: #???

## Description

Related to https://github.com/onflow/flow-evm-gateway/pull/571

I missed collecting metrics when the cadence block does not include a evm block.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced event processing to record cadence height for heartbeat events without payloads.
  
- **Bug Fixes**
	- Improved reliability of event handling within the ingestion engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->