### PR TITLE
Cleanup run cmd

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -7,6 +7,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/onflow/flow-go/module/component"
+
 	pebbleDB "github.com/cockroachdb/pebble"
 
 	"github.com/onflow/flow-go-sdk/access"
@@ -557,7 +559,7 @@ func setupStorage(
 // Run will run complete bootstrap of the EVM gateway with all the engines.
 // Run is a blocking call, but it does signal readiness of the service
 // through a channel provided as an argument.
-func Run(ctx context.Context, cfg *config.Config, ready chan struct{}) error {
+func Run(ctx context.Context, cfg *config.Config, ready component.ReadyFunc) error {
 	boot, err := New(cfg)
 	if err != nil {
 		return err
@@ -580,7 +582,7 @@ func Run(ctx context.Context, cfg *config.Config, ready chan struct{}) error {
 	}
 
 	// mark ready
-	close(ready)
+	ready()
 
 	// if context is canceled start shutdown
 	<-ctx.Done()

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -161,7 +161,9 @@ func servicesSetup(t *testing.T) (emulator.Emulator, func()) {
 
 	bootstrapDone := make(chan struct{})
 	go func() {
-		err = bootstrap.Run(ctx, cfg, bootstrapDone)
+		err = bootstrap.Run(ctx, cfg, func() {
+			close(bootstrapDone)
+		})
 		require.NoError(t, err)
 	}()
 

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -83,7 +83,9 @@ func Test_ConcurrentTransactionSubmission(t *testing.T) {
 
 	ready := make(chan struct{})
 	go func() {
-		err := bootstrap.Run(ctx, cfg, ready)
+		err := bootstrap.Run(ctx, cfg, func() {
+			close(ready)
+		})
 		require.NoError(t, err)
 	}()
 
@@ -181,7 +183,9 @@ func Test_EthClientTest(t *testing.T) {
 
 	ready := make(chan struct{})
 	go func() {
-		err := bootstrap.Run(ctx, cfg, ready)
+		err := bootstrap.Run(ctx, cfg, func() {
+			close(ready)
+		})
 		require.NoError(t, err)
 	}()
 
@@ -288,7 +292,9 @@ func Test_CloudKMSConcurrentTransactionSubmission(t *testing.T) {
 
 	ready := make(chan struct{})
 	go func() {
-		err := bootstrap.Run(ctx, cfg, ready)
+		err := bootstrap.Run(ctx, cfg, func() {
+			close(ready)
+		})
 		require.NoError(t, err)
 	}()
 


### PR DESCRIPTION
## Description

Progressively refactoring startup/shutdown to switch to node builder.

This is part 1, with some cleanup to the CMD to make it cleared whats going on.

Note: I did not like the design where `bootstrap.Run` closed a write channel that was passed in, so I refactored that into a `ready()` function which is also more in line with components in flow-go

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 