### PR TITLE
Add the EVM GW version to log lines

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -57,7 +57,8 @@ type Bootstrap struct {
 
 func New(config *config.Config) (*Bootstrap, error) {
 	logger := zerolog.New(config.LogWriter).
-		With().Timestamp().Logger().Level(config.LogLevel)
+		With().Timestamp().Str("version", api.Version).
+		Logger().Level(config.LogLevel)
 
 	client, err := setupCrossSporkClient(config, logger)
 	if err != nil {


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/594

## Description

For each log line, we include the released version that is running:
```json
{
    "level": "debug",
    "version": "v0.36.4",
    "component": "API",
    "id": 4,
    "jsonrpc": "2.0",
    "method": "eth_call",
    "params": [
        {
            "from": "0x658bdf435d810c91414ec09147daa6db62406379",
            "gas": "0x76c0",
            "gasPrice": "0x0",
            "input": "0xc6888fa10000000000000000000000000000000000000000000000000000000000000006",
            "to": "0x99466ed2e37b892a2ee3e9cd55a98b68f5735db2",
            "value": "0x0"
        },
        "latest"
    ],
    "result": "0x000000000000000000000000000000000000000000000000000000000000002a",
    "time": "2024-09-30T09:38:33+03:00",
    "message": "API response"
}
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 