### PR TITLE
Fix panic from missing batch in force-start-height

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -557,25 +557,25 @@ func setupStorage(
 	storageAddress := evm.StorageAccountAddress(config.FlowNetworkID)
 	registerStore := pebble.NewRegisterStorage(store, storageAddress)
 
+	batch := store.NewBatch()
+	defer func() {
+		err := batch.Close()
+		if err != nil {
+			// we don't know what went wrong, so this is fatal
+			logger.Fatal().Err(err).Msg("failed to close batch")
+		}
+	}()
+
 	// hard set the start cadence height, this is used when force reindexing
 	if config.ForceStartCadenceHeight != 0 {
 		logger.Warn().Uint64("height", config.ForceStartCadenceHeight).Msg("force setting starting Cadence height!!!")
-		if err := blocks.SetLatestCadenceHeight(config.ForceStartCadenceHeight, nil); err != nil {
+		if err := blocks.SetLatestCadenceHeight(config.ForceStartCadenceHeight, batch); err != nil {
 			return nil, nil, err
 		}
 	}
 
 	// if database is not initialized require init height
 	if _, err := blocks.LatestCadenceHeight(); errors.Is(err, errs.ErrStorageNotInitialized) {
-		batch := store.NewBatch()
-		defer func(batch *pebbleDB.Batch) {
-			err := batch.Close()
-			if err != nil {
-				// we don't know what went wrong, so this is fatal
-				logger.Fatal().Err(err).Msg("failed to close batch")
-			}
-		}(batch)
-
 		cadenceHeight := config.InitCadenceHeight
 		evmBlokcHeight := uint64(0)
 		cadenceBlock, err := client.GetBlockHeaderByHeight(context.Background(), cadenceHeight)
@@ -613,11 +613,6 @@ func setupStorage(
 			)
 		}
 
-		err = batch.Commit(pebbleDB.Sync)
-		if err != nil {
-			return nil, nil, fmt.Errorf("could not commit register updates: %w", err)
-		}
-
 		logger.Info().
 			Stringer("fvm_address_for_evm_storage_account", storageAddress).
 			Msgf("database initialized with cadence height: %d", cadenceHeight)
@@ -625,6 +620,13 @@ func setupStorage(
 	// else {
 	//	// TODO(JanezP): verify storage account owner is correct
 	// }
+
+	if batch.Count() > 0 {
+		err = batch.Commit(pebbleDB.Sync)
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not commit setup updates: %w", err)
+		}
+	}
 
 	return db, &Storages{
 		Storage:      store,


### PR DESCRIPTION
Closes: #???

## Description

Fixes panic when running with ` --force-start-height` that was caused by a missing `batch` in the call to `SetLatestCadenceHeight`.

Also combines the db setup updates into a single batch to ensure the changes are only made if the setup is successful


______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
	- Enhanced database operation efficiency by introducing a new batch handling mechanism
	- Optimized storage setup process with consolidated batch updates
	- Improved database commit strategy to reduce individual write operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->