### PR TITLE
Use buffered channel for subscription errors

### DIFF
--- a/api/stream.go
+++ b/api/stream.go
@@ -145,7 +145,7 @@ func newSubscription[T any](
 
 	rpcSub := notifier.CreateSubscription()
 
-	subs := models.NewSubscription(callback(notifier, rpcSub))
+	subs := models.NewSubscription(logger, callback(notifier, rpcSub))
 
 	l := logger.With().
 		Str("gateway-subscription-id", fmt.Sprintf("%p", subs)).
@@ -160,7 +160,7 @@ func newSubscription[T any](
 		for {
 			select {
 			case err := <-subs.Error():
-				fmt.Println(err)
+				l.Debug().Err(err).Msg("subscription returned error")
 				return
 			case err := <-rpcSub.Err():
 				l.Debug().Err(err).Msg("client unsubscribed")

--- a/models/stream_test.go
+++ b/models/stream_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/onflow/flow-evm-gateway/models"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -115,7 +116,7 @@ func Test_Stream(t *testing.T) {
 		s := &mockSubscription{}
 		errContent := fmt.Errorf("failed to process data")
 
-		s.Subscription = models.NewSubscription[mockData](func(data mockData) error {
+		s.Subscription = models.NewSubscription[mockData](zerolog.Nop(), func(data mockData) error {
 			s.callCount.Add(1)
 			return errContent
 		})
@@ -149,7 +150,7 @@ type mockSubscription struct {
 
 func newMockSubscription() *mockSubscription {
 	s := &mockSubscription{}
-	s.Subscription = models.NewSubscription[mockData](func(data mockData) error {
+	s.Subscription = models.NewSubscription[mockData](zerolog.Nop(), func(data mockData) error {
 		s.callCount.Add(1)
 		return nil
 	})


### PR DESCRIPTION
Closes: #590

## Description

This is related to deadlock fix from: https://github.com/onflow/flow-evm-gateway/pull/602

This PR updates the subscription error channel to be buffered to handle the case where an error occurs before the listener goroutine is setup. It also updates the previous deadlock fix to log an error instead of panicking, as I think this creates an unnecessary DoS vector. Subscriptions losing errors is relatively benign and the logging will allow the operator to debug as needed.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 