### PR TITLE
Start event ingestion on proper block height when connecting to local Emulator

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -145,6 +145,12 @@ func (b *Bootstrap) StartEventIngestion(ctx context.Context) error {
 	// the event subscriber takes the first block to sync from the Access node, which is the block
 	// after the latest cadence block
 	nextCadenceHeight := latestCadenceHeight + 1
+	// Special case when using a local Emulator as Access Node. The Emulator
+	// always starts at block height 0, so if we try to subscribe at block
+	// height 1, we'll get an error, as it doesn't exist.
+	if latestCadenceHeight == config.EmulatorInitCadenceHeight {
+		nextCadenceHeight -= 1
+	}
 
 	// create event subscriber
 	subscriber := ingestion.NewRPCEventSubscriber(


### PR DESCRIPTION
## Description

The Emulator always starts at block height 0, so if we try to subscribe at block height 1, we'll get an error, as it doesn't exist.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling for event ingestion, improving stability in local testing environments by preventing potential subscription issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->