### PR TITLE
Handle ingestion of missing `EVM.BlockExecuted` event in backfill process

### DIFF
--- a/models/events_test.go
+++ b/models/events_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCadenceEvents_Block(t *testing.T) {
+func TestNewSingleBlockEvents(t *testing.T) {
 	invalid := cadence.String("invalid")
 
 	b0, e0, err := newBlock(0, nil)
@@ -47,17 +47,18 @@ func TestCadenceEvents_Block(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e, err := NewCadenceEvents(tt.events)
-			require.NoError(t, err)
+			evmEvents := NewSingleBlockEvents(tt.events)
+			require.NoError(t, evmEvents.Err)
 
+			cdcEvents := evmEvents.Events
 			if tt.block != nil {
 				ttHash, err := tt.block.Hash()
 				require.NoError(t, err)
-				hash, err := e.Block().Hash()
+				hash, err := cdcEvents.Block().Hash()
 				require.NoError(t, err)
 				assert.Equal(t, ttHash, hash)
 			} else {
-				assert.Nil(t, e.Block())
+				assert.Nil(t, cdcEvents.Block())
 			}
 		})
 	}
@@ -75,6 +76,26 @@ func TestCadenceEvents_Block(t *testing.T) {
 		events = append(events, txEvent)
 	}
 
