### PR TITLE
Fix API version shown in build details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BRANCH_NAME:=$(shell git rev-parse --abbrev-ref HEAD | tr '/' '-')
 # The Git commit hash
 COMMIT := $(shell git rev-parse HEAD)
 # The tag of the current commit, otherwise empty
-GIT_VERSION := $(shell git describe --tags --abbrev=2 2>/dev/null)
+GIT_VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null)
 CMD_ARGS :=
 # ACCESS_NODE_SPORK_HOSTS are comma separated
 TESTNET_ACCESS_NODE_SPORK_HOSTS := access-001.devnet51.nodes.onflow.org:9000
@@ -86,7 +86,7 @@ check-tidy:
 
 .PHONY: build
 build:
-	$(COMPILER_FLAGS) go build -o flow-evm-gateway -ldflags="-X github.com/onflow/flow-evm-gateway/api.Version=$(IMAGE_TAG)" cmd/main.go
+	$(COMPILER_FLAGS) go build -o flow-evm-gateway -ldflags="-X github.com/onflow/flow-evm-gateway/api.Version=$(GIT_VERSION)" cmd/main.go
 	chmod a+x flow-evm-gateway
 
 .PHONY: fix-lint


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/730

## Description

There was a regression with the latest changes on the `Makefile`, which ended up showing the commit tag in the build version:
```json
{"level":"info","version":"a4ce4cc","time":"2025-01-23T12:56:18+01:00","message":"build details"}
```
instead of the proper tag version, e.g. `v1.0.1`.
This is also used in the `web3_clientVersion` JSON-RPC endpoint, and is useful for viewing which version is run by a given EVM Gateway instance.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version retrieval method in build process
	- Modified how version is embedded in the binary
	- Changed Git tag version extraction to use most recent tag without additional commit details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->