### PR TITLE
Fix wrong block hash value for the 1st EVM block with `PrevRandao`

### DIFF
--- a/storage/pebble/blocks.go
+++ b/storage/pebble/blocks.go
@@ -253,6 +253,15 @@ func (b *Blocks) getBlock(keyCode byte, key []byte) (*models.Block, error) {
 	}
 
 	if b.chainID == flowGo.Testnet && slices.Contains(testnetBrokenParentHashBlockHeights, block.Height) {
+		// Since we are going to modify the `block.ParentBlockHash` field,
+		// we need to set the `block.FixedHash` field. If we don't do so,
+		// `block.Hash()` will return a different hash.
+		blockHash, err := block.Hash()
+		if err != nil {
+			return nil, err
+		}
+		block.FixedHash = blockHash
+
 		parentBlock, err := b.getBlock(blockHeightKey, uint64Bytes(block.Height-1))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description

The EVM block at which `PrevRandao` was introduced, needs some special handling for setting the `Hash` & `ParentBlockHash` fields, as the addition of the `PrevRandao` field caused the hash calculation to change.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 