### PR TITLE
Refactor  event subscriber

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @janezpodhostnik @peterargue @m-Peter @zhangchiqing @ramtinms
+* @janezpodhostnik @peterargue @m-Peter @zhangchiqing

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -117,7 +117,7 @@ func (b *Bootstrap) StartEventIngestion(ctx context.Context) error {
 		Msg("indexing cadence height information")
 
 	// create event subscriber
-	subscriber := ingestion.NewRPCSubscriber(
+	subscriber := ingestion.NewRPCEventSubscriber(
 		b.client,
 		b.config.HeartbeatInterval,
 		b.config.FlowNetworkID,

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -117,7 +117,12 @@ func (b *Bootstrap) StartEventIngestion(ctx context.Context) error {
 		Msg("indexing cadence height information")
 
 	// create event subscriber
-	subscriber := ingestion.NewRPCEventSubscriber(b.logger, b.client, b.config.FlowNetworkID, latestCadenceHeight, b.config.HeartbeatInterval)
+	subscriber := ingestion.NewRPCEventSubscriber(
+		b.logger,
+		b.client,
+		b.config.FlowNetworkID,
+		latestCadenceHeight,
+	)
 
 	// initialize event ingestion engine
 	b.events = ingestion.NewEventIngestionEngine(

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -117,12 +117,7 @@ func (b *Bootstrap) StartEventIngestion(ctx context.Context) error {
 		Msg("indexing cadence height information")
 
 	// create event subscriber
-	subscriber := ingestion.NewRPCEventSubscriber(
-		b.client,
-		b.config.HeartbeatInterval,
-		b.config.FlowNetworkID,
-		b.logger,
-	)
+	subscriber := ingestion.NewRPCEventSubscriber(b.logger, b.client, b.config.FlowNetworkID, latestCadenceHeight, b.config.HeartbeatInterval)
 
 	// initialize event ingestion engine
 	b.events = ingestion.NewEventIngestionEngine(

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -268,7 +268,6 @@ func init() {
 	Cmd.Flags().Float64Var(&cfg.StreamLimit, "stream-limit", 10, "Rate-limits the events sent to the client within one second")
 	Cmd.Flags().Uint64Var(&cfg.RateLimit, "rate-limit", 50, "Rate-limit requests per second made by the client over any protocol (ws/http)")
 	Cmd.Flags().StringVar(&cfg.AddressHeader, "address-header", "", "Address header that contains the client IP, this is useful when the server is behind a proxy that sets the source IP of the client. Leave empty if no proxy is used.")
-	Cmd.Flags().Uint64Var(&cfg.HeartbeatInterval, "heartbeat-interval", 100, "Heartbeat interval for AN event subscription")
 	Cmd.Flags().UintVar(&cfg.CacheSize, "script-cache-size", 10000, "Cache size used for script execution in items kept in cache")
 	Cmd.Flags().IntVar(&streamTimeout, "stream-timeout", 3, "Defines the timeout in seconds the server waits for the event to be sent to the client")
 	Cmd.Flags().Uint64Var(&forceStartHeight, "force-start-height", 0, "Force set starting Cadence height. WARNING: This should only be used locally or for testing, never in production.")

--- a/config/config.go
+++ b/config/config.go
@@ -74,8 +74,6 @@ type Config struct {
 	FilterExpiry time.Duration
 	// ForceStartCadenceHeight will force set the starting Cadence height, this should be only used for testing or locally.
 	ForceStartCadenceHeight uint64
-	// HeartbeatInterval sets custom heartbeat interval for events
-	HeartbeatInterval uint64
 	// TracesBucketName sets the GCP bucket name where transaction traces are being stored.
 	TracesBucketName string
 	// TracesEnabled sets whether the node is supporting transaction traces.

--- a/services/ingestion/engine.go
+++ b/services/ingestion/engine.go
@@ -98,25 +98,19 @@ func (e *Engine) Stop() {
 // drops.
 // All other errors are unexpected.
 func (e *Engine) Run(ctx context.Context) error {
-	latestCadence, err := e.blocks.LatestCadenceHeight()
-	if err != nil {
-		return fmt.Errorf("failed to get latest cadence height: %w", err)
-	}
-
-	e.log.Info().Uint64("start-cadence-height", latestCadence).Msg("starting ingestion")
+	e.log.Info().Msg("starting ingestion")
 
 	e.MarkReady()
 
-	for events := range e.subscriber.Subscribe(ctx, latestCadence) {
+	for events := range e.subscriber.Subscribe(ctx) {
 		if events.Err != nil {
 			return fmt.Errorf(
-				"failure in event subscription at height %d, with: %w",
-				latestCadence,
+				"failure in event subscription with: %w",
 				events.Err,
 			)
 		}
 
-		err = e.processEvents(events.Events)
+		err := e.processEvents(events.Events)
 		if err != nil {
 			e.log.Error().Err(err).Msg("failed to process EVM events")
 			return err

--- a/services/ingestion/engine_test.go
+++ b/services/ingestion/engine_test.go
@@ -56,8 +56,8 @@ func TestSerialBlockIngestion(t *testing.T) {
 
 		subscriber := &mocks.EventSubscriber{}
 		subscriber.
-			On("Subscribe", mock.Anything, mock.AnythingOfType("uint64")).
-			Return(func(ctx context.Context, latest uint64) <-chan models.BlockEvents {
+			On("Subscribe", mock.Anything).
+			Return(func(ctx context.Context) <-chan models.BlockEvents {
 				return eventsChan
 			})
 
@@ -136,8 +136,8 @@ func TestSerialBlockIngestion(t *testing.T) {
 		eventsChan := make(chan models.BlockEvents)
 		subscriber := &mocks.EventSubscriber{}
 		subscriber.
-			On("Subscribe", mock.Anything, mock.AnythingOfType("uint64")).
-			Return(func(ctx context.Context, latest uint64) <-chan models.BlockEvents {
+			On("Subscribe", mock.Anything).
+			Return(func(ctx context.Context) <-chan models.BlockEvents {
 				return eventsChan
 			})
 
@@ -246,8 +246,8 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 		eventsChan := make(chan models.BlockEvents)
 		subscriber := &mocks.EventSubscriber{}
 		subscriber.
-			On("Subscribe", mock.Anything, mock.AnythingOfType("uint64")).
-			Return(func(ctx context.Context, latest uint64) <-chan models.BlockEvents {
+			On("Subscribe", mock.Anything).
+			Return(func(ctx context.Context) <-chan models.BlockEvents {
 				return eventsChan
 			})
 
@@ -349,8 +349,8 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 		eventsChan := make(chan models.BlockEvents)
 		subscriber := &mocks.EventSubscriber{}
 		subscriber.
-			On("Subscribe", mock.Anything, mock.AnythingOfType("uint64")).
-			Return(func(ctx context.Context, latest uint64) <-chan models.BlockEvents {
+			On("Subscribe", mock.Anything).
+			Return(func(ctx context.Context) <-chan models.BlockEvents {
 				return eventsChan
 			})
 
@@ -448,9 +448,8 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 		eventsChan := make(chan models.BlockEvents)
 		subscriber := &mocks.EventSubscriber{}
 		subscriber.
-			On("Subscribe", mock.Anything, mock.AnythingOfType("uint64")).
-			Return(func(ctx context.Context, latest uint64) <-chan models.BlockEvents {
-				assert.Equal(t, latestCadenceHeight, latest)
+			On("Subscribe", mock.Anything).
+			Return(func(ctx context.Context) <-chan models.BlockEvents {
 				return eventsChan
 			}).
 			Once()

--- a/services/ingestion/event_subscriber_test.go
+++ b/services/ingestion/event_subscriber_test.go
@@ -43,7 +43,7 @@ func Test_Subscribing(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1, 100)
+	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1)
 
 	events := subscriber.Subscribe(context.Background())
 
@@ -83,7 +83,7 @@ func Test_MissingBlockEvent(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1, 100)
+	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1)
 
 	events := subscriber.Subscribe(context.Background())
 
@@ -185,7 +185,7 @@ func Test_SubscribingWithRetryOnError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1, 100)
+	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1)
 
 	events := subscriber.Subscribe(context.Background())
 
@@ -248,7 +248,7 @@ func Test_SubscribingWithRetryOnErrorMultipleBlocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1, 100)
+	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1)
 
 	events := subscriber.Subscribe(context.Background())
 
@@ -310,7 +310,7 @@ func Test_SubscribingWithRetryOnErrorEmptyBlocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1, 100)
+	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1)
 
 	events := subscriber.Subscribe(context.Background())
 

--- a/services/ingestion/event_subscriber_test.go
+++ b/services/ingestion/event_subscriber_test.go
@@ -43,9 +43,9 @@ func Test_Subscribing(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
+	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1, 100)
 
-	events := subscriber.Subscribe(context.Background(), 1)
+	events := subscriber.Subscribe(context.Background())
 
 	var prevHeight uint64
 
@@ -83,9 +83,9 @@ func Test_MissingBlockEvent(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
+	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1, 100)
 
-	events := subscriber.Subscribe(context.Background(), 1)
+	events := subscriber.Subscribe(context.Background())
 
 	missingHashes := make([]gethCommon.Hash, 0)
 
@@ -160,7 +160,7 @@ func Test_MissingBlockEvent(t *testing.T) {
 // EVM events through the gRPC API, returns the correct data.
 func Test_SubscribingWithRetryOnError(t *testing.T) {
 	endHeight := uint64(10)
-	sporkClients := []access.Client{}
+	var sporkClients []access.Client
 	currentClient := testutils.SetupClientForRange(1, endHeight)
 
 	cadenceHeight := uint64(5)
@@ -185,9 +185,9 @@ func Test_SubscribingWithRetryOnError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
+	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1, 100)
 
-	events := subscriber.Subscribe(context.Background(), 1)
+	events := subscriber.Subscribe(context.Background())
 
 	var prevHeight uint64
 
@@ -214,7 +214,7 @@ func Test_SubscribingWithRetryOnError(t *testing.T) {
 	}
 
 	// this makes sure we indexed all the events
-	require.Equal(t, uint64(endHeight), prevHeight)
+	require.Equal(t, endHeight, prevHeight)
 }
 
 // Test that back-up fetching of EVM events is triggered when the
@@ -223,7 +223,7 @@ func Test_SubscribingWithRetryOnError(t *testing.T) {
 // of EVM events through the gRPC API, returns duplicate EVM blocks.
 func Test_SubscribingWithRetryOnErrorMultipleBlocks(t *testing.T) {
 	endHeight := uint64(10)
-	sporkClients := []access.Client{}
+	var sporkClients []access.Client
 	currentClient := testutils.SetupClientForRange(1, endHeight)
 
 	cadenceHeight := uint64(5)
@@ -248,9 +248,9 @@ func Test_SubscribingWithRetryOnErrorMultipleBlocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
+	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1, 100)
 
-	events := subscriber.Subscribe(context.Background(), 1)
+	events := subscriber.Subscribe(context.Background())
 
 	var prevHeight uint64
 
@@ -286,7 +286,7 @@ func Test_SubscribingWithRetryOnErrorMultipleBlocks(t *testing.T) {
 // of EVM events through the gRPC API, returns no EVM blocks.
 func Test_SubscribingWithRetryOnErrorEmptyBlocks(t *testing.T) {
 	endHeight := uint64(10)
-	sporkClients := []access.Client{}
+	var sporkClients []access.Client
 	currentClient := testutils.SetupClientForRange(1, endHeight)
 
 	cadenceHeight := uint64(5)
@@ -310,9 +310,9 @@ func Test_SubscribingWithRetryOnErrorEmptyBlocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
+	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, 1, 100)
 
-	events := subscriber.Subscribe(context.Background(), 1)
+	events := subscriber.Subscribe(context.Background())
 
 	var prevHeight uint64
 
@@ -405,16 +405,16 @@ func setupClientForBackupEventFetching(
 		"GetEventsForHeightRange",
 		mock.AnythingOfType("context.backgroundCtx"),
 		"A.b6763b4399a888c8.EVM.BlockExecuted",
-		uint64(cadenceHeight),
-		uint64(cadenceHeight),
+		cadenceHeight,
+		cadenceHeight,
 	).Return(evmBlockEvents, nil).Once()
 
 	client.On(
 		"GetEventsForHeightRange",
 		mock.AnythingOfType("context.backgroundCtx"),
 		"A.b6763b4399a888c8.EVM.TransactionExecuted",
-		uint64(cadenceHeight),
-		uint64(cadenceHeight),
+		cadenceHeight,
+		cadenceHeight,
 	).Return([]flow.BlockEvents{evmTxEvents}, nil).Once()
 
 	client.SubscribeEventsByBlockHeightFunc = func(

--- a/services/ingestion/event_subscriber_test.go
+++ b/services/ingestion/event_subscriber_test.go
@@ -43,7 +43,7 @@ func Test_Subscribing(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
+	subscriber := NewRPCEventSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
 
 	events := subscriber.Subscribe(context.Background(), 1)
 
@@ -83,7 +83,7 @@ func Test_MissingBlockEvent(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
+	subscriber := NewRPCEventSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
 
 	events := subscriber.Subscribe(context.Background(), 1)
 
@@ -185,7 +185,7 @@ func Test_SubscribingWithRetryOnError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
+	subscriber := NewRPCEventSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
 
 	events := subscriber.Subscribe(context.Background(), 1)
 
@@ -248,7 +248,7 @@ func Test_SubscribingWithRetryOnErrorMultipleBlocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
+	subscriber := NewRPCEventSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
 
 	events := subscriber.Subscribe(context.Background(), 1)
 
@@ -310,7 +310,7 @@ func Test_SubscribingWithRetryOnErrorEmptyBlocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
+	subscriber := NewRPCEventSubscriber(client, 100, flowGo.Previewnet, zerolog.Nop())
 
 	events := subscriber.Subscribe(context.Background(), 1)
 

--- a/services/ingestion/mocks/EventSubscriber.go
+++ b/services/ingestion/mocks/EventSubscriber.go
@@ -15,17 +15,17 @@ type EventSubscriber struct {
 	mock.Mock
 }
 
-// Subscribe provides a mock function with given fields: ctx, height
-func (_m *EventSubscriber) Subscribe(ctx context.Context, height uint64) <-chan models.BlockEvents {
-	ret := _m.Called(ctx, height)
+// Subscribe provides a mock function with given fields: ctx
+func (_m *EventSubscriber) Subscribe(ctx context.Context) <-chan models.BlockEvents {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Subscribe")
 	}
 
 	var r0 <-chan models.BlockEvents
-	if rf, ok := ret.Get(0).(func(context.Context, uint64) <-chan models.BlockEvents); ok {
-		r0 = rf(ctx, height)
+	if rf, ok := ret.Get(0).(func(context.Context) <-chan models.BlockEvents); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(<-chan models.BlockEvents)


### PR DESCRIPTION
Closes: #???

## Description

A small refactor for the event subscriber.

I want to eventually switch this to a `flowgo.Component`, because of the easier and clearer error handling we get that way.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced event subscription process by centralizing state management within the RPCEventSubscriber.
	- Streamlined command-line interface configuration for the EVM Gateway Node, improving clarity and usability.

- **Bug Fixes**
	- Improved error handling during event subscription by removing references to the removed cadence height.

- **Tests**
	- Updated test cases to reflect changes in event subscriber instantiation and method signatures, ensuring continued validation of event ingestion functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->