### PR TITLE
Relax required flags when `index-only` mode is set

### DIFF
--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -122,22 +122,25 @@ func NewEVM(
 	keystore *KeyStore,
 ) (*EVM, error) {
 	logger = logger.With().Str("component", "requester").Logger()
-	address := config.COAAddress
-	acc, err := client.GetAccount(context.Background(), address)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"could not fetch the configured COA account: %s make sure it exists: %w",
-			address.String(),
-			err,
-		)
-	}
 
-	if acc.Balance < minFlowBalance {
-		return nil, fmt.Errorf(
-			"COA account must be funded with at least %d Flow, but has balance of: %d",
-			minFlowBalance,
-			acc.Balance,
-		)
+	if !config.IndexOnly {
+		address := config.COAAddress
+		acc, err := client.GetAccount(context.Background(), address)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"could not fetch the configured COA account: %s make sure it exists: %w",
+				address.String(),
+				err,
+			)
+		}
+
+		if acc.Balance < minFlowBalance {
+			return nil, fmt.Errorf(
+				"COA account must be funded with at least %d Flow, but has balance of: %d",
+				minFlowBalance,
+				acc.Balance,
+			)
+		}
 	}
 
 	head := &types.Header{


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/706

## Description

Avoid asking the user values for flags such as:

- `coa-address`,
- `coa-key`,
- `coinbase`

when they only use the EVM GW in `index-only` mode, which does not allow transactions.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced control flow based on the `IndexOnly` configuration, optimizing account retrieval and signer creation.
  - Conditional processing for Certificate of Authority (COA) address and keys, improving error handling and configuration clarity.

- **Bug Fixes**
  - Updated error messages for Cloud KMS key handling to clarify required parameters.

- **Refactor**
  - Streamlined logic in various components to ensure operations are only executed when necessary based on the `IndexOnly` flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->