### PR TITLE
Increase computation limit for Cadence tx

### DIFF
--- a/models/errors/errors.go
+++ b/models/errors/errors.go
@@ -66,6 +66,13 @@ func NewTxGasPriceTooLowError(gasPrice *big.Int) error {
 	))
 }
 
+func NewTxGasLimitTooHighError(maxGasLimit uint64) error {
+	return NewInvalidTransactionError(fmt.Errorf(
+		"tx gas limit exceeds the max value of %d: ",
+		maxGasLimit,
+	))
+}
+
 func NewRecoverableError(err error) error {
 	return fmt.Errorf("%w: %w", ErrRecoverable, err)
 }

--- a/tests/web3js/eth_failure_handling_test.js
+++ b/tests/web3js/eth_failure_handling_test.js
@@ -1,7 +1,26 @@
 const { assert } = require('chai')
 const helpers = require('./helpers')
-const conf = require("./config")
+const conf = require('./config')
 const web3 = conf.web3
+
+it('should fail when tx gas limit higher than the max value', async () => {
+    let receiver = web3.eth.accounts.create()
+
+    try {
+        await helpers.signAndSend({
+            from: conf.eoa.address,
+            to: receiver.address,
+            value: 10,
+            gasPrice: conf.minGasPrice,
+            gasLimit: 51_000_000, // max tx gas limit is 50_000_000
+        })
+    } catch (e) {
+        assert.include(e.message, 'tx gas limit exceeds the max value of 50000000')
+        return
+    }
+
+    assert.fail('should not reach')
+})
 
 it('should fail when nonce too low', async () => {
     let receiver = web3.eth.accounts.create()


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/732

## Description

- We set the computation limit for the Cadence tx that wraps EVM txs, to its max value.
- We also add a validation check, for rejecting EVM txs which go beyond the max gas limit. This will avoid invalid EVM transactions, such as https://testnet.flowscan.io/tx/775a9d1518523c4d6be9e49f6e9d0a1b2f0c19bf534b452538b6e526cfa83367, being submitted to the network.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a maximum gas limit of 50,000,000 for transactions
	- Added enhanced error handling for transactions exceeding gas limit

- **Tests**
	- Added a new test case to verify transaction gas limit enforcement

- **Bug Fixes**
	- Implemented checks to prevent transactions with excessively high gas limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->