### PR TITLE
Add profiler server for pprof

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,14 @@ start:
 start-local:
 	rm -rf db/
 	rm -rf metrics/data/
-	go run cmd/main/main.go --flow-network-id=flow-emulator --coinbase=FACF71692421039876a5BB4F10EF7A439D8ef61E --coa-address=f8d6e0586b0a20c7 --coa-key=2619878f0e2ff438d17835c2a4561cb87b4d24d72d12ec34569acd0dd4af7c21 --wallet-api-key=2619878f0e2ff438d17835c2a4561cb87b4d24d72d12ec34569acd0dd4af7c21 --coa-resource-create=true --gas-price=0 --log-writer=console
+	go run cmd/main/main.go \
+		--flow-network-id=flow-emulator \
+		--coinbase=FACF71692421039876a5BB4F10EF7A439D8ef61E \
+		--coa-address=f8d6e0586b0a20c7 \
+		--coa-key=2619878f0e2ff438d17835c2a4561cb87b4d24d72d12ec34569acd0dd4af7c21 \
+		--wallet-api-key=2619878f0e2ff438d17835c2a4561cb87b4d24d72d12ec34569acd0dd4af7c21 \
+		--coa-resource-create=true \
+		--gas-price=0 \
+		--log-writer=console \
+		--profiler-enabled=true \
+		--profiler-port=6060

--- a/README.md
+++ b/README.md
@@ -172,40 +172,43 @@ Running the EVM gateway for mainnet requires additional security and stability m
 
 The application can be configured using the following flags at runtime:
 
