### PR TITLE
Use instance of config instead of reference

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -109,7 +109,7 @@ func SupportedAPIs(
 	pullAPI *PullAPI,
 	debugAPI *DebugAPI,
 	walletAPI *WalletAPI,
-	config *config.Config,
+	config config.Config,
 ) []rpc.API {
 	apis := []rpc.API{{
 		Namespace: "eth",
@@ -151,7 +151,7 @@ func SupportedAPIs(
 
 type BlockChainAPI struct {
 	logger                zerolog.Logger
-	config                *config.Config
+	config                config.Config
 	evm                   requester.Requester
 	blocks                storage.BlockIndexer
 	transactions          storage.TransactionIndexer
@@ -163,7 +163,7 @@ type BlockChainAPI struct {
 
 func NewBlockChainAPI(
 	logger zerolog.Logger,
-	config *config.Config,
+	config config.Config,
 	evm requester.Requester,
 	blocks storage.BlockIndexer,
 	transactions storage.TransactionIndexer,

--- a/api/debug.go
+++ b/api/debug.go
@@ -49,7 +49,7 @@ type DebugAPI struct {
 	transactions  storage.TransactionIndexer
 	receipts      storage.ReceiptIndexer
 	client        *requester.CrossSporkClient
-	config        *config.Config
+	config        config.Config
 	collector     metrics.Collector
 }
 
@@ -60,7 +60,7 @@ func NewDebugAPI(
 	transactions storage.TransactionIndexer,
 	receipts storage.ReceiptIndexer,
 	client *requester.CrossSporkClient,
-	config *config.Config,
+	config config.Config,
 	logger zerolog.Logger,
 	collector metrics.Collector,
 ) *DebugAPI {

--- a/api/net.go
+++ b/api/net.go
@@ -9,10 +9,10 @@ import (
 
 // NetAPI offers network related RPC methods
 type NetAPI struct {
-	config *config.Config
+	config config.Config
 }
 
-func NewNetAPI(config *config.Config) *NetAPI {
+func NewNetAPI(config config.Config) *NetAPI {
 	return &NetAPI{
 		config: config,
 	}

--- a/api/pull.go
+++ b/api/pull.go
@@ -129,7 +129,7 @@ func newLogsFilter(
 
 type PullAPI struct {
 	logger       zerolog.Logger
-	config       *config.Config
+	config       config.Config
 	blocks       storage.BlockIndexer
 	transactions storage.TransactionIndexer
 	receipts     storage.ReceiptIndexer
@@ -140,7 +140,7 @@ type PullAPI struct {
 
 func NewPullAPI(
 	logger zerolog.Logger,
-	config *config.Config,
+	config config.Config,
 	blocks storage.BlockIndexer,
 	transactions storage.TransactionIndexer,
 	receipts storage.ReceiptIndexer,

--- a/api/pull_test.go
+++ b/api/pull_test.go
@@ -60,7 +60,7 @@ func TestFilterExpiryChecker(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			api := &PullAPI{
 				filters: make(map[rpc.ID]filter),
-				config:  &config.Config{FilterExpiry: time.Millisecond * 5},
+				config:  config.Config{FilterExpiry: time.Millisecond * 5},
 			}
 
 			tc.setup(api)

--- a/api/server.go
+++ b/api/server.go
@@ -53,7 +53,7 @@ type Server struct {
 	host     string
 	port     int
 
-	config    *config.Config
+	config    config.Config
 	collector metrics.Collector
 }
 
@@ -66,7 +66,7 @@ const (
 func NewServer(
 	logger zerolog.Logger,
 	collector metrics.Collector,
-	cfg *config.Config,
+	cfg config.Config,
 ) *Server {
 	logger = logger.With().Str("component", "API").Logger()
 

--- a/api/stream.go
+++ b/api/stream.go
@@ -21,7 +21,7 @@ import (
 
 type StreamAPI struct {
 	logger                zerolog.Logger
-	config                *config.Config
+	config                config.Config
 	blocks                storage.BlockIndexer
 	transactions          storage.TransactionIndexer
 	receipts              storage.ReceiptIndexer
@@ -32,7 +32,7 @@ type StreamAPI struct {
 
 func NewStreamAPI(
 	logger zerolog.Logger,
-	config *config.Config,
+	config config.Config,
 	blocks storage.BlockIndexer,
 	transactions storage.TransactionIndexer,
 	receipts storage.ReceiptIndexer,

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -19,10 +19,10 @@ import (
 
 type WalletAPI struct {
 	net    *BlockChainAPI
-	config *config.Config
+	config config.Config
 }
 
-func NewWalletAPI(config *config.Config, net *BlockChainAPI) *WalletAPI {
+func NewWalletAPI(config config.Config, net *BlockChainAPI) *WalletAPI {
 	return &WalletAPI{
 		net:    net,
 		config: config,

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -51,7 +51,7 @@ type Publishers struct {
 
 type Bootstrap struct {
 	logger     zerolog.Logger
-	config     *config.Config
+	config     config.Config
 	client     *requester.CrossSporkClient
 	storages   *Storages
 	publishers *Publishers
@@ -63,7 +63,7 @@ type Bootstrap struct {
 	db         *pebbleDB.DB
 }
 
-func New(config *config.Config) (*Bootstrap, error) {
+func New(config config.Config) (*Bootstrap, error) {
 	logger := zerolog.New(config.LogWriter).
 		With().Timestamp().Str("version", api.Version).
 		Logger().Level(config.LogLevel)
@@ -432,7 +432,7 @@ func StartEngine(
 }
 
 // setupCrossSporkClient sets up a cross-spork AN client.
-func setupCrossSporkClient(config *config.Config, logger zerolog.Logger) (*requester.CrossSporkClient, error) {
+func setupCrossSporkClient(config config.Config, logger zerolog.Logger) (*requester.CrossSporkClient, error) {
 	// create access client with cross-spork capabilities
 	currentSporkClient, err := grpc.NewClient(
 		config.AccessNodeHost,
@@ -474,7 +474,7 @@ func setupCrossSporkClient(config *config.Config, logger zerolog.Logger) (*reque
 // setupStorage creates storage and initializes it with configured starting cadence height
 // in case such a height doesn't already exist in the database.
 func setupStorage(
-	config *config.Config,
+	config config.Config,
 	client *requester.CrossSporkClient,
 	logger zerolog.Logger,
 ) (*pebbleDB.DB, *Storages, error) {
@@ -571,7 +571,7 @@ func setupStorage(
 // Run will run complete bootstrap of the EVM gateway with all the engines.
 // Run is a blocking call, but it does signal readiness of the service
 // through a channel provided as an argument.
-func Run(ctx context.Context, cfg *config.Config, ready component.ReadyFunc) error {
+func Run(ctx context.Context, cfg config.Config, ready component.ReadyFunc) error {
 	boot, err := New(cfg)
 	if err != nil {
 		return err

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -244,7 +244,7 @@ func parseConfigFromFlags() error {
 	return nil
 }
 
-var cfg = &config.Config{}
+var cfg = config.Config{}
 var (
 	coinbase,
 	gas,

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -98,7 +98,7 @@ type EVM struct {
 	registerStore  *pebble.RegisterStorage
 	blocksProvider *replayer.BlocksProvider
 	client         *CrossSporkClient
-	config         *config.Config
+	config         config.Config
 	signer         crypto.Signer
 	txPool         *TxPool
 	logger         zerolog.Logger
@@ -116,7 +116,7 @@ func NewEVM(
 	registerStore *pebble.RegisterStorage,
 	blocksProvider *replayer.BlocksProvider,
 	client *CrossSporkClient,
-	config *config.Config,
+	config config.Config,
 	signer crypto.Signer,
 	logger zerolog.Logger,
 	blocks storage.BlockIndexer,

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -137,7 +137,7 @@ func servicesSetup(t *testing.T) (emulator.Emulator, func()) {
 	service := emu.ServiceKey()
 
 	// default config
-	cfg := &config.Config{
+	cfg := config.Config{
 		DatabaseDir:       t.TempDir(),
 		AccessNodeHost:    "localhost:3569", // emulator
 		RPCPort:           8545,

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -59,7 +59,7 @@ func Test_ConcurrentTransactionSubmission(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	cfg := &config.Config{
+	cfg := config.Config{
 		DatabaseDir:       t.TempDir(),
 		AccessNodeHost:    grpcHost,
 		RPCPort:           8545,
@@ -165,7 +165,7 @@ func Test_EthClientTest(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	cfg := &config.Config{
+	cfg := config.Config{
 		DatabaseDir:       t.TempDir(),
 		AccessNodeHost:    grpcHost,
 		RPCPort:           8545,
@@ -268,7 +268,7 @@ func Test_CloudKMSConcurrentTransactionSubmission(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	cfg := &config.Config{
+	cfg := config.Config{
 		DatabaseDir:       t.TempDir(),
 		AccessNodeHost:    grpcHost,
 		RPCPort:           8545,


### PR DESCRIPTION

## Description

IMO its safer to use an instance so we don't get strange behavior if something accidentally changes the config. It also doesn't need to be a reference since it is not expected to be modified.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 