### PR TITLE
Run without coa account

### DIFF
--- a/services/requester/cadence/run.cdc
+++ b/services/requester/cadence/run.cdc
@@ -1,14 +1,6 @@
 import EVM
 
 transaction(hexEncodedTx: String, coinbase: String) {
-    let coa: &EVM.CadenceOwnedAccount
-
-    prepare(signer: auth(Storage) &Account) {
-        self.coa = signer.storage.borrow<&EVM.CadenceOwnedAccount>(
-            from: /storage/evm
-        ) ?? panic("Could not borrow reference to the COA!")
-    }
-
     execute {
         let txResult = EVM.run(
             tx: hexEncodedTx.decodeHex(),

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -315,8 +315,7 @@ func (e *EVM) buildTransaction(ctx context.Context, script []byte, args ...caden
 		SetScript(script).
 		SetProposalKey(address, index, seqNum).
 		SetReferenceBlockID(latestBlock.ID).
-		SetPayer(address).
-		AddAuthorizer(address)
+		SetPayer(address)
 
 	for _, arg := range args {
 		if err := flowTx.AddArgument(arg); err != nil {


### PR DESCRIPTION
Closes: #???

## Description
The run.cdc creates a unused coa account, which is unnecessary. 
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified transaction execution by removing unnecessary variable preparation, enhancing performance and reliability.
  
- **Refactor**
	- Streamlined the transaction handling process by removing the additional authorizer in transaction creation.
	- Enhanced error logging for better visibility of issues during execution.
	- Introduced caching for script execution results to improve performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->