-| Flag                         | Default Value                   | Description                                                                                                                                                          |
-|------------------------------|---------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `database-dir`               | `./db`                          | Path to the directory for the database                                                                                                                               |
-| `rpc-host`                   | `""`                            | Host for the RPC API server                                                                                                                                          |
-| `rpc-port`                   | `8545`                          | Port for the RPC API server                                                                                                                                          |
-| `ws-enabled`                 | `false`                         | Enable websocket connections                                                                                                                                         |
-| `access-node-grpc-host`      | `localhost:3569`                | Host to the flow access node gRPC API                                                                                                                                |
-| `access-node-spork-hosts`    | `""`                            | Previous spork AN hosts, defined as a comma-separated list (e.g. `"host-1.com,host2.com"`)                                                                             |
-| `evm-network-id`             | `testnet   `                    | EVM network ID (options: `testnet`, `mainnet`)                                                                                                         |
-| `flow-network-id`            | `flow-emulator`                 | Flow network ID (options: `flow-emulator`, `flow-testnet`, `flow-mainnet`)                                                                                       |
-| `coinbase`                   | `""`                            | Coinbase address to use for fee collection                                                                                                                           |
-| `init-cadence-height`        | `0`                             | Cadence block height to start indexing; avoid using on a new network                                                                                                 |
-| `gas-price`                  | `1`                             | Static gas price for EVM transactions                                                                                                                                |
-| `coa-address`                | `""`                            | Flow address holding COA account for submitting transactions                                                                                                         |
-| `coa-key`                    | `""`                            | Private key for the COA address used for transactions                                                                                                                |
-| `coa-key-file`               | `""`                            | Path to a JSON file of COA keys for key-rotation (exclusive with `coa-key` flag)                                                                                     |
-| `coa-resource-create`        | `false`                         | Auto-create the COA resource if it doesn't exist in the Flow COA account                                                                                             |
-| `coa-cloud-kms-project-id`   | `""`                            | Project ID for KMS keys (e.g. `flow-evm-gateway`)                                                                                                                    |
-| `coa-cloud-kms-location-id`  | `""`                            | Location ID for KMS key ring (e.g. 'global')                                                                                                                         |
-| `coa-cloud-kms-key-ring-id`  | `""`                            | Key ring ID for KMS keys (e.g. 'tx-signing')                                                                                                                         |
-| `coa-cloud-kms-keys`         | `""`                            | KMS keys and versions, comma-separated (e.g. `"gw-key-6@1,gw-key-7@1"`)                                                                                                |
-| `log-level`                  | `debug`                         | Log verbosity level (`debug`, `info`, `warn`, `error`, `fatal`, `panic`)                                                                                             |
-| `log-writer`                 | `stderr`                        | Output method for logs (`stderr`, `console`)                                                                                                                         |
-| `stream-limit`               | `10`                            | Rate-limit for client events sent per second                                                                                                                         |
-| `rate-limit`                 | `50`                            | Requests per second limit for clients over any protocol (ws/http)                                                                                                    |
-| `address-header`             | `""`                            | Header for client IP when server is behind a proxy                                                                                                                   |
-| `heartbeat-interval`         | `100`                           | Interval for AN event subscription heartbeats                                                                                                                        |
-| `stream-timeout`             | `3`                             | Timeout in seconds for sending events to clients                                                                                                                     |
-| `force-start-height`         | `0`                             | Force-set starting Cadence height (local/testing use only)                                                                                                           |
-| `wallet-api-key`             | `""`                            | ECDSA private key for wallet APIs (local/testing use only)                                                                                                           |
-| `filter-expiry`              | `5m`                            | Expiry time for idle filters                                                                                                                                         |
-| `traces-gcp-bucket`          | `""`                            | GCP bucket name for transaction traces                                                                                                                               |
-| `prometheus-config-file-path`| `./metrics/prometheus.yml`      | Path to the Prometheus configuration file                                                                                                                            |
-| `index-only`                 | `false`                         | Run in index-only mode, allowing state queries and indexing but no transaction sending                                                                               |
+| Flag                         | Default Value                   | Description                                                                              |
+|------------------------------|---------------------------------|------------------------------------------------------------------------------------------|
+| `database-dir`               | `./db`                          | Path to the directory for the database                                                   |
+| `rpc-host`                   | `""`                            | Host for the RPC API server                                                              |
+| `rpc-port`                   | `8545`                          | Port for the RPC API server                                                              |
+| `ws-enabled`                 | `false`                         | Enable websocket connections                                                             |
+| `access-node-grpc-host`      | `localhost:3569`                | Host to the flow access node gRPC API                                                    |
+| `access-node-spork-hosts`    | `""`                            | Previous spork AN hosts, defined as a comma-separated list (e.g. `"host-1.com,host2.com"`) |
+| `evm-network-id`             | `testnet   `                    | EVM network ID (options: `testnet`, `mainnet`)                                           |
+| `flow-network-id`            | `flow-emulator`                 | Flow network ID (options: `flow-emulator`, `flow-testnet`, `flow-mainnet`)               |
+| `coinbase`                   | `""`                            | Coinbase address to use for fee collection                                               |
+| `init-cadence-height`        | `0`                             | Cadence block height to start indexing; avoid using on a new network                     |
+| `gas-price`                  | `1`                             | Static gas price for EVM transactions                                                    |
+| `coa-address`                | `""`                            | Flow address holding COA account for submitting transactions                             |
+| `coa-key`                    | `""`                            | Private key for the COA address used for transactions                                    |
+| `coa-key-file`               | `""`                            | Path to a JSON file of COA keys for key-rotation (exclusive with `coa-key` flag)         |
+| `coa-resource-create`        | `false`                         | Auto-create the COA resource if it doesn't exist in the Flow COA account                 |
+| `coa-cloud-kms-project-id`   | `""`                            | Project ID for KMS keys (e.g. `flow-evm-gateway`)                                        |
+| `coa-cloud-kms-location-id`  | `""`                            | Location ID for KMS key ring (e.g. 'global')                                             |
+| `coa-cloud-kms-key-ring-id`  | `""`                            | Key ring ID for KMS keys (e.g. 'tx-signing')                                             |
+| `coa-cloud-kms-keys`         | `""`                            | KMS keys and versions, comma-separated (e.g. `"gw-key-6@1,gw-key-7@1"`)                  |
+| `log-level`                  | `debug`                         | Log verbosity level (`debug`, `info`, `warn`, `error`, `fatal`, `panic`)                 |
+| `log-writer`                 | `stderr`                        | Output method for logs (`stderr`, `console`)                                             |
+| `stream-limit`               | `10`                            | Rate-limit for client events sent per second                                             |
+| `rate-limit`                 | `50`                            | Requests per second limit for clients over any protocol (ws/http)                        |
+| `address-header`             | `""`                            | Header for client IP when server is behind a proxy                                       |
+| `heartbeat-interval`         | `100`                           | Interval for AN event subscription heartbeats                                            |
+| `stream-timeout`             | `3`                             | Timeout in seconds for sending events to clients                                         |
+| `force-start-height`         | `0`                             | Force-set starting Cadence height (local/testing use only)                               |
+| `wallet-api-key`             | `""`                            | ECDSA private key for wallet APIs (local/testing use only)                               |
+| `filter-expiry`              | `5m`                            | Expiry time for idle filters                                                             |
+| `traces-gcp-bucket`          | `""`                            | GCP bucket name for transaction traces                                                   |
+| `prometheus-config-file-path`| `./metrics/prometheus.yml`      | Path to the Prometheus configuration file                                                |
+| `index-only`                 | `false`                         | Run in index-only mode, allowing state queries and indexing but no transaction sending   |
+| `profiler-enabled`           | `false`                         | Enable the pprof profiler server                                                         |
+| `profiler-host`              | `localhost`                     | Host for the pprof profiler                                                              |
+| `profiler-port`              | `6060`                          | Port for the pprof profiler                                                              |
 
 # Deploying
 Deploying the EVM Gateway node comes with some prerequisites as well as expectations and they are best explained in the WIP document: https://flowfoundation.notion.site/EVM-Gateway-Deployment-3c41da6710af40acbaf971e22ce0a9fd
