### PR TITLE
Avoid logging debug info for invalid JSON-RPC methods

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -32,6 +32,67 @@ import (
 
 const maxFeeHistoryBlockCount = 1024
 
+// A map containing all the valid method names that are found
+// in the Ethereum JSON-RPC API specification.
+// Update accordingly if any new methods are added/removed.
+var validMethods = map[string]struct{}{
+	// eth namespace
+	"eth_blockNumber":                         {},
+	"eth_syncing":                             {},
+	"eth_sendRawTransaction":                  {},
+	"eth_getBalance":                          {},
+	"eth_getTransactionByHash":                {},
+	"eth_getTransactionByBlockHashAndIndex":   {},
+	"eth_getTransactionByBlockNumberAndIndex": {},
+	"eth_getTransactionReceipt":               {},
+	"eth_getBlockByHash":                      {},
+	"eth_getBlockByNumber":                    {},
+	"eth_getBlockReceipts":                    {},
+	"eth_getBlockTransactionCountByHash":      {},
+	"eth_getBlockTransactionCountByNumber":    {},
+	"eth_call":                                {},
+	"eth_getLogs":                             {},
+	"eth_getTransactionCount":                 {},
+	"eth_estimateGas":                         {},
+	"eth_getCode":                             {},
+	"eth_feeHistory":                          {},
+	"eth_getStorageAt":                        {},
+	"eth_chainId":                             {},
+	"eth_coinbase":                            {},
+	"eth_gasPrice":                            {},
+	"eth_getUncleCountByBlockHash":            {},
+	"eth_getUncleCountByBlockNumber":          {},
+	"eth_getUncleByBlockHashAndIndex":         {},
+	"eth_getUncleByBlockNumberAndIndex":       {},
+	"eth_maxPriorityFeePerGas":                {},
+	"eth_mining":                              {},
+	"eth_hashrate":                            {},
+	"eth_getProof":                            {},
+	"eth_createAccessList":                    {},
+
+	// web3 namespace
+	"web3_clientVersion": {},
+	"web3_sha3":          {},
+
+	// net namespace
+	"net_listening": {},
+	"net_peerCount": {},
+	"net_version":   {},
+
+	// txpool namespace
+	"txpool_content":     {},
+	"txpool_contentFrom": {},
+	"txpool_status":      {},
+	"txpool_inspect":     {},
+}
+
+// Returns whether the given method name is a valid method from
+// the Ethereum JSON-RPC API specification.
+func IsValidMethod(methodName string) bool {
+	_, ok := validMethods[methodName]
+	return ok
+}
+
 var latestBlockNumberOrHash = rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 
 func SupportedAPIs(


### PR DESCRIPTION
## Description

When the EVM Gateway receives requests with unknown JSON-RPC methods, we still log the following two lines:
```json
{
    "level": "debug",
    "version": "development",
    "component": "API",
    "IP": "[::1]:60022",
    "url": "/",
    "id": 1,
    "jsonrpc": "2.0",
    "method": "eth_etc/passwd",
    "params": [],
    "is-ws": false,
    "time": "2024-10-08T17:08:57+03:00",
    "message": "API request"
}
{
    "level": "debug",
    "version": "development",
    "component": "API",
    "id": 1,
    "jsonrpc": "2.0",
    "method": "eth_etc/passwd",
    "params": [],
    "error": "the method eth_etc/passwd does not exist/is not available",
    "code": -32601,
    "data": null,
    "time": "2024-10-08T17:08:57+03:00",
    "message": "API error response"
}
```
This creates a lot of noise on the logged data, and in tools such as Grafana, so we completely avoid logging anything in this case.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method validation feature for JSON-RPC API, ensuring only valid methods are processed.

- **Improvements**
	- Enhanced logging capabilities for better tracking of JSON-RPC requests and responses.
	- Improved error handling in response management to filter known errors from logs.
	- Refined WebSocket request handling for improved clarity and organization.

- **Code Cleanup**
	- General code organization and formatting adjustments for clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->