### PR TITLE
Add transaction rate-limit functionality

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -132,6 +132,8 @@ func handleError[T any](err error, log zerolog.Logger, collector metrics.Collect
 		return zero, err
 	case errors.Is(err, core.ErrInsufficientFunds):
 		return zero, err
+	case errors.Is(err, errs.ErrRateLimit):
+		return zero, err
 	default:
 		collector.ApiErrorOccurred()
 		log.Error().Err(err).Msg("api error")

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -222,12 +222,6 @@ func parseConfigFromFlags() error {
 		return fmt.Errorf("unknown tx state validation: %s", txStateValidation)
 	}
 
-	txDuration, err := time.ParseDuration(txDurationLimit)
-	if err != nil {
-		return fmt.Errorf("invalid unit %s for TX duration limit: %w", txDuration, err)
-	}
-	cfg.TxDurationLimit = txDuration
-
 	return nil
 }
 
@@ -248,8 +242,7 @@ var (
 	cloudKMSLocationID,
 	cloudKMSKeyRingID,
 	walletKey,
-	txStateValidation,
-	txDurationLimit string
+	txStateValidation string
 
 	initHeight,
 	forceStartHeight uint64
@@ -287,6 +280,6 @@ func init() {
 	Cmd.Flags().StringVar(&cfg.ProfilerHost, "profiler-host", "localhost", "Host for the Profiler server")
 	Cmd.Flags().IntVar(&cfg.ProfilerPort, "profiler-port", 6060, "Port for the Profiler server")
 	Cmd.Flags().StringVar(&txStateValidation, "tx-state-validation", "tx-seal", "Sets the transaction validation mechanism. It can validate using the local state index, or wait for the outer Flow transaction to seal. Available values ('local-index' / 'tx-seal'), defaults to 'tx-seal'.")
-	Cmd.Flags().Uint64Var(&cfg.TxRequestLimit, "tx-request-limit", 1, "Number of transaction submissions to allow per the specified interval. Applies only on Testnet.")
-	Cmd.Flags().StringVar(&txDurationLimit, "tx-duration-limit", "3s", "Time interval upon which to enforce transaction submission rate limiting. Applies only on Testnet.")
+	Cmd.Flags().Uint64Var(&cfg.TxRequestLimit, "tx-request-limit", 0, "Number of transaction submissions to allow per the specified interval.")
+	Cmd.Flags().DurationVar(&cfg.TxRequestDurationLimit, "tx-request-duration-limit", time.Second*3, "Time interval upon which to enforce transaction submission rate limiting.")
 }

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -222,6 +222,12 @@ func parseConfigFromFlags() error {
 		return fmt.Errorf("unknown tx state validation: %s", txStateValidation)
 	}
 
+	txDuration, err := time.ParseDuration(txDurationLimit)
+	if err != nil {
+		return fmt.Errorf("invalid unit %s for TX duration limit: %w", txDuration, err)
+	}
+	cfg.TxDurationLimit = txDuration
+
 	return nil
 }
 
