### PR TITLE
Output version info from version command to output channel

### DIFF
--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -1,6 +1,8 @@
 package version
 
 import (
+	"os"
+
 	"github.com/onflow/flow-evm-gateway/api"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -10,6 +12,7 @@ var Cmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the current version of the EVM Gateway Node",
 	Run: func(*cobra.Command, []string) {
-		log.Info().Str("version", api.Version).Msg("build details")
+		logger := log.Output(os.Stdout)
+		logger.Info().Str("version", api.Version).Msg("build details")
 	},
 }


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/624

## Description

Outputs the version info on `stdout`, instead of `stderr`. E.g.:
```bash
$ ./flow-evm-gateway version | grep version 
{"level":"info","version":"v0.36.5","time":"2024-10-24T12:45:02+03:00","message":"build details"}
```

```bash
$ ./flow-evm-gateway version | jq '.version'  
"v0.36.5"
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the logging mechanism to improve output clarity by directing logs to standard output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->