### PR TITLE
Introduce dedicated `BlockHeader` type for usage in `newHeads` subscription endpoint

### DIFF
--- a/api/models.go
+++ b/api/models.go
@@ -291,6 +291,24 @@ type Block struct {
 	BaseFeePerGas    hexutil.Big      `json:"baseFeePerGas"`
 }
 
+type BlockHeader struct {
+	Number           hexutil.Uint64   `json:"number"`
+	Hash             common.Hash      `json:"hash"`
+	ParentHash       common.Hash      `json:"parentHash"`
+	Nonce            types.BlockNonce `json:"nonce"`
+	Sha3Uncles       common.Hash      `json:"sha3Uncles"`
+	LogsBloom        hexutil.Bytes    `json:"logsBloom"`
+	TransactionsRoot common.Hash      `json:"transactionsRoot"`
+	StateRoot        common.Hash      `json:"stateRoot"`
+	ReceiptsRoot     common.Hash      `json:"receiptsRoot"`
+	Miner            common.Address   `json:"miner"`
+	ExtraData        hexutil.Bytes    `json:"extraData"`
+	GasLimit         hexutil.Uint64   `json:"gasLimit"`
+	GasUsed          hexutil.Uint64   `json:"gasUsed"`
+	Timestamp        hexutil.Uint64   `json:"timestamp"`
+	Difficulty       hexutil.Uint64   `json:"difficulty"`
+}
+
 type SyncStatus struct {
 	StartingBlock hexutil.Uint64 `json:"startingBlock"`
 	CurrentBlock  hexutil.Uint64 `json:"currentBlock"`

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -292,7 +292,6 @@ func (b *Bootstrap) StartAPIServer(ctx context.Context) error {
 	streamAPI := api.NewStreamAPI(
 		b.logger,
 		b.config,
-		blockchainAPI,
 		b.storages.Blocks,
 		b.storages.Transactions,
 		b.storages.Receipts,


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/524

## Description

This will allow us to return only the necessary fields for `eth_subscribe("newHeads")` subscription endpoint.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new `BlockHeader` type for structured representation of Ethereum block header data.
	- Enhanced `StreamAPI` to prepare block headers more effectively and independently of the blockchain API.
	- Improved API server integration with streamlined setup for the `StreamAPI`.

- **Bug Fixes**
	- Updated error handling in `StreamAPI` for clearer messaging related to block header responses.

- **Tests**
	- Enhanced blockchain event subscription tests to validate block header properties against blockchain data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->