### PR TITLE
Reuse block preparation logic in streaming API

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -292,6 +292,7 @@ func (b *Bootstrap) StartAPIServer(ctx context.Context) error {
 	streamAPI := api.NewStreamAPI(
 		b.logger,
 		b.config,
+		blockchainAPI,
 		b.storages.Blocks,
 		b.storages.Transactions,
 		b.storages.Receipts,


### PR DESCRIPTION
Closes: #???

Related to: https://github.com/onflow/flow-evm-gateway/issues/524

## Description

When using the go-ethereum client to stream block headers, I go this error:
`error: hex string has length 0, want 512 for Bloom`

This was because the code that produces the blocks that are returned does not include the bloom filter, and the stock go-ethereum client requires that the server returns a non-empy value.

The polling endpoint does include it as well as a few other fields. This PR updates the streaming endpoint to reuse the logic from the polling endpoint to generate the block responses.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `StreamAPI` functionality to better handle block notifications and responses through integration with the `BlockChainAPI`.
	- Improved error handling for block response preparation.
  
- **Bug Fixes**
	- Updated notification system for subscribers to reflect changes in block response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->