@@ -242,7 +248,8 @@ var (
 	cloudKMSLocationID,
 	cloudKMSKeyRingID,
 	walletKey,
-	txStateValidation string
+	txStateValidation,
+	txDurationLimit string
 
 	initHeight,
 	forceStartHeight uint64
@@ -280,4 +287,6 @@ func init() {
 	Cmd.Flags().StringVar(&cfg.ProfilerHost, "profiler-host", "localhost", "Host for the Profiler server")
 	Cmd.Flags().IntVar(&cfg.ProfilerPort, "profiler-port", 6060, "Port for the Profiler server")
 	Cmd.Flags().StringVar(&txStateValidation, "tx-state-validation", "tx-seal", "Sets the transaction validation mechanism. It can validate using the local state index, or wait for the outer Flow transaction to seal. Available values ('local-index' / 'tx-seal'), defaults to 'tx-seal'.")
+	Cmd.Flags().Uint64Var(&cfg.TxRequestLimit, "tx-request-limit", 1, "Number of transaction submissions to allow per the specified interval. Applies only on Testnet.")
+	Cmd.Flags().StringVar(&txDurationLimit, "tx-duration-limit", "3s", "Time interval upon which to enforce transaction submission rate limiting. Applies only on Testnet.")
 }

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -281,5 +281,5 @@ func init() {
 	Cmd.Flags().IntVar(&cfg.ProfilerPort, "profiler-port", 6060, "Port for the Profiler server")
 	Cmd.Flags().StringVar(&txStateValidation, "tx-state-validation", "tx-seal", "Sets the transaction validation mechanism. It can validate using the local state index, or wait for the outer Flow transaction to seal. Available values ('local-index' / 'tx-seal'), defaults to 'tx-seal'.")
 	Cmd.Flags().Uint64Var(&cfg.TxRequestLimit, "tx-request-limit", 0, "Number of transaction submissions to allow per the specified interval.")
-	Cmd.Flags().DurationVar(&cfg.TxRequestDurationLimit, "tx-request-duration-limit", time.Second*3, "Time interval upon which to enforce transaction submission rate limiting.")
+	Cmd.Flags().DurationVar(&cfg.TxRequestLimitDuration, "tx-request-limit-duration", time.Second*3, "Time interval upon which to enforce transaction submission rate limiting.")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -89,4 +89,9 @@ type Config struct {
 	// TxStateValidation sets the transaction validation mechanism. It can validate
 	// using the local state index, or wait for the outer Flow transaction to seal.
 	TxStateValidation string
+	// TxRequestLimit is the number of transaction submissions to allow per interval.
+	TxRequestLimit uint64
+	// TxDurationLimit is the time interval upon which to enforce transaction submission
+	// rate limiting.
+	TxDurationLimit time.Duration
 }

--- a/config/config.go
+++ b/config/config.go
@@ -91,7 +91,7 @@ type Config struct {
 	TxStateValidation string
 	// TxRequestLimit is the number of transaction submissions to allow per interval.
 	TxRequestLimit uint64
-	// TxDurationLimit is the time interval upon which to enforce transaction submission
+	// TxRequestDurationLimit is the time interval upon which to enforce transaction submission
 	// rate limiting.
-	TxDurationLimit time.Duration
+	TxRequestDurationLimit time.Duration
 }

--- a/config/config.go
+++ b/config/config.go
@@ -91,7 +91,7 @@ type Config struct {
 	TxStateValidation string
 	// TxRequestLimit is the number of transaction submissions to allow per interval.
 	TxRequestLimit uint64
-	// TxRequestDurationLimit is the time interval upon which to enforce transaction submission
+	// TxRequestLimitDuration is the time interval upon which to enforce transaction submission
 	// rate limiting.
-	TxRequestDurationLimit time.Duration
+	TxRequestLimitDuration time.Duration
 }

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -171,7 +171,7 @@ func NewEVM(
 	ratelimiter, err := memorystore.New(
 		&memorystore.Config{
 			Tokens:   config.TxRequestLimit,
-			Interval: config.TxDurationLimit,
+			Interval: config.TxRequestDurationLimit,
 		},
 	)
 	if err != nil {

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -211,8 +211,7 @@ func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash,
 		return common.Hash{}, fmt.Errorf("failed to derive the sender: %w", err)
 	}
 
-	rateLimitEnabled := e.config.TxRequestLimit > 0
-	if rateLimitEnabled {
+	if e.config.TxRequestLimit > 0 {
 		_, _, _, ok, err := e.limiter.Take(ctx, from.Hex())
 		if err != nil {
 			return common.Hash{}, fmt.Errorf("failed to check rate limit: %w", err)

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -171,7 +171,7 @@ func NewEVM(
 	ratelimiter, err := memorystore.New(
 		&memorystore.Config{
 			Tokens:   config.TxRequestLimit,
-			Interval: config.TxRequestDurationLimit,
+			Interval: config.TxRequestLimitDuration,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/746

## Description

The default TX submission rate-limit is set for 1 request / 3s..
The `3s` magic value here is the block production time on `testnet`.
Both of these are configurable with the flags below:
- `tx-request-limit` (default is `0`, meaning no rate-limit applies)
- `tx-request-duration-limit` (default is `3s`, for 3 seconds)
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved error handling to gracefully signal rate limit issues.
  - Introduced transaction submission rate limiting, adding controls for the number of allowed submissions and duration limits.
  - Enabled new command-line options for customized transaction rate parameters.
- **Bug Fixes**
  - Enhanced transaction handling logic by implementing a rate limiting mechanism to prevent excessive submissions from the same address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->