### PR TITLE
use go build in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG VERSION
 ARG ARCH
 
 # Build binary
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=$ARCH build -o bin -ldflags="-X github.com/onflow/flow-evm-gateway/api.Version=$VERSION" -trimpath cmd/main.go
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=$ARCH go build -o bin -ldflags="-X github.com/onflow/flow-evm-gateway/api.Version=$VERSION" -trimpath cmd/main.go
 RUN chmod a+x bin
 
 # RUN APP


### PR DESCRIPTION
Fixing[ the build error:](https://github.com/onflow/flow-evm-gateway/actions/runs/12403228880/job/34626289955)

```
#17 [app-builder 7/8] RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 build -o bin -ldflags="-X github.com/onflow/flow-evm-gateway/api.Version=v1.0.0" -trimpath cmd/main.go
223
#17 0.202 /bin/sh: 1: build: not found
224
#17 ERROR: process "/bin/sh -c CGO_ENABLED=1 GOOS=linux GOARCH=$ARCH build -o bin -ldflags=\"-X github.com/onflow/flow-evm-gateway/api.Version=$VERSION\" -trimpath cmd/main.go" did not complete successfully: exit code: 127
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build command in the Dockerfile for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->