### PR TITLE
Track time taken to fully ingest an EVM block in the local state index

### DIFF
--- a/metrics/nop.go
+++ b/metrics/nop.go
@@ -12,13 +12,14 @@ var _ Collector = &nopCollector{}
 
 var NopCollector = &nopCollector{}
 
-func (c *nopCollector) ApiErrorOccurred()                        {}
-func (c *nopCollector) ServerPanicked(string)                    {}
-func (c *nopCollector) CadenceHeightIndexed(uint64)              {}
-func (c *nopCollector) EVMHeightIndexed(uint64)                  {}
-func (c *nopCollector) EVMTransactionIndexed(int)                {}
-func (c *nopCollector) EVMAccountInteraction(string)             {}
-func (c *nopCollector) MeasureRequestDuration(time.Time, string) {}
-func (c *nopCollector) OperatorBalance(*flow.Account)            {}
-func (c *nopCollector) AvailableSigningKeys(count int)           {}
-func (c *nopCollector) GasEstimationIterations(count int)        {}
+func (c *nopCollector) ApiErrorOccurred()                          {}
+func (c *nopCollector) ServerPanicked(string)                      {}
+func (c *nopCollector) CadenceHeightIndexed(uint64)                {}
+func (c *nopCollector) EVMHeightIndexed(uint64)                    {}
+func (c *nopCollector) EVMTransactionIndexed(int)                  {}
+func (c *nopCollector) EVMAccountInteraction(string)               {}
+func (c *nopCollector) MeasureRequestDuration(time.Time, string)   {}
+func (c *nopCollector) OperatorBalance(*flow.Account)              {}
+func (c *nopCollector) AvailableSigningKeys(count int)             {}
+func (c *nopCollector) GasEstimationIterations(count int)          {}
+func (c *nopCollector) BlockIngestionTime(blockCreation time.Time) {}

--- a/services/ingestion/engine.go
+++ b/services/ingestion/engine.go
@@ -3,6 +3,7 @@ package ingestion
 import (
 	"context"
 	"fmt"
+	"time"
 
 	flowGo "github.com/onflow/flow-go/model/flow"
 
@@ -305,6 +306,9 @@ func (e *Engine) indexEvents(events *models.CadenceEvents, batch *pebbleDB.Batch
 			return err
 		}
 	}
+
+	blockCreation := time.Unix(int64(events.Block().Timestamp), 0)
+	e.collector.BlockIngestionTime(blockCreation)
 
 	return nil
 }


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/751

## Description



______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced performance monitoring now captures block ingestion timing, offering improved insights into system performance through more detailed metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->