### PR TITLE
Add metric to count iterations taken for `eth_estimateGas`

### DIFF
--- a/metrics/nop.go
+++ b/metrics/nop.go
@@ -21,3 +21,4 @@ func (c *nopCollector) EVMAccountInteraction(string)             {}
 func (c *nopCollector) MeasureRequestDuration(time.Time, string) {}
 func (c *nopCollector) OperatorBalance(*flow.Account)            {}
 func (c *nopCollector) AvailableSigningKeys(count int)           {}
+func (c *nopCollector) GasEstimationIterations(count int)        {}


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/684

## Description



______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added tracking for gas estimation iterations across the metrics collection system.
	- Enhanced gas estimation process with iteration count reporting.

- **Improvements**
	- Implemented a new metric to monitor the number of iterations during gas estimation.
	- Expanded metrics collection to provide more detailed performance insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->