### PR TITLE
Use default tx expiration from flow-go

### DIFF
--- a/services/requester/key_store.go
+++ b/services/requester/key_store.go
@@ -6,11 +6,12 @@ import (
 
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 var ErrNoKeysAvailable = fmt.Errorf("no keys available")
 
-const accountKeyBlockExpiration = 1_000
+const accountKeyBlockExpiration = flow.DefaultTransactionExpiry
 
 type AccountKey struct {
 	flowsdk.AccountKey


### PR DESCRIPTION
Closes: #???

## Description

Update's the key management logic to use the transaction expiration from flow-go (600 blocks)

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated account key block expiration to use Flow SDK's default transaction expiry
	- Added import for Flow SDK package

<!-- end of auto-generated comment: release notes by coderabbit.ai -->