### PR TITLE
Fix bootstrapping to subscribe to correct start block

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -141,13 +141,17 @@ func (b *Bootstrap) StartEventIngestion(ctx context.Context) error {
 
 	chainID := b.config.FlowNetworkID
 
+	// the event subscriber takes the first block to sync from the Access node, which is the block
+	// after the latest cadence block
+	nextCadenceHeight := latestCadenceHeight + 1
+
 	// create event subscriber
 	subscriber := ingestion.NewRPCEventSubscriber(
 		b.logger,
 		b.client,
 		chainID,
 		b.keystore,
-		latestCadenceHeight,
+		nextCadenceHeight,
 	)
 
 	callTracerCollector, err := replayer.NewCallTracerCollector(b.logger)


### PR DESCRIPTION
Closes: #743

## Description

The ingestion engine tracks the latest indexed cadence height with the `latestCadenceHeight` value stored in the db. This value is updated atomically with the indexing using a batch.

Currently, the bootstrapping logic passes the `latestCadenceHeight` to the event subscribing when starting up. This tells the subscriber to return events for block `latestCadenceHeight` forward. This results in the ingestion engine always reindexing the last block on startup.

Before we added local transaction execution, this was fine because the indexing operation was idempotent. However, the transaction replaying logic currently isn't, so restarting now causes the replay to fail when the last block processed contains transaction.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected event synchronization logic to ensure proper starting block height for event ingestion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->