### PR TITLE
Add quick balance cache to test if it helps with load on mainnet

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -250,7 +250,7 @@ func getCacheKey(address common.Address, evmHeight int64) common.Hash {
 	// hash is 32 bytes
 	// address (20 bytes) + int64 (8 bytes) = 28 bytes total
 	keyData := address.Bytes()
-	binary.BigEndian.AppendUint64(keyData, uint64(evmHeight))
+	keyData = binary.BigEndian.AppendUint64(keyData, uint64(evmHeight))
 	return common.BytesToHash(keyData)
 }
 


### PR DESCRIPTION
Closes: #???

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Implemented a caching mechanism for balance retrieval, improving performance and reducing load times.
- **Bug Fixes**
	- Enhanced the accuracy of balance data by ensuring it is retrieved efficiently from the cache or underlying source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->