### PR TITLE
Remove obsolete config flags `stream-limit` & `stream-timeout`

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,11 +242,9 @@ The application can be configured using the following flags at runtime:
 | `coa-cloud-kms-key`            | `""`             | KMS keys and versions, comma-separated (e.g. `"gw-key-6@1,gw-key-7@1"`)                    |
 | `log-level`                    | `debug`          | Log verbosity level (`debug`, `info`, `warn`, `error`, `fatal`, `panic`)                   |
 | `log-writer`                   | `stderr`         | Output method for logs (`stderr`, `console`)                                               |
-| `stream-limit`                 | `10`             | Rate-limit for client events sent per second                                               |
 | `rate-limit`                   | `50`             | Requests per second limit for clients over any protocol (ws/http)                          |
 | `address-header`               | `""`             | Header for client IP when server is behind a proxy                                         |
 | `heartbeat-interval`           | `100`            | Interval for AN event subscription heartbeats                                              |
-| `stream-timeout`               | `3`              | Timeout in seconds for sending events to clients                                           |
 | `force-start-height`           | `0`              | Force-set starting Cadence height (local/testing use only)                                 |
 | `wallet-api-key`               | `""`             | ECDSA private key for wallet APIs (local/testing use only)                                 |
 | `filter-expiry`                | `5m`             | Expiry time for idle filters                                                               |

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -199,8 +199,6 @@ func parseConfigFromFlags() error {
 		cfg.LogWriter = zerolog.NewConsoleWriter()
 	}
 
-	cfg.StreamTimeout = time.Second * time.Duration(streamTimeout)
-
 	exp, err := time.ParseDuration(filterExpiry)
 	if err != nil {
 		return fmt.Errorf("invalid unit %s for filter expiry: %w", filterExpiry, err)
@@ -246,8 +244,6 @@ var (
 	walletKey,
 	txStateValidation string
 
-	streamTimeout int
-
 	initHeight,
 	forceStartHeight uint64
 )
@@ -269,10 +265,8 @@ func init() {
 	Cmd.Flags().StringVar(&keyAlg, "coa-key-alg", "ECDSA_P256", "Private key algorithm for the COA private key, only effective if coa-key/coa-key-file is present. Available values (ECDSA_P256 / ECDSA_secp256k1 / BLS_BLS12_381), defaults to ECDSA_P256.")
 	Cmd.Flags().StringVar(&logLevel, "log-level", "debug", "Define verbosity of the log output ('debug', 'info', 'warn', 'error', 'fatal', 'panic')")
 	Cmd.Flags().StringVar(&logWriter, "log-writer", "stderr", "Log writer used for output ('stderr', 'console')")
-	Cmd.Flags().Float64Var(&cfg.StreamLimit, "stream-limit", 10, "Rate-limits the events sent to the client within one second")
 	Cmd.Flags().Uint64Var(&cfg.RateLimit, "rate-limit", 50, "Rate-limit requests per second made by the client over any protocol (ws/http)")
 	Cmd.Flags().StringVar(&cfg.AddressHeader, "address-header", "", "Address header that contains the client IP, this is useful when the server is behind a proxy that sets the source IP of the client. Leave empty if no proxy is used.")
-	Cmd.Flags().IntVar(&streamTimeout, "stream-timeout", 3, "Defines the timeout in seconds the server waits for the event to be sent to the client")
 	Cmd.Flags().Uint64Var(&forceStartHeight, "force-start-height", 0, "Force set starting Cadence height. WARNING: This should only be used locally or for testing, never in production.")
 	Cmd.Flags().StringVar(&filterExpiry, "filter-expiry", "5m", "Filter defines the time it takes for an idle filter to expire")
 	Cmd.Flags().StringVar(&cloudKMSProjectID, "coa-cloud-kms-project-id", "", "The project ID containing the KMS keys, e.g. 'flow-evm-gateway'")

--- a/config/config.go
+++ b/config/config.go
@@ -68,10 +68,6 @@ type Config struct {
 	RateLimit uint64
 	// Address header used to identified clients, usually set by the proxy
 	AddressHeader string
-	// StreamLimit rate-limits the events sent to the client within 1 second time interval.
-	StreamLimit float64
-	// StreamTimeout defines the timeout the server waits for the event to be sent to the client.
-	StreamTimeout time.Duration
 	// FilterExpiry defines the time it takes for an idle filter to expire
 	FilterExpiry time.Duration
 	// ForceStartCadenceHeight will force set the starting Cadence height, this should be only used for testing or locally.

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -167,8 +167,6 @@ func servicesSetup(t *testing.T) (emulator.Emulator, func()) {
 		GasPrice:          new(big.Int).SetUint64(150),
 		LogLevel:          zerolog.DebugLevel,
 		LogWriter:         testLogWriter(),
-		StreamTimeout:     time.Second * 30,
-		StreamLimit:       10,
 		RateLimit:         500,
 		WSEnabled:         true,
 		MetricsPort:       8443,


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/716

## Description

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Expanded README with comprehensive EVM Gateway details
	- Added sections on endpoints, JSON-RPC API, debugging, contributing, and licensing

- **Configuration**
	- Removed stream timeout and stream limit configurations
	- Simplified command-line and service setup options for event streaming

- **Refactor**
	- Streamlined configuration handling in multiple files
	- Removed unused streaming-related parameters
<!-- end of auto-generated comment: release notes by coderabbit.ai -->