### PR TITLE
Set a non-zero `BaseFeePerGas` on block responses

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -32,6 +32,8 @@ import (
 
 const maxFeeHistoryBlockCount = 1024
 
+var baseFeesPerGas = big.NewInt(1)
+
 // A map containing all the valid method names that are found
 // in the Ethereum JSON-RPC API specification.
 // Update accordingly if any new methods are added/removed.
@@ -937,7 +939,7 @@ func (b *BlockChainAPI) FeeHistory(
 			oldestBlock = (*hexutil.Big)(big.NewInt(int64(block.Height)))
 		}
 
-		baseFees = append(baseFees, (*hexutil.Big)(big.NewInt(0)))
+		baseFees = append(baseFees, (*hexutil.Big)(baseFeesPerGas))
 
 		rewards = append(rewards, blockRewards)
 
@@ -1053,7 +1055,7 @@ func (b *BlockChainAPI) prepareBlockResponse(
 		GasLimit:         hexutil.Uint64(blockGasLimit),
 		Nonce:            types.BlockNonce{0x1},
 		Timestamp:        hexutil.Uint64(block.Timestamp),
-		BaseFeePerGas:    hexutil.Big(*big.NewInt(0)),
+		BaseFeePerGas:    hexutil.Big(*baseFeesPerGas),
 		LogsBloom:        types.LogsBloom([]*types.Log{}),
 		Miner:            evmTypes.CoinbaseAddress.ToCommon(),
 		Sha3Uncles:       types.EmptyUncleHash,
@@ -1230,8 +1232,7 @@ func (b *BlockChainAPI) GetUncleByBlockNumberAndIndex(
 
 // MaxPriorityFeePerGas returns a suggestion for a gas tip cap for dynamic fee transactions.
 func (b *BlockChainAPI) MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big, error) {
-	fee := hexutil.Big(*big.NewInt(1))
-	return &fee, nil
+	return (*hexutil.Big)(b.config.GasPrice), nil
 }
 
 // Mining returns true if client is actively mining new blocks.

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -379,7 +379,7 @@ it('get fee history', async () => {
         {
             oldestBlock: 1n,
             reward: [['0x96'], ['0x96'], ['0x96']], // gas price is 150 during testing
-            baseFeePerGas: [0n, 0n, 0n],
+            baseFeePerGas: [1n, 1n, 1n],
             gasUsedRatio: [0, 0, 0.006205458333333334]
         }
     )


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/647

## Description

Also update the `eth_maxPriorityFeePerGas` to return the configured gas price.

Example usage of hardhat ignition deployment:
```bash
$ npx hardhat ignition deploy ./ignition/modules/Lock.ts  --network testnet --verbose --show-stack-traces

Hardhat Ignition 🚀

Deploying [ LockModule ]

Batch #1
  Executing LockModule#Lock...
Batch #1
  Executed LockModule#Lock

[ LockModule ] successfully deployed 🚀

Deployed Addresses

LockModule#Lock - 0x3d636a648df1964feE061AD7A89AacaDa1b0F728
```

Example usage of `forge create`:
```bash
$ forge create --rpc-url='http://localhost:8545' --private-key='0xc3a9ecb56c3ad2c5e3dc7b228f458f63c4a33de571317842d3e89f96b8e3901c' tests/fixtures/storage.sol:Storage

[⠊] Compiling...
[⠢] Compiling 1 files with Solc 0.8.26
[⠆] Solc 0.8.26 finished in 118.60ms
Compiler run successful with warnings:
Warning (5159): "selfdestruct" has been deprecated. Note that, starting from the Cancun hard fork, the underlying opcode no longer deletes the code and data associated with an account and only transfers its Ether to the beneficiary, unless executed in the same transaction in which the contract was created (see EIP-6780). Any use in newly deployed contracts is strongly discouraged even if the new behavior is taken into account. Future changes to the EVM might further reduce the functionality of the opcode.
  --> tests/fixtures/storage.sol:64:9:
   |
64 |         selfdestruct(payable(msg.sender));
   |         ^^^^^^^^^^^^

Deployer: 0x2502E08Ebb5375cdC1d64c68dA8aB38a27E76FFA
Deployed to: 0x3d636a648df1964feE061AD7A89AacaDa1b0F728
Transaction hash: 0x0eeaa0d7fc835818527ff6e7af28c19586ade9de61024d7a18bd807f8739ef1c
```

Example usage of `cast send`:
```bash
$ cast send 0x3d636a648df1964feE061AD7A89AacaDa1b0F728 --rpc-url='http://localhost:8545' --private-key='0xc3a9ecb56c3ad2c5e3dc7b228f458f63c4a33de571317842d3e89f96b8e3901c' "storeWithLog(uint256 num)" 42

blockHash               0xad9bedad5c92ead24951a732f4244fc32a89c56855b30ca4f18673638cb22703
blockNumber             4
contractAddress         
cumulativeGasUsed       28024
effectiveGasPrice       1000000000
from                    0x2502E08Ebb5375cdC1d64c68dA8aB38a27E76FFA
gasUsed                 28024
logs                    [{"address":"0x3d636a648df1964fee061ad7a89aacada1b0f728","topics":["0x043cc306157a91d747b36aba0e235bbbc5771d75aba162f6e5540767d22673c6","0x0000000000000000000000002502e08ebb5375cdc1d64c68da8ab38a27e76ffa","0x000000000000000000000000000000000000000000000000000000000000002a"],"data":"0x","blockHash":"0xad9bedad5c92ead24951a732f4244fc32a89c56855b30ca4f18673638cb22703","blockNumber":"0x4","transactionHash":"0xa051d40c1359bfceb9bb4b9168150b4c6baa15ae0bc8126245df2eff5a2d2209","transactionIndex":"0x0","logIndex":"0x0","removed":false}]
logsBloom               0x00000000000000000000200000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000080000080400000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000004000000000000000000000000001000000000000000000000000000800000000000000000000000000000000000000000000000000000000000100000000000000000000000000020000000000000000000000000000000000000
root                    
status                  1 (success)
transactionHash         0xa051d40c1359bfceb9bb4b9168150b4c6baa15ae0bc8126245df2eff5a2d2209
transactionIndex        0
type                    2
blobGasPrice            
blobGasUsed             
to                      0x3d636a648df1964feE061AD7A89AacaDa1b0F728
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dynamic handling of gas fees in the API for more accurate fee calculations.
- **Bug Fixes**
	- Updated tests for fetching fee history to reflect new base fee values.
- **Tests**
	- Improved test cases in the Web3 API suite to validate various functionalities with updated fee expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->