### PR TITLE
Move recording of available-signing-keys metric inside a deferred function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ EMULATOR_ARGS := --flow-network-id=flow-emulator \
 		--log-writer=console \
 		--tx-state-validation=local-index \
 		--profiler-enabled=true \
-		--profiler-port=6060 \
-		--tx-state-validation=local-index
+		--profiler-port=6060
 
 # Set VERSION from command line, environment, or default to SHORT_COMMIT
 VERSION ?= $(SHORT_COMMIT)

--- a/api/server.go
+++ b/api/server.go
@@ -430,6 +430,7 @@ type responseHandler struct {
 }
 
 var knownErrors = []error{
+	errs.ErrInternal,
 	errs.ErrRateLimit,
 	errs.ErrInvalid,
 	errs.ErrFailedTransaction,

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -569,6 +569,10 @@ func (e *EVM) buildTransaction(
 	e.mux.Lock()
 	defer e.mux.Unlock()
 
+	defer func() {
+		e.collector.AvailableSigningKeys(e.keystore.AvailableKeys())
+	}()
+
 	var (
 		g           = errgroup.Group{}
 		err1, err2  error
@@ -609,7 +613,6 @@ func (e *EVM) buildTransaction(
 	}
 	e.keystore.LockKey(flowTx.ID(), latestBlock.Height, accKey)
 
-	e.collector.AvailableSigningKeys(e.keystore.AvailableKeys())
 	e.collector.OperatorBalance(account)
 
 	return flowTx, nil

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -225,7 +225,6 @@ func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash,
 	script := replaceAddresses(runTxScript, e.config.FlowNetworkID)
 	flowTx, err := e.buildTransaction(ctx, script, hexEncodedTx, coinbaseAddress)
 	if err != nil {
-		e.logger.Error().Err(err).Str("data", txData).Msg("failed to build transaction")
 		return common.Hash{}, err
 	}
 


### PR DESCRIPTION
## Description

If the relevant function errors out early, because there are no keys available, then we wouldn't record that there are `0` available signing keys. This would skew the related data.
Also made some improvements regarding logging errors.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Makefile configuration for emulator arguments.
	- Enhanced internal error handling in server API.
	- Modified transaction building process to defer logging of available signing keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->