@@ -252,6 +255,25 @@ The EVM Gateway implements APIs according to the Ethereum specification: https:/
 - Access Lists: we don't yet support creating access lists as they don't affect the fees we charge. We might support this in the future
   to optimize fees, but it currently is not part of our priorities. 
 
+# Debugging
+
+## Profiler
+
+The EVM Gateway supports profiling via the `pprof` package. To enable profiling, add the following flags to the command line:
+```
+--profiler-enabled=true
+--profiler-host=localhost
+--profiler-port=6060
+```
+
+This will start a pprof server on the provide host:port. You can generate profiles using the following `go tool` commands
+```
+go tool pprof -http :2000 http://localhost:6060/debug/pprof/profile
+```
+```
+curl --output trace.out http://localhost:6060/debug/pprof/trace
+go tool trace -http :2001 trace.out
+```
 
 # Contributing
 We welcome contributions from the community! Please read our [Contributing Guide](./CONTRIBUTING.md) for information on how to get involved.

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ The EVM Gateway supports profiling via the `pprof` package. To enable profiling,
 --profiler-port=6060
 ```
 
-This will start a pprof server on the provide host:port. You can generate profiles using the following `go tool` commands
+This will start a pprof server on the provided `host` and `port`. You can generate profiles using the following `go tool` commands
 ```
 go tool pprof -http :2000 http://localhost:6060/debug/pprof/profile
 ```

--- a/api/profiler.go
+++ b/api/profiler.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	_ "net/http/pprof"
+	"strconv"
+
+	"github.com/rs/zerolog"
+)
+
+type ProfileServer struct {
+	logger   zerolog.Logger
+	server   *http.Server
+	endpoint string
+}
+
+func NewProfileServer(
+	logger zerolog.Logger,
+	host string,
+	port int,
+) *ProfileServer {
+	endpoint := net.JoinHostPort(host, strconv.Itoa(port))
+	return &ProfileServer{
+		logger:   logger,
+		server:   &http.Server{Addr: endpoint},
+		endpoint: endpoint,
+	}
+}
+
+func (h *ProfileServer) ListenAddr() string {
+	return h.endpoint
+}
+
+func (s *ProfileServer) Start() {
+	go func() {
+		err := s.server.ListenAndServe()
+		if err != nil {
+			if errors.Is(err, http.ErrServerClosed) {
+				s.logger.Warn().Msg("Profiler server shutdown")
+				return
+			}
+			s.logger.Err(err).Msg("failed to start Profiler server")
+			panic(err)
+		}
+	}()
+}
+
+func (s *ProfileServer) Stop() error {
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	return s.server.Shutdown(ctx)
+}
+
+func (s *ProfileServer) Close() error {
+	return s.server.Close()
+}

--- a/config/config.go
+++ b/config/config.go
@@ -97,6 +97,12 @@ type Config struct {
 	IndexOnly bool
 	// Cache size in units of items in cache, one unit in cache takes approximately 64 bytes
 	CacheSize uint
+	// ProfilerEnabled sets whether the profiler server is enabled
+	ProfilerEnabled bool
+	// ProfilerHost is the host for the profiler server will listen to (e.g. localhost, 0.0.0.0)
+	ProfilerHost string
+	// ProfilerPort is the port for the profiler server
+	ProfilerPort int
 }
 
 func FromFlags() (*Config, error) {
@@ -159,6 +165,9 @@ func FromFlags() (*Config, error) {
 	flag.StringVar(&walletKey, "wallet-api-key", "", "ECDSA private key used for wallet APIs. WARNING: This should only be used locally or for testing, never in production.")
 	flag.IntVar(&cfg.MetricsPort, "metrics-port", 9091, "Port for the metrics server")
 	flag.BoolVar(&cfg.IndexOnly, "index-only", false, "Run the gateway in index-only mode which only allows querying the state and indexing, but disallows sending transactions.")
+	flag.BoolVar(&cfg.ProfilerEnabled, "profiler-enabled", false, "Run the profiler server to capture pprof data.")
+	flag.StringVar(&cfg.ProfilerHost, "profiler-host", "localhost", "Host for the Profiler server")
+	flag.IntVar(&cfg.ProfilerPort, "profiler-port", 6060, "Port for the Profiler server")
 	flag.Parse()
 
 	if coinbase == "" {


### PR DESCRIPTION
Closes: #???

## Description

Add a profiler to the gateway

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced profiling capabilities with new configuration flags: `profiler-enabled`, `profiler-host`, and `profiler-port`.
	- Added instructions in the README for enabling and using the profiling feature.

- **Documentation**
	- Updated README for clarity on new configuration flags and profiling instructions.

- **Bug Fixes**
	- Improved command readability in the Makefile for starting the local environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->