+	t.Run("missing block with transactions", func(t *testing.T) {
+		// generate single block
+		_, _, err := newBlock(cadenceHeight, hashes)
+		require.NoError(t, err)
+
+		blockEvents := flow.BlockEvents{
+			BlockID: flow.Identifier{0x1},
+			Height:  cadenceHeight,
+			Events:  events,
+		}
+
+		evmEvents := NewSingleBlockEvents(blockEvents)
+		require.Error(t, evmEvents.Err)
+		assert.ErrorContains(
+			t,
+			evmEvents.Err,
+			"missing block EVM block nil at flow block: 1",
+		)
+	})
+
 	t.Run("block with less transaction hashes", func(t *testing.T) {
 		// generate single block
 		_, blockEvent, err := newBlock(cadenceHeight, hashes[:txCount-2])
@@ -88,11 +109,11 @@ func TestCadenceEvents_Block(t *testing.T) {
 
 		blockEvents.Events = append(blockEvents.Events, blockEvent)
 
-		_, err = NewCadenceEvents(blockEvents)
-		require.Error(t, err)
+		evmEvents := NewSingleBlockEvents(blockEvents)
+		require.Error(t, evmEvents.Err)
 		assert.ErrorContains(
 			t,
-			err,
+			evmEvents.Err,
 			"block 1 references missing transaction/s",
 		)
 	})
@@ -110,8 +131,8 @@ func TestCadenceEvents_Block(t *testing.T) {
 
 		blockEvents.Events = append(blockEvents.Events, blockEvent)
 
-		_, err = NewCadenceEvents(blockEvents)
-		require.NoError(t, err)
+		evmEvents := NewSingleBlockEvents(blockEvents)
+		require.NoError(t, evmEvents.Err)
 	})
 
 	t.Run("block with empty transaction hashes", func(t *testing.T) {
@@ -126,8 +147,8 @@ func TestCadenceEvents_Block(t *testing.T) {
 
 		blockEvents.Events = append(blockEvents.Events, blockEvent)
 
-		_, err = NewCadenceEvents(blockEvents)
-		require.NoError(t, err)
+		evmEvents := NewSingleBlockEvents(blockEvents)
+		require.NoError(t, evmEvents.Err)
 	})
 
 	t.Run("block with more transaction hashes", func(t *testing.T) {
@@ -145,11 +166,11 @@ func TestCadenceEvents_Block(t *testing.T) {
 
 		blockEvents.Events = append(blockEvents.Events, blockEvent)
 
-		_, err = NewCadenceEvents(blockEvents)
-		require.Error(t, err)
+		evmEvents := NewSingleBlockEvents(blockEvents)
+		require.Error(t, evmEvents.Err)
 		assert.ErrorContains(
 			t,
-			err,
+			evmEvents.Err,
 			"block 1 references missing transaction/s",
 		)
 	})
@@ -201,9 +222,9 @@ func TestCadenceEvents_Block(t *testing.T) {
 		blockEvents.Events = append(blockEvents.Events, blockEvent)
 
 		// parse the EventStreaming API response
-		blkEvents := NewSingleBlockEvents(blockEvents)
-		require.NoError(t, blkEvents.Err)
-		cdcEvents := blkEvents.Events
+		evmEvents := NewSingleBlockEvents(blockEvents)
+		require.NoError(t, evmEvents.Err)
+		cdcEvents := evmEvents.Events
 
 		// assert that Flow events are sorted by their TransactionIndex and EventIndex fields
 		assert.Equal(
@@ -237,6 +258,239 @@ func TestCadenceEvents_Block(t *testing.T) {
 			assert.Equal(t, tx.Hash(), txEventPayload.Hash)
 			assert.Equal(t, blockEventPayload.Height, txEventPayload.BlockHeight)
 		}
+	})
+}
+
+func TestNewMultiBlockEvents(t *testing.T) {
+	invalid := cadence.String("invalid")
+
+	b0, e0, err := newBlock(0, nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		events flow.BlockEvents
+		block  *Block
+		err    error
+	}{
+		{
+			name:   "BlockExecutedEventExists",
+			events: flow.BlockEvents{Events: []flow.Event{e0}},
+			block:  b0,
+		}, {
+			name:   "BlockExecutedEventEmpty",
+			events: flow.BlockEvents{Events: []flow.Event{}},
+			block:  nil,
+		}, {
+			name: "BlockExecutedNotFound",
+			events: flow.BlockEvents{Events: []flow.Event{{
+				Type:  e0.Type,
+				Value: cadence.NewEvent([]cadence.Value{invalid}),
+			}}},
+			block: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evmEvents := NewMultiBlockEvents(tt.events)
+			require.NoError(t, evmEvents.Err)
+
+			cdcEvents := evmEvents.Events
+			if tt.block != nil {
+				ttHash, err := tt.block.Hash()
+				require.NoError(t, err)
+				hash, err := cdcEvents.Block().Hash()
+				require.NoError(t, err)
+				assert.Equal(t, ttHash, hash)
+			} else {
+				assert.Nil(t, cdcEvents.Block())
+			}
+		})
+	}
+
+	cadenceHeight := uint64(15)
+	txCount := 10
+	hashes := make([]gethCommon.Hash, txCount)
+	evmTxEvents := make([]flow.BlockEvents, txCount)
+
+	// generate txs
+	for i := 0; i < txCount; i++ {
+		tx, _, txEvent, err := newTransaction(uint64(i), uint16(i))
+		require.NoError(t, err)
+		hashes[i] = tx.Hash()
+		evmTxEvents[i] = flow.BlockEvents{
+			BlockID: flow.BytesToID([]byte{uint8(i + 1)}),
+			Height:  uint64(i + 1),
+			Events:  []flow.Event{txEvent},
+		}
+	}
+
+	t.Run("missing block with transactions", func(t *testing.T) {
+		// generate single block
+		_, _, err := newBlock(cadenceHeight, hashes)
+		require.NoError(t, err)
+
+		blockEvents := flow.BlockEvents{
+			BlockID: flow.Identifier{0x1},
+			Height:  cadenceHeight,
+		}
+
+		// Below we add all the EVM transaction events, but we have omitted
+		// the EVM.BlockExecuted event.
+		for i := 0; i < txCount; i++ {
+			blockEvents.Events = append(blockEvents.Events, evmTxEvents[i].Events...)
+		}
+
+		evmEvents := NewSingleBlockEvents(blockEvents)
+		require.Error(t, evmEvents.Err)
+		assert.ErrorContains(
+			t,
+			evmEvents.Err,
+			"missing block EVM block nil at flow block: 1",
+		)
+	})
+
+	t.Run("block with less transaction hashes", func(t *testing.T) {
+		// generate single block
+		_, blockEvent, err := newBlock(cadenceHeight, hashes)
+		require.NoError(t, err)
+
+		blockEvents := flow.BlockEvents{
+			BlockID: flow.Identifier{0x1},
+			Height:  cadenceHeight,
+		}
+
+		// Below we omit 2 EVM transactions from the events
+		for i := 0; i < txCount-2; i++ {
+			blockEvents.Events = append(blockEvents.Events, evmTxEvents[i].Events...)
+		}
+
+		blockEvents.Events = append(blockEvents.Events, blockEvent)
+
+		evmEvents := NewMultiBlockEvents(blockEvents)
+		require.Error(t, evmEvents.Err)
+		assert.ErrorContains(
+			t,
+			evmEvents.Err,
+			"block 15 references missing transaction/s",
+		)
+	})
+
+	t.Run("block with equal transaction hashes", func(t *testing.T) {
+		// generate single block
+		_, blockEvent, err := newBlock(cadenceHeight, hashes)
+		require.NoError(t, err)
+
+		blockEvents := flow.BlockEvents{
+			BlockID: flow.Identifier{0x1},
+			Height:  cadenceHeight,
+		}
+
+		// Below we add all the EVM transaction events
+		for i := 0; i < txCount; i++ {
+			blockEvents.Events = append(blockEvents.Events, evmTxEvents[i].Events...)
+		}
+
+		blockEvents.Events = append(blockEvents.Events, blockEvent)
+
+		evmEvents := NewMultiBlockEvents(blockEvents)
+		require.NoError(t, evmEvents.Err)
+	})
+
+	t.Run("block with empty transaction hashes", func(t *testing.T) {
+		// generate single block
+		_, blockEvent, err := newBlock(cadenceHeight, []gethCommon.Hash{})
+		require.NoError(t, err)
+
+		blockEvents := flow.BlockEvents{
+			BlockID: flow.Identifier{0x1},
+			Height:  cadenceHeight,
+		}
+
+		blockEvents.Events = append(blockEvents.Events, blockEvent)
+
+		evmEvents := NewMultiBlockEvents(blockEvents)
+		require.NoError(t, evmEvents.Err)
+	})
+
+	t.Run("block with more transaction hashes", func(t *testing.T) {
+		tx, _, _, err := newTransaction(1, 0)
+		require.NoError(t, err)
+
+		// generate single block
+		_, blockEvent, err := newBlock(cadenceHeight, []gethCommon.Hash{tx.Hash()})
+		require.NoError(t, err)
+
+		blockEvents := flow.BlockEvents{
+			BlockID: flow.Identifier{0x1},
+			Height:  cadenceHeight,
+		}
+
+		blockEvents.Events = append(blockEvents.Events, blockEvent)
+
+		evmEvents := NewMultiBlockEvents(blockEvents)
+		require.Error(t, evmEvents.Err)
+		assert.ErrorContains(
+			t,
+			evmEvents.Err,
+			"block 15 references missing transaction/s",
+		)
+	})
+
+	t.Run("EVM.TransactionExecuted events should be properly ordered", func(t *testing.T) {
+		blockEvents := flow.BlockEvents{
+			BlockID: flow.Identifier{0x1},
+			Height:  cadenceHeight,
+		}
+
+		// tx1 and tx2 are EVM transactions executed on a single Flow transaction.
+		tx1, _, txEvent1, err := newTransaction(0, 0)
+		require.NoError(t, err)
+		txEvent1.TransactionIndex = 0
+		txEvent1.EventIndex = 2
+
+		tx2, _, txEvent2, err := newTransaction(1, 1)
+		require.NoError(t, err)
+		txEvent2.TransactionIndex = 0
+		txEvent2.EventIndex = 5
+
+		// tx3 is a Flow transaction with a single EVM transaction on EventIndex=1
+		tx3, _, txEvent3, err := newTransaction(2, 0)
+		require.NoError(t, err)
+		txEvent3.TransactionIndex = 2
+		txEvent3.EventIndex = 1
+
+		// needed for computing the `TransactionHashRoot` field on
+		// EVM.BlockExecuted event payload. the order is sensitive.
+		hashes = []gethCommon.Hash{
+			tx1.Hash(),
+			tx2.Hash(),
+			tx3.Hash(),
+		}
+
+		// add the tx events in a shuffled order
+		blockEvents.Events = []flow.Event{
+			txEvent3,
+			txEvent1,
+			txEvent2,
+		}
+
+		// generate single block
+		_, blockEvent, err := newBlock(cadenceHeight, hashes)
+		require.NoError(t, err)
+		blockEvent.TransactionIndex = 4
+		blockEvent.EventIndex = 0
+		blockEvents.Events = append(blockEvents.Events, blockEvent)
+
+		// parse the EventStreaming API response
+		evmEvents := NewMultiBlockEvents(blockEvents)
+		require.Error(t, evmEvents.Err)
+		assert.ErrorContains(
+			t,
+			evmEvents.Err,
+			"block 15 references missing transaction/s",
+		)
 	})
 }
 

