### PR TITLE
Fix timeouts from E2E test regarding `eth_subscribe`

### DIFF
--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -190,12 +190,12 @@ func executeTest(t *testing.T, testFile string) {
 		}
 
 		out, err := cmd.CombinedOutput()
-		t.Log(string(out))
 
 		if err != nil {
+			t.Log(string(out))
 			var exitError *exec.ExitError
 			if errors.As(err, &exitError) {
-				if exitError.ExitCode() == 1 {
+				if exitError.ExitCode() >= 1 {
 					require.Fail(t, err.Error())
 				}
 				t.Fatalf("unknown test issue: %s, output: %s", err.Error(), string(out))


### PR DESCRIPTION
## Description

Adding any asserts to the JavaScript test file, resulted in a test timeout, due to:
```javascript
setTimeout(() => process.exit(1), 1000 * 120)
```
This was fixed, along with some other changes that made the test file less complex, by removing promises.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in test execution, ensuring more informative logging when errors occur.
	- Enhanced error handling for Web3 subscription events, simplifying the control flow and ensuring proper failure assertions.

- **New Features**
	- Reduced timeout for the failsafe mechanism in Web3 subscriptions from 120 seconds to 25 seconds. 

- **Style**
	- Standardized the use of single quotes for string literals in the Web3 testing code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->