### PR TITLE
Use the released tag version to identify newly-created docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 env:
-  DOCKER_IMAGE_URL: ${{ vars.REPO_DOCKER_IMAGE_URL }}:${{ github.sha }}
+  DOCKER_IMAGE_URL: ${{ vars.REPO_DOCKER_IMAGE_URL }}
 
 jobs:
   build:
@@ -19,6 +19,10 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Set Gateway Version
+        id: set_version
+        run: echo "GATEWAY_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo 'unknown')" >> $GITHUB_OUTPUT
 
       - name: Google auth
         id: auth
@@ -36,5 +40,5 @@ jobs:
       - name: Docker Auth
         run: |-
           gcloud auth configure-docker ${{ vars.GAR_LOCATION }}-docker.pkg.dev
-          docker build -t ${{ env.DOCKER_IMAGE_URL }} --build-arg GATEWAY_VERSION=$(git describe --tags --abbrev=0 2>/dev/null) --file Dockerfile .
-          docker push ${{ env.DOCKER_IMAGE_URL }}
+          docker build -t ${{ env.DOCKER_IMAGE_URL }}:${{ steps.set_version.outputs.GATEWAY_VERSION }} --build-arg GATEWAY_VERSION=${{ steps.set_version.outputs.GATEWAY_VERSION }} --file Dockerfile .
+          docker push ${{ env.DOCKER_IMAGE_URL }}:${{ steps.set_version.outputs.GATEWAY_VERSION }}


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/489

## Description

The new docker image URL will include the released tag version, instead of a git commit hash, e.g.:
```bash
us-west1-docker.pkg.dev/dl-flow-devex-production/development/flow-evm-gateway:v0.36.3
```
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated the Docker build process to utilize a new environment variable for versioning.
	- Streamlined the versioning mechanism for Docker images by referencing Git tags.
	- Added a new step to set the gateway version, enhancing clarity and maintainability of the build workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->