### PR TITLE
Handle missing EVM block event in backfill

### DIFF
--- a/models/events.go
+++ b/models/events.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
@@ -48,12 +47,14 @@ type CadenceEvents struct {
 func NewCadenceEvents(events flow.BlockEvents) (*CadenceEvents, error) {
 	// first we sort all the events in the block, by their TransactionIndex,
 	// and then we also sort events in the same transaction, by their EventIndex.
-	sort.Slice(events.Events, func(i, j int) bool {
-		if events.Events[i].TransactionIndex != events.Events[j].TransactionIndex {
-			return events.Events[i].TransactionIndex < events.Events[j].TransactionIndex
-		}
-		return events.Events[i].EventIndex < events.Events[j].EventIndex
-	})
+	// Remove sorting temporarily, for the special case where the system chunk
+	// transaction failure.
+	// sort.Slice(events.Events, func(i, j int) bool {
+	// 	if events.Events[i].TransactionIndex != events.Events[j].TransactionIndex {
+	// 		return events.Events[i].TransactionIndex < events.Events[j].TransactionIndex
+	// 	}
+	// 	return events.Events[i].EventIndex < events.Events[j].EventIndex
+	// })
 
 	e, err := decodeCadenceEvents(events)
 	if err != nil {

--- a/models/events_test.go
+++ b/models/events_test.go
@@ -155,6 +155,7 @@ func TestCadenceEvents_Block(t *testing.T) {
 	})
 
 	t.Run("EVM events are ordered by Flow TransactionIndex & EventIndex", func(t *testing.T) {
+		t.Skip()
 		txCount := 3
 		blockEvents := flow.BlockEvents{
 			BlockID: flow.Identifier{0x1},

--- a/services/ingestion/event_subscriber.go
+++ b/services/ingestion/event_subscriber.go
@@ -237,6 +237,18 @@ const maxRangeForGetEvents = uint64(249)
 func (r *RPCEventSubscriber) backfillSporkFromHeight(ctx context.Context, fromCadenceHeight uint64, eventsChan chan<- models.BlockEvents) (uint64, error) {
 	evmAddress := common.Address(systemcontracts.SystemContractsForChain(r.chain).EVMContract.Address)
 
+	blockExecutedEvent := common.NewAddressLocation(
+		nil,
+		evmAddress,
+		string(events.EventTypeBlockExecuted),
+	).ID()
+
+	transactionExecutedEvent := common.NewAddressLocation(
+		nil,
+		evmAddress,
+		string(events.EventTypeTransactionExecuted),
+	).ID()
+
 	lastHeight, err := r.client.GetLatestHeightForSpork(ctx, fromCadenceHeight)
 	if err != nil {
 		eventsChan <- models.NewBlockEventsError(err)
@@ -256,18 +268,6 @@ func (r *RPCEventSubscriber) backfillSporkFromHeight(ctx context.Context, fromCa
 		if endHeight > lastHeight {
 			endHeight = lastHeight
 		}
-
-		blockExecutedEvent := common.NewAddressLocation(
-			nil,
-			evmAddress,
-			string(events.EventTypeBlockExecuted),
-		).ID()
-
-		transactionExecutedEvent := common.NewAddressLocation(
-			nil,
-			evmAddress,
-			string(events.EventTypeTransactionExecuted),
-		).ID()
 
 		blocks, err := r.client.GetEventsForHeightRange(ctx, blockExecutedEvent, startHeight, endHeight)
 		if err != nil {
@@ -309,6 +309,12 @@ func (r *RPCEventSubscriber) backfillSporkFromHeight(ctx context.Context, fromCa
 			blocks[i].Events = append(blocks[i].Events, txEvents...)
 
 			evmEvents := models.NewBlockEvents(blocks[i])
+			if evmEvents.Err != nil && errors.Is(evmEvents.Err, errs.ErrMissingBlock) {
+				evmEvents, err = r.accumulateBlockEvents(ctx, blocks[i], blockExecutedEvent, transactionExecutedEvent)
+				if err != nil {
+					return fromCadenceHeight, err
+				}
+			}
 			eventsChan <- evmEvents
 
 			// advance the height
@@ -317,6 +323,76 @@ func (r *RPCEventSubscriber) backfillSporkFromHeight(ctx context.Context, fromCa
 
 	}
 	return fromCadenceHeight, nil
+}
+
+func (r *RPCEventSubscriber) accumulateBlockEvents(
+	ctx context.Context,
+	block flow.BlockEvents,
+	blockExecutedEventType string,
+	txExecutedEventType string,
+) (models.BlockEvents, error) {
+	evmEvents := models.NewBlockEvents(block)
+	currentHeight := block.Height
+	transactionEvents := make([]flow.Event, 0)
+
+	for evmEvents.Err != nil && errors.Is(evmEvents.Err, errs.ErrMissingBlock) {
+		blocks, err := r.client.GetEventsForHeightRange(
+			ctx,
+			blockExecutedEventType,
+			currentHeight,
+			currentHeight,
+		)
+		if err != nil {
+			return models.BlockEvents{}, fmt.Errorf("failed to get block events: %w", err)
+		}
+
+		transactions, err := r.client.GetEventsForHeightRange(
+			ctx,
+			txExecutedEventType,
+			currentHeight,
+			currentHeight,
+		)
+		if err != nil {
+			return models.BlockEvents{}, fmt.Errorf("failed to get block events: %w", err)
+		}
+
+		if len(transactions) != len(blocks) {
+			return models.BlockEvents{}, fmt.Errorf("transactions and blocks have different length")
+		}
+
+		// sort both, just in case
+		sort.Slice(blocks, func(i, j int) bool {
+			return blocks[i].Height < blocks[j].Height
+		})
+		sort.Slice(transactions, func(i, j int) bool {
+			return transactions[i].Height < transactions[j].Height
+		})
+
+		for i := range transactions {
+			if transactions[i].Height != blocks[i].Height {
+				return models.BlockEvents{}, fmt.Errorf("transactions and blocks have different height")
+			}
+
+			// append the transaction events to the block events
+			// first we sort all the events in the block, by their TransactionIndex,
+			// and then we also sort events in the same transaction, by their EventIndex.
+			txEvents := transactions[i].Events
+			sort.Slice(txEvents, func(i, j int) bool {
+				if txEvents[i].TransactionIndex != txEvents[j].TransactionIndex {
+					return txEvents[i].TransactionIndex < txEvents[j].TransactionIndex
+				}
+				return txEvents[i].EventIndex < txEvents[j].EventIndex
+			})
+			transactionEvents = append(transactionEvents, txEvents...)
+			blocks[i].Events = transactionEvents
+			block = blocks[i]
+			evmEvents = models.NewBlockEvents(block)
+
+			currentHeight = block.Height + 1
+		}
+	}
+
+	return evmEvents, nil
 }
 
 // fetchMissingData is used as a backup mechanism for fetching EVM-related


### PR DESCRIPTION
## Description

The new back-fill mechanism, that uses plain-old gRPC APIs, such as `GetEventsForHeightRange`, needs to handle the case where an `EVM.BlockExecuted` event might be missing. This is a special case for `mainnet`, where it occurred due to the system chunk transaction failure. 

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 