### PR TITLE
Refactor re-execution

### DIFF
--- a/services/ingestion/engine_test.go
+++ b/services/ingestion/engine_test.go
@@ -164,7 +164,7 @@ func TestSerialBlockIngestion(t *testing.T) {
 		go func() {
 			err := engine.Run(context.Background())
 			assert.ErrorIs(t, err, models.ErrInvalidHeight)
-			assert.EqualError(t, err, "invalid height: received new block: 20, non-sequential of latest block: 11")
+			assert.ErrorContains(t, err, "invalid height: received new block: 20, non-sequential of latest block: 11")
 			close(waitErr)
 		}()
 

--- a/storage/index.go
+++ b/storage/index.go
@@ -42,7 +42,6 @@ type BlockIndexer interface {
 	LatestCadenceHeight() (uint64, error)
 
 	// SetLatestCadenceHeight sets the latest Cadence height.
-	// Batch is required to batch multiple indexer operations, skipped if nil.
 	SetLatestCadenceHeight(cadenceHeight uint64, batch *pebble.Batch) error
 
 	// GetCadenceHeight returns the Cadence height that matches the


### PR DESCRIPTION
## Description

I split up the function a bit, to hopefully make it a bit clearer. 
I also noticed that there was a bug where if `events.Empty()` then the batch containing the new cadence height never got committed. This should be fixed.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 