### PR TITLE
Implement `BlockSnapshotProvider` & `BlockSnapshot` interfaces

### DIFF
--- a/services/ingestion/engine_test.go
+++ b/services/ingestion/engine_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/onflow/flow-evm-gateway/metrics"
 	"github.com/onflow/flow-evm-gateway/services/ingestion/mocks"
+	"github.com/onflow/flow-evm-gateway/services/replayer"
 	"github.com/onflow/flow-evm-gateway/storage/pebble"
 
 	"github.com/onflow/cadence"
@@ -63,6 +64,7 @@ func TestSerialBlockIngestion(t *testing.T) {
 
 		engine := NewEventIngestionEngine(
 			subscriber,
+			replayer.NewBlocksProvider(blocks, flowGo.Emulator, nil),
 			store,
 			blocks,
 			receipts,
@@ -143,6 +145,7 @@ func TestSerialBlockIngestion(t *testing.T) {
 
 		engine := NewEventIngestionEngine(
 			subscriber,
+			replayer.NewBlocksProvider(blocks, flowGo.Emulator, nil),
 			store,
 			blocks,
 			receipts,
@@ -258,6 +261,7 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 
 		engine := NewEventIngestionEngine(
 			subscriber,
+			replayer.NewBlocksProvider(blocks, flowGo.Emulator, nil),
 			store,
 			blocks,
 			receipts,
@@ -361,6 +365,7 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 
 		engine := NewEventIngestionEngine(
 			subscriber,
+			replayer.NewBlocksProvider(blocks, flowGo.Emulator, nil),
 			store,
 			blocks,
 			receipts,
@@ -456,6 +461,7 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 
 		engine := NewEventIngestionEngine(
 			subscriber,
+			replayer.NewBlocksProvider(blocks, flowGo.Emulator, nil),
 			store,
 			blocks,
 			receipts,

--- a/services/replayer/blocks_provider.go
+++ b/services/replayer/blocks_provider.go
@@ -1,0 +1,112 @@
+package replayer
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-evm-gateway/models"
+	"github.com/onflow/flow-evm-gateway/storage"
+	evmTypes "github.com/onflow/flow-go/fvm/evm/types"
+	flowGo "github.com/onflow/flow-go/model/flow"
+	gethCommon "github.com/onflow/go-ethereum/common"
+	"github.com/onflow/go-ethereum/eth/tracers"
+)
+
+type blockSnapshot struct {
+	*BlocksProvider
+	block models.Block
+}
+
+var _ evmTypes.BlockSnapshot = (*blockSnapshot)(nil)
+
+func (bs *blockSnapshot) BlockContext() (evmTypes.BlockContext, error) {
+	return evmTypes.BlockContext{
+		ChainID:                evmTypes.EVMChainIDFromFlowChainID(bs.chainID),
+		BlockNumber:            bs.block.Height,
+		BlockTimestamp:         bs.block.Timestamp,
+		DirectCallBaseGasUsage: evmTypes.DefaultDirectCallBaseGasUsage,
+		DirectCallGasPrice:     evmTypes.DefaultDirectCallGasPrice,
+		GasFeeCollector:        evmTypes.CoinbaseAddress,
+		GetHashFunc: func(n uint64) gethCommon.Hash {
+			// For block heights greater than or equal to the current,
+			// return an empty block hash.
+			if n >= bs.block.Height {
+				return gethCommon.Hash{}
+			}
+			// If the given block height, is more than 256 blocks
+			// in the past, return an empty block hash.
+			if bs.block.Height-n > 256 {
+				return gethCommon.Hash{}
+			}
+
+			block, err := bs.blocks.GetByHeight(n)
+			if err != nil {
+				return gethCommon.Hash{}
+			}
+			blockHash, err := block.Hash()
+			if err != nil {
+				return gethCommon.Hash{}
+			}
+
+			return blockHash
+		},
+		Random: bs.block.PrevRandao,
+		Tracer: bs.tracer,
+	}, nil
+}
+
+type BlocksProvider struct {
+	blocks      storage.BlockIndexer
+	chainID     flowGo.ChainID
+	tracer      *tracers.Tracer
+	latestBlock *models.Block
+}
+
+var _ evmTypes.BlockSnapshotProvider = (*BlocksProvider)(nil)
+
+func NewBlocksProvider(
+	blocks storage.BlockIndexer,
+	chainID flowGo.ChainID,
+	tracer *tracers.Tracer,
+) *BlocksProvider {
+	return &BlocksProvider{
+		blocks:  blocks,
+		chainID: chainID,
+		tracer:  tracer,
+	}
+}
+
+func (bp *BlocksProvider) OnBlockReceived(block *models.Block) error {
+	if bp.latestBlock != nil && bp.latestBlock.Height != (block.Height-1) {
+		return fmt.Errorf(
+			"received new block: %d, non-sequential of latest block: %d",
+			block.Height,
+			bp.latestBlock.Height,
+		)
+	}
+
+	bp.latestBlock = block
+
+	return nil
+}
+
+func (bp *BlocksProvider) GetSnapshotAt(height uint64) (
+	evmTypes.BlockSnapshot,
+	error,
+) {
+	if bp.latestBlock != nil && bp.latestBlock.Height == height {
+		return &blockSnapshot{
+			BlocksProvider: bp,
+			block:          *bp.latestBlock,
+		}, nil
+	}
+
+	block, err := bp.blocks.GetByHeight(height)
+	if err != nil {
+		return nil, err
+	}
+
+	return &blockSnapshot{
+		BlocksProvider: bp,
+		block:          *block,
+	}, nil
+}

--- a/services/replayer/blocks_provider_test.go
+++ b/services/replayer/blocks_provider_test.go
@@ -1,0 +1,291 @@
+package replayer
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/onflow/flow-evm-gateway/config"
+	"github.com/onflow/flow-evm-gateway/models"
+	"github.com/onflow/flow-evm-gateway/storage"
+	"github.com/onflow/flow-evm-gateway/storage/mocks"
+	"github.com/onflow/flow-evm-gateway/storage/pebble"
+	"github.com/onflow/flow-go-sdk"
+	evmTypes "github.com/onflow/flow-go/fvm/evm/types"
+	flowGo "github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/go-ethereum/common"
+	"github.com/onflow/go-ethereum/eth/tracers"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// this import is needed for side-effects, because the
+	// tracers.DefaultDirectory is relying on the init function
+	_ "github.com/onflow/go-ethereum/eth/tracers/native"
+)
+
+func TestOnBlockReceived(t *testing.T) {
+
+	t.Run("without latest block", func(t *testing.T) {
+		blocks := setupBlocksDB(t)
+		blocksProvider := NewBlocksProvider(blocks, flowGo.Emulator, nil)
+
+		block := mocks.NewBlock(1)
+		err := blocksProvider.OnBlockReceived(block)
+		require.NoError(t, err)
+	})
+
+	t.Run("with new block non-sequential to latest block", func(t *testing.T) {
+		blocks := setupBlocksDB(t)
+		blocksProvider := NewBlocksProvider(blocks, flowGo.Emulator, nil)
+
+		block1 := mocks.NewBlock(1)
+		err := blocksProvider.OnBlockReceived(block1)
+		require.NoError(t, err)
+
+		block2 := mocks.NewBlock(3)
+		err = blocksProvider.OnBlockReceived(block2)
+		require.Error(t, err)
+		assert.ErrorContains(
+			t,
+			err,
+			"received new block: 3, non-sequential of latest block: 1",
+		)
+	})
+
+	t.Run("with new block non-sequential to latest block", func(t *testing.T) {
+		blocks := setupBlocksDB(t)
+		blocksProvider := NewBlocksProvider(blocks, flowGo.Emulator, nil)
+
+		block1 := mocks.NewBlock(10)
+		err := blocksProvider.OnBlockReceived(block1)
+		require.NoError(t, err)
+
+		block2 := mocks.NewBlock(11)
+		err = blocksProvider.OnBlockReceived(block2)
+		require.NoError(t, err)
+	})
+}
+
+func TestBlockContext(t *testing.T) {
+
+	t.Run("for latest block", func(t *testing.T) {
+		blocks := setupBlocksDB(t)
+		tracer := newCallTracer(t)
+		blocksProvider := NewBlocksProvider(blocks, flowGo.Emulator, tracer)
+
+		block := mocks.NewBlock(1)
+		err := blocksProvider.OnBlockReceived(block)
+		require.NoError(t, err)
+
+		blockSnapshopt, err := blocksProvider.GetSnapshotAt(block.Height)
+		require.NoError(t, err)
+
+		blockContext, err := blockSnapshopt.BlockContext()
+		require.NoError(t, err)
+
+		assert.Equal(t, evmTypes.FlowEVMPreviewNetChainID, blockContext.ChainID)
+		assert.Equal(t, block.Height, blockContext.BlockNumber)
+		assert.Equal(t, block.Timestamp, blockContext.BlockTimestamp)
+		assert.Equal(t, evmTypes.DefaultDirectCallBaseGasUsage, blockContext.DirectCallBaseGasUsage)
+		assert.Equal(t, evmTypes.DefaultDirectCallGasPrice, blockContext.DirectCallGasPrice)
+		assert.Equal(t, evmTypes.CoinbaseAddress, blockContext.GasFeeCollector)
+		blockHash := blockContext.GetHashFunc(block.Height)
+		assert.Equal(t, common.Hash{}, blockHash)
+		assert.Equal(t, block.PrevRandao, blockContext.Random)
+		assert.Equal(t, tracer, blockContext.Tracer)
+	})
+}
+
+func TestGetHashFunc(t *testing.T) {
+	blocks := setupBlocksDB(t)
+	missingHeight := uint64(100)
+
+	blockMapping := make(map[uint64]*models.Block, 0)
+	for i := uint64(1); i <= 300; i++ {
+		// simulate a missing block
+		if i == missingHeight {
+			continue
+		}
+
+		block := mocks.NewBlock(i)
+		err := blocks.Store(i, flow.Identifier{0x1}, block, nil)
+		require.NoError(t, err)
+		blockMapping[i] = block
+	}
+
+	t.Run("with requested height >= latest block height", func(t *testing.T) {
+		tracer := newCallTracer(t)
+		blocksProvider := NewBlocksProvider(blocks, flowGo.Emulator, tracer)
+
+		latestBlock := blockMapping[200]
+		err := blocksProvider.OnBlockReceived(latestBlock)
+		require.NoError(t, err)
+
+		blockSnapshopt, err := blocksProvider.GetSnapshotAt(latestBlock.Height)
+		require.NoError(t, err)
+
+		blockContext, err := blockSnapshopt.BlockContext()
+		require.NoError(t, err)
+		require.Equal(t, latestBlock.Height, blockContext.BlockNumber)
+
+		// GetHashFunc should return empty block hash for block heights >= latest
+		blockHash := blockContext.GetHashFunc(latestBlock.Height)
+		assert.Equal(t, common.Hash{}, blockHash)
+
+		blockHash = blockContext.GetHashFunc(latestBlock.Height + 1)
+		assert.Equal(t, common.Hash{}, blockHash)
+	})
+
+	t.Run("with requested height within 256 block height range", func(t *testing.T) {
+		tracer := newCallTracer(t)
+		blocksProvider := NewBlocksProvider(blocks, flowGo.Emulator, tracer)
+
+		latestBlock := blockMapping[257]
+		err := blocksProvider.OnBlockReceived(latestBlock)
+		require.NoError(t, err)
+
+		blockSnapshopt, err := blocksProvider.GetSnapshotAt(latestBlock.Height)
+		require.NoError(t, err)
+
+		blockContext, err := blockSnapshopt.BlockContext()
+		require.NoError(t, err)
+		require.Equal(t, latestBlock.Height, blockContext.BlockNumber)
+
+		blockHash := blockContext.GetHashFunc(latestBlock.Height - 256)
+		expectedBlock := blockMapping[latestBlock.Height-256]
+		expectedHash, err := expectedBlock.Hash()
+		require.NoError(t, err)
+		assert.Equal(t, expectedHash, blockHash)
+	})
+
+	t.Run("with requested height outside the 256 block height range", func(t *testing.T) {
+		tracer := newCallTracer(t)
+		blocksProvider := NewBlocksProvider(blocks, flowGo.Emulator, tracer)
+
+		latestBlock := blockMapping[260]
+		err := blocksProvider.OnBlockReceived(latestBlock)
+		require.NoError(t, err)
+
+		blockSnapshopt, err := blocksProvider.GetSnapshotAt(latestBlock.Height)
+		require.NoError(t, err)
+
+		blockContext, err := blockSnapshopt.BlockContext()
+		require.NoError(t, err)
+		require.Equal(t, latestBlock.Height, blockContext.BlockNumber)
+
+		blockHash := blockContext.GetHashFunc(latestBlock.Height - 259)
+		assert.Equal(t, common.Hash{}, blockHash)
+	})
+
+	t.Run("with requested height missing from Blocks DB", func(t *testing.T) {
+		tracer := newCallTracer(t)
+		blocksProvider := NewBlocksProvider(blocks, flowGo.Emulator, tracer)
+
+		latestBlock := blockMapping[260]
+		err := blocksProvider.OnBlockReceived(latestBlock)
+		require.NoError(t, err)
+
+		blockSnapshopt, err := blocksProvider.GetSnapshotAt(latestBlock.Height)
+		require.NoError(t, err)
+
+		blockContext, err := blockSnapshopt.BlockContext()
+		require.NoError(t, err)
+		require.Equal(t, latestBlock.Height, blockContext.BlockNumber)
+
+		blockHash := blockContext.GetHashFunc(missingHeight)
+		assert.Equal(t, common.Hash{}, blockHash)
+	})
+}
+
+func TestGetSnapshotAt(t *testing.T) {
+
+	t.Run("for latest block", func(t *testing.T) {
+		blocks := setupBlocksDB(t)
+		tracer := newCallTracer(t)
+		blocksProvider := NewBlocksProvider(blocks, flowGo.Emulator, tracer)
+
+		block := mocks.NewBlock(1)
+		err := blocksProvider.OnBlockReceived(block)
+		require.NoError(t, err)
+
+		blockSnapshot, err := blocksProvider.GetSnapshotAt(block.Height)
+		require.NoError(t, err)
+
+		blockContext, err := blockSnapshot.BlockContext()
+		require.NoError(t, err)
+		assert.Equal(t, block.Height, blockContext.BlockNumber)
+		assert.Equal(t, block.Timestamp, blockContext.BlockTimestamp)
+		assert.Equal(t, block.PrevRandao, blockContext.Random)
+		assert.Equal(t, tracer, blockContext.Tracer)
+	})
+
+	t.Run("for historic block", func(t *testing.T) {
+		blocks := setupBlocksDB(t)
+		tracer := newCallTracer(t)
+		blocksProvider := NewBlocksProvider(blocks, flowGo.Emulator, tracer)
+
+		block1 := mocks.NewBlock(1)
+		err := blocks.Store(1, flow.Identifier{0x1}, block1, nil)
+		require.NoError(t, err)
+
+		block2 := mocks.NewBlock(2)
+		err = blocksProvider.OnBlockReceived(block2)
+		require.NoError(t, err)
+
+		blockSnapshot, err := blocksProvider.GetSnapshotAt(block1.Height)
+		require.NoError(t, err)
+
+		blockContext, err := blockSnapshot.BlockContext()
+		require.NoError(t, err)
+		assert.Equal(t, block1.Height, blockContext.BlockNumber)
+		assert.Equal(t, block1.Timestamp, blockContext.BlockTimestamp)
+		assert.Equal(t, block1.PrevRandao, blockContext.Random)
+		assert.Equal(t, tracer, blockContext.Tracer)
+	})
+
+	t.Run("for missing historic block", func(t *testing.T) {
+		blocks := setupBlocksDB(t)
+		tracer := newCallTracer(t)
+		blocksProvider := NewBlocksProvider(blocks, flowGo.Emulator, tracer)
+
+		// `block1` is not stored on Blocks DB
+		block1 := mocks.NewBlock(1)
+
+		block2 := mocks.NewBlock(2)
+		err := blocksProvider.OnBlockReceived(block2)
+		require.NoError(t, err)
+
+		_, err = blocksProvider.GetSnapshotAt(block1.Height)
+		require.Error(t, err)
+		assert.ErrorContains(
+			t,
+			err,
+			"entity not found",
+		)
+	})
+}
+
+func setupBlocksDB(t *testing.T) storage.BlockIndexer {
+	dir := t.TempDir()
+	db, err := pebble.New(dir, zerolog.Nop())
+	require.NoError(t, err)
+
+	chainID := flowGo.Emulator
+	blocks := pebble.NewBlocks(db, chainID)
+
+	err = blocks.InitHeights(config.EmulatorInitCadenceHeight, flow.Identifier{0x1})
+	require.NoError(t, err)
+
+	return blocks
+}
+
+func newCallTracer(t *testing.T) *tracers.Tracer {
+	tracer, err := tracers.DefaultDirectory.New(
+		"callTracer",
+		&tracers.Context{},
+		json.RawMessage(`{ "onlyTopCall": true }`),
+	)
+	require.NoError(t, err)
+
+	return tracer
+}

--- a/storage/mocks/mocks.go
+++ b/storage/mocks/mocks.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/go-ethereum/common"
@@ -20,10 +21,14 @@ func NewBlock(height uint64) *models.Block {
 
 	return &models.Block{
 		Block: &types.Block{
-			ParentBlockHash: parent,
-			Height:          height,
-			TotalSupply:     big.NewInt(1000),
-			ReceiptRoot:     common.HexToHash(fmt.Sprintf("0x1337%d", height)),
+			ParentBlockHash:     parent,
+			Height:              height,
+			Timestamp:           uint64(time.Now().Second()),
+			TotalSupply:         big.NewInt(1000),
+			ReceiptRoot:         common.HexToHash(fmt.Sprintf("0x100%d", height)),
+			TransactionHashRoot: common.HexToHash(fmt.Sprintf("0x200%d", height)),
+			TotalGasUsed:        uint64(30_000),
+			PrevRandao:          common.HexToHash(fmt.Sprintf("0x300%d", height)),
 		},
 		TransactionHashes: make([]common.Hash, 0),
 	}


### PR DESCRIPTION
Closes: #630
Closes: #631 

## Description

- Adds two new types that implement the `BlockSnapshotProvider` & `BlockSnapshot` interfaces
- Injects the `BlocksProvider` type to the Event Ingestion Engine, with a default `callTracer`
- Keeps track of `EVM` blocks that are received
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 