### PR TITLE
Add debug_flowHeight API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ The EVM Gateway implements APIs according to the Ethereum specification: https:/
     * debug_traceBlockByNumber
     * debug_traceBlockByHash
 
-- debug_flowBlock - returns the flow block height for the given EVM block (id or height)
+- debug_flowHeightByBlock - returns the flow block height for the given EVM block (id or height)
 
 **Unsupported APIs**
 - Wallet APIs: we don't officially support wallet APIs (eth_accounts, eth_sign, eth_signTransaction, eth_sendTransaction) due to security

--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ The EVM Gateway implements APIs according to the Ethereum specification: https:/
     * debug_traceBlockByNumber
     * debug_traceBlockByHash
 
+- debug_flowBlock - returns the flow block height for the given EVM block (id or height)
+
 **Unsupported APIs**
 - Wallet APIs: we don't officially support wallet APIs (eth_accounts, eth_sign, eth_signTransaction, eth_sendTransaction) due to security
   concerns that come with managing the keys on production environments, however, it is possible to configure the gateway to allow these

--- a/api/api.go
+++ b/api/api.go
@@ -76,6 +76,7 @@ var validMethods = map[string]struct{}{
 	"debug_traceBlockByNumber": {},
 	"debug_traceBlockByHash":   {},
 	"debug_traceCall":          {},
+	"debug_flowHeightByBlock":  {},
 
 	// web3 namespace
 	"web3_clientVersion": {},

--- a/api/debug.go
+++ b/api/debug.go
@@ -361,6 +361,24 @@ func (d *DebugAPI) TraceCall(
 	return tracer.GetResult()
 }
 
+// FlowHeight returns the Flow height for the given EVM block.
+func (d *DebugAPI) FlowHeight(
+	_ context.Context,
+	blockNrOrHash rpc.BlockNumberOrHash,
+) (uint64, error) {
+	height, err := resolveBlockTag(&blockNrOrHash, d.blocks, d.logger)
+	if err != nil {
+		return 0, err
+	}
+
+	cdcHeight, err := d.blocks.GetCadenceHeight(height)
+	if err != nil {
+		return 0, err
+	}
+
+	return cdcHeight, nil
+}
+
 func (d *DebugAPI) executorAtBlock(block *models.Block) (*evm.BlockExecutor, error) {
 	snapshot, err := d.registerStore.GetSnapshotAt(block.Height)
 	if err != nil {

--- a/api/debug.go
+++ b/api/debug.go
@@ -361,7 +361,8 @@ func (d *DebugAPI) TraceCall(
 	return tracer.GetResult()
 }
 
-// FlowHeight returns the Flow height for the given EVM block.
+// FlowHeight returns the Flow height for the given EVM block specified either by EVM
+// block height or EVM block hash.
 func (d *DebugAPI) FlowHeight(
 	_ context.Context,
 	blockNrOrHash rpc.BlockNumberOrHash,

--- a/api/debug.go
+++ b/api/debug.go
@@ -361,9 +361,9 @@ func (d *DebugAPI) TraceCall(
 	return tracer.GetResult()
 }
 
-// FlowHeight returns the Flow height for the given EVM block specified either by EVM
+// FlowHeightByBlock returns the Flow height for the given EVM block specified either by EVM
 // block height or EVM block hash.
-func (d *DebugAPI) FlowHeight(
+func (d *DebugAPI) FlowHeightByBlock(
 	_ context.Context,
 	blockNrOrHash rpc.BlockNumberOrHash,
 ) (uint64, error) {

--- a/tests/e2e_web3js_test.go
+++ b/tests/e2e_web3js_test.go
@@ -36,7 +36,7 @@ func TestWeb3_E2E(t *testing.T) {
 		runWeb3Test(t, "debug_traces_test")
 	})
 
-	t.Run("test transaction traces", func(t *testing.T) {
+	t.Run("test debug utils", func(t *testing.T) {
 		runWeb3Test(t, "debug_util_test")
 	})
 

--- a/tests/e2e_web3js_test.go
+++ b/tests/e2e_web3js_test.go
@@ -36,6 +36,10 @@ func TestWeb3_E2E(t *testing.T) {
 		runWeb3Test(t, "debug_traces_test")
 	})
 
+	t.Run("test transaction traces", func(t *testing.T) {
+		runWeb3Test(t, "debug_util_test")
+	})
+
 	t.Run("test setup sanity check", func(t *testing.T) {
 		runWeb3Test(t, "setup_test")
 	})

--- a/tests/web3js/debug_util_test.js
+++ b/tests/web3js/debug_util_test.js
@@ -4,7 +4,7 @@ const conf = require('./config')
 
 it('should retrieve flow height', async () => {
     let response = await helpers.callRPCMethod(
-        'debug_flowHeight',
+        'debug_flowHeightByBlock',
         ['latest']
     )
     assert.equal(response.status, 200)

--- a/tests/web3js/debug_util_test.js
+++ b/tests/web3js/debug_util_test.js
@@ -1,8 +1,9 @@
 const { assert } = require('chai')
 const helpers = require('./helpers')
+const conf = require('./config')
 
 it('should retrieve flow height', async () => {
-    response = await helpers.callRPCMethod(
+    let response = await helpers.callRPCMethod(
         'debug_flowHeight',
         ['latest']
     )
@@ -10,5 +11,5 @@ it('should retrieve flow height', async () => {
     assert.isDefined(response.body)
 
     let height = response.body.result
-    assert.isTrue(height > 0)
+    assert.equal(height, conf.startBlockHeight)
 })

--- a/tests/web3js/debug_util_test.js
+++ b/tests/web3js/debug_util_test.js
@@ -1,0 +1,14 @@
+const { assert } = require('chai')
+const helpers = require('./helpers')
+
+it('should retrieve flow height', async () => {
+    response = await helpers.callRPCMethod(
+        'debug_flowHeight',
+        ['latest']
+    )
+    assert.equal(response.status, 200)
+    assert.isDefined(response.body)
+
+    let height = response.body.result
+    assert.isTrue(height > 0)
+})


### PR DESCRIPTION

## Description

Added `debug_flowHeight` API endpoint so you can get the flow height at a given EVM block

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 