--- a/models/events_test.go
+++ b/models/events_test.go
@@ -201,8 +201,9 @@ func TestCadenceEvents_Block(t *testing.T) {
 		blockEvents.Events = append(blockEvents.Events, blockEvent)
 
 		// parse the EventStreaming API response
-		cdcEvents, err := NewCadenceEvents(blockEvents)
-		require.NoError(t, err)
+		blkEvents := NewSingleBlockEvents(blockEvents)
+		require.NoError(t, blkEvents.Err)
+		cdcEvents := blkEvents.Events
 
 		// assert that Flow events are sorted by their TransactionIndex and EventIndex fields
 		assert.Equal(

--- a/services/ingestion/engine_test.go
+++ b/services/ingestion/engine_test.go
@@ -104,7 +104,7 @@ func TestSerialBlockIngestion(t *testing.T) {
 				}).
 				Once()
 
-			eventsChan <- models.NewBlockEvents(flow.BlockEvents{
+			eventsChan <- models.NewSingleBlockEvents(flow.BlockEvents{
 				Events: []flow.Event{{
 					Type:  string(blockEvent.Etype),
 					Value: blockCdc,
@@ -318,7 +318,7 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 			}).
 			Once()
 
-		eventsChan <- models.NewBlockEvents(flow.BlockEvents{
+		eventsChan <- models.NewSingleBlockEvents(flow.BlockEvents{
 			Events: []flow.Event{{
 				Type:  string(blockEvent.Etype),
 				Value: blockCdc,
@@ -420,7 +420,7 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 			}).
 			Once()
 
-		eventsChan <- models.NewBlockEvents(flow.BlockEvents{
+		eventsChan <- models.NewSingleBlockEvents(flow.BlockEvents{
 			Events: []flow.Event{
 				// first transaction
 				{
@@ -557,7 +557,7 @@ func TestBlockAndTransactionIngestion(t *testing.T) {
 		// and it will make the first block be swapped with second block out-of-order
 		events[1], events[2] = events[2], events[1]
 
-		eventsChan <- models.NewBlockEvents(flow.BlockEvents{
+		eventsChan <- models.NewSingleBlockEvents(flow.BlockEvents{
 			Events: events,
 			Height: latestCadenceHeight + 1,
 		})

--- a/services/ingestion/event_subscriber.go
+++ b/services/ingestion/event_subscriber.go
@@ -160,7 +160,7 @@ func (r *RPCEventSubscriber) subscribe(ctx context.Context, height uint64) <-cha
 					return
 				}
 
-				evmEvents := models.NewBlockEvents(blockEvents)
+				evmEvents := models.NewSingleBlockEvents(blockEvents)
 				// if events contain an error, or we are in a recovery mode
 				if evmEvents.Err != nil || r.recovery {
 					evmEvents = r.recover(ctx, blockEvents, evmEvents.Err)
@@ -237,6 +237,18 @@ const maxRangeForGetEvents = uint64(249)
 func (r *RPCEventSubscriber) backfillSporkFromHeight(ctx context.Context, fromCadenceHeight uint64, eventsChan chan<- models.BlockEvents) (uint64, error) {
 	evmAddress := common.Address(systemcontracts.SystemContractsForChain(r.chain).EVMContract.Address)
 
+	blockExecutedEvent := common.NewAddressLocation(
+		nil,
+		evmAddress,
+		string(events.EventTypeBlockExecuted),
+	).ID()
+
+	transactionExecutedEvent := common.NewAddressLocation(
+		nil,
+		evmAddress,
+		string(events.EventTypeTransactionExecuted),
+	).ID()
+
 	lastHeight, err := r.client.GetLatestHeightForSpork(ctx, fromCadenceHeight)
 	if err != nil {
 		eventsChan <- models.NewBlockEventsError(err)
@@ -256,18 +268,6 @@ func (r *RPCEventSubscriber) backfillSporkFromHeight(ctx context.Context, fromCa
 		if endHeight > lastHeight {
 			endHeight = lastHeight
 		}
-
-		blockExecutedEvent := common.NewAddressLocation(
-			nil,
-			evmAddress,
-			string(events.EventTypeBlockExecuted),
-		).ID()
-
-		transactionExecutedEvent := common.NewAddressLocation(
-			nil,
-			evmAddress,
-			string(events.EventTypeTransactionExecuted),
-		).ID()
 
 		blocks, err := r.client.GetEventsForHeightRange(ctx, blockExecutedEvent, startHeight, endHeight)
 		if err != nil {
@@ -299,7 +299,22 @@ func (r *RPCEventSubscriber) backfillSporkFromHeight(ctx context.Context, fromCa
 			// append the transaction events to the block events
 			blocks[i].Events = append(blocks[i].Events, transactions[i].Events...)
 
-			evmEvents := models.NewBlockEvents(blocks[i])
+			evmEvents := models.NewSingleBlockEvents(blocks[i])
+			if evmEvents.Err != nil && errors.Is(evmEvents.Err, errs.ErrMissingBlock) {
+				evmEvents, err = r.accumulateBlockEvents(
+					ctx,
+					blocks[i],
+					blockExecutedEvent,
+					transactionExecutedEvent,
+				)
+				if err != nil {
+					return 0, err
+				}
+				eventsChan <- evmEvents
+				// advance the height
+				fromCadenceHeight = evmEvents.Events.CadenceHeight() + 1
+				break
+			}
 			eventsChan <- evmEvents
 
 			// advance the height
@@ -308,6 +323,86 @@ func (r *RPCEventSubscriber) backfillSporkFromHeight(ctx context.Context, fromCa
 
 	}
 	return fromCadenceHeight, nil
+}
+
+// accumulateBlockEvents will keep fetching `EVM.TransactionExecuted` events
+// until it finds their `EVM.BlockExecuted` event.
+// At that point it will return the valid models.BlockEvents.
+func (r *RPCEventSubscriber) accumulateBlockEvents(
+	ctx context.Context,
+	block flow.BlockEvents,
+	blockExecutedEventType string,
+	txExecutedEventType string,
+) (models.BlockEvents, error) {
+	evmEvents := models.NewSingleBlockEvents(block)
+	currentHeight := block.Height
+	transactionEvents := make([]flow.Event, 0)
+
+	for evmEvents.Err != nil && errors.Is(evmEvents.Err, errs.ErrMissingBlock) {
+		blocks, err := r.client.GetEventsForHeightRange(
+			ctx,
+			blockExecutedEventType,
+			currentHeight,
+			currentHeight+maxRangeForGetEvents,
+		)
+		if err != nil {
+			return models.BlockEvents{}, fmt.Errorf("failed to get block events: %w", err)
+		}
+
+		transactions, err := r.client.GetEventsForHeightRange(
+			ctx,
+			txExecutedEventType,
+			currentHeight,
+			currentHeight+maxRangeForGetEvents,
+		)
+		if err != nil {
+			return models.BlockEvents{}, fmt.Errorf("failed to get block events: %w", err)
+		}
+
+		if len(transactions) != len(blocks) {
+			return models.BlockEvents{}, fmt.Errorf("transactions and blocks have different length")
+		}
+
+		// sort both, just in case
+		sort.Slice(blocks, func(i, j int) bool {
+			return blocks[i].Height < blocks[j].Height
+		})
+		sort.Slice(transactions, func(i, j int) bool {
+			return transactions[i].Height < transactions[j].Height
+		})
+
+		for i := range blocks {
+			if transactions[i].Height != blocks[i].Height {
+				return models.BlockEvents{}, fmt.Errorf("transactions and blocks have different height")
+			}
+
+			// If no EVM.BlockExecuted event found, keep accumulating the incoming
+			// EVM.TransactionExecuted events, until we find the EVM.BlockExecuted
+			// event that includes them.
+			if len(blocks[i].Events) == 0 {
+				txEvents := transactions[i].Events
+				// Sort `EVM.TransactionExecuted` events
+				sort.Slice(txEvents, func(i, j int) bool {
+					if txEvents[i].TransactionIndex != txEvents[j].TransactionIndex {
+						return txEvents[i].TransactionIndex < txEvents[j].TransactionIndex
+					}
+					return txEvents[i].EventIndex < txEvents[j].EventIndex
+				})
+				transactionEvents = append(transactionEvents, txEvents...)
+			} else {
+				blocks[i].Events = append(blocks[i].Events, transactionEvents...)
+				// We use `models.NewMultiBlockEvents`, as the `transactionEvents`
+				// are coming from different Flow blocks.
+				evmEvents = models.NewMultiBlockEvents(blocks[i])
+				if evmEvents.Err == nil {
+					return evmEvents, nil
+				}
+			}
+
+			currentHeight = blocks[i].Height + 1
+		}
+	}
+	return evmEvents, nil
 }
 
 // fetchMissingData is used as a backup mechanism for fetching EVM-related
@@ -346,17 +441,27 @@ func (r *RPCEventSubscriber) fetchMissingData(
 		blockEvents.Events = append(blockEvents.Events, recoveredEvents[0].Events...)
 	}
 
-	return models.NewBlockEvents(blockEvents)
+	return models.NewSingleBlockEvents(blockEvents)
 }
 
 // accumulateEventsMissingBlock will keep receiving transaction events until it can produce a valid
 // EVM block event containing a block and transactions. At that point it will reset the recovery mode
 // and return the valid block events.
 func (r *RPCEventSubscriber) accumulateEventsMissingBlock(events flow.BlockEvents) models.BlockEvents {
-	r.recoveredEvents = append(r.recoveredEvents, events.Events...)
+	txEvents := events.Events
+	// Sort `EVM.TransactionExecuted` events
+	sort.Slice(txEvents, func(i, j int) bool {
+		if txEvents[i].TransactionIndex != txEvents[j].TransactionIndex {
+			return txEvents[i].TransactionIndex < txEvents[j].TransactionIndex
+		}
+		return txEvents[i].EventIndex < txEvents[j].EventIndex
+	})
+	r.recoveredEvents = append(r.recoveredEvents, txEvents...)
 	events.Events = r.recoveredEvents
 
-	recovered := models.NewBlockEvents(events)
+	// We use `models.NewMultiBlockEvents`, as the `transactionEvents`
+	// are coming from different Flow blocks.
+	recovered := models.NewMultiBlockEvents(events)
 	r.recovery = recovered.Err != nil
 
 	if !r.recovery {


### PR DESCRIPTION
## Description


______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 