### PR TITLE
Fix race for `startingBlock` field of `eth_syncing` endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -170,13 +170,8 @@ func NewBlockChainAPI(
 	receipts storage.ReceiptIndexer,
 	ratelimiter limiter.Store,
 	collector metrics.Collector,
-) (*BlockChainAPI, error) {
-	// get the height from which the indexing resumed since the last restart, this is needed for syncing status.
-	indexingResumedHeight, err := blocks.LatestEVMHeight()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve the indexing resumed height: %w", err)
-	}
-
+	indexingResumedHeight uint64,
+) *BlockChainAPI {
 	return &BlockChainAPI{
 		logger:                logger,
 		config:                config,
@@ -187,7 +182,7 @@ func NewBlockChainAPI(
 		indexingResumedHeight: indexingResumedHeight,
 		limiter:               ratelimiter,
 		collector:             collector,
-	}, nil
+	}
 }
 
 // BlockNumber returns the block number of the chain head.


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/644

## Description


______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 