### PR TITLE
Update gasPrice for COA transactions to use the baseFeePerGas

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -31,8 +31,6 @@ const BlockGasLimit uint64 = 120_000_000
 
 const maxFeeHistoryBlockCount = 1024
 
-var baseFeesPerGas = big.NewInt(1)
-
 var latestBlockNumberOrHash = rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 
 func SupportedAPIs(
@@ -851,7 +849,7 @@ func (b *BlockChainAPI) FeeHistory(
 			oldestBlock = (*hexutil.Big)(big.NewInt(int64(block.Height)))
 		}
 
-		baseFees = append(baseFees, (*hexutil.Big)(baseFeesPerGas))
+		baseFees = append(baseFees, (*hexutil.Big)(models.BaseFeesPerGas))
 
 		rewards = append(rewards, blockRewards)
 
@@ -967,7 +965,7 @@ func (b *BlockChainAPI) prepareBlockResponse(
 		GasLimit:         hexutil.Uint64(BlockGasLimit),
 		Nonce:            types.BlockNonce{0x1},
 		Timestamp:        hexutil.Uint64(block.Timestamp),
-		BaseFeePerGas:    hexutil.Big(*baseFeesPerGas),
+		BaseFeePerGas:    hexutil.Big(*models.BaseFeesPerGas),
 		LogsBloom:        types.LogsBloom([]*types.Log{}),
 		Miner:            evmTypes.CoinbaseAddress.ToCommon(),
 		Sha3Uncles:       types.EmptyUncleHash,

--- a/eth/types/types.go
+++ b/eth/types/types.go
@@ -345,6 +345,10 @@ func MarshalReceipt(
 		"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
 	}
 
+	if _, ok := tx.(models.DirectCall); ok {
+		fields["effectiveGasPrice"] = (*hexutil.Big)(models.BaseFeesPerGas)
+	}
+
 	if tx.To() != nil {
 		fields["to"] = tx.To().Hex()
 	}

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -29,6 +29,8 @@ const (
 	TxMaxSize = 4 * TxSlotSize // 128KB
 )
 
+var BaseFeesPerGas = big.NewInt(1)
+
 type Transaction interface {
 	Hash() common.Hash
 	RawSignatureValues() (v *big.Int, r *big.Int, s *big.Int)
@@ -111,7 +113,7 @@ func (dc DirectCall) GasTipCap() *big.Int {
 }
 
 func (dc DirectCall) GasPrice() *big.Int {
-	return big.NewInt(0)
+	return BaseFeesPerGas
 }
 
 func (dc DirectCall) BlobGas() uint64 {
@@ -226,6 +228,7 @@ func decodeTransactionEvent(event cadence.Event) (
 				err,
 			)
 		}
+		receipt.EffectiveGasPrice = BaseFeesPerGas
 		tx = DirectCall{DirectCall: directCall}
 	} else {
 		gethTx := &gethTypes.Transaction{}

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -166,7 +166,7 @@ func Test_DecodeDirectCall(t *testing.T) {
 	assert.Equal(t, big.NewInt(10000000000), decTx.Value())
 	assert.Equal(t, uint8(gethTypes.LegacyTxType), decTx.Type())
 	assert.Equal(t, uint64(23_300), decTx.Gas())
-	assert.Equal(t, big.NewInt(0), decTx.GasPrice())
+	assert.Equal(t, BaseFeesPerGas, decTx.GasPrice())
 	assert.Equal(t, uint64(0), decTx.BlobGas())
 	assert.Equal(t, uint64(61), decTx.Size())
 }
@@ -273,7 +273,7 @@ func Test_UnmarshalTransaction(t *testing.T) {
 		assert.Equal(t, big.NewInt(10000000000), decTx.Value())
 		assert.Equal(t, uint8(gethTypes.LegacyTxType), decTx.Type())
 		assert.Equal(t, uint64(23_300), decTx.Gas())
-		assert.Equal(t, big.NewInt(0), decTx.GasPrice())
+		assert.Equal(t, BaseFeesPerGas, decTx.GasPrice())
 		assert.Equal(t, uint64(0), decTx.BlobGas())
 		assert.Equal(t, uint64(61), decTx.Size())
 	})

--- a/tests/web3js/eth_filter_endpoints_test.js
+++ b/tests/web3js/eth_filter_endpoints_test.js
@@ -413,7 +413,7 @@ describe('eth_getFilterChanges', async () => {
             blockNumber: '0xd',
             from: '0x0000000000000000000000030000000000000000',
             gas: '0x5b04',
-            gasPrice: '0x0',
+            gasPrice: '0x1',
             hash: '0x71201dbf66271cedb6e87a5364b2cb84f6170e282f2b3f676196687bdf4babe0',
             input: '0x',
             nonce: '0x9',

--- a/tests/web3js/eth_non_interactive_test.js
+++ b/tests/web3js/eth_non_interactive_test.js
@@ -61,6 +61,13 @@ it('should get block', async () => {
         assert.isString(tx.hash)
         assert.equal(tx.transactionIndex, txIndex)
 
+        // COA interactions
+        if (tx.v === 255n) {
+            assert.equal(tx.gasPrice, 1n)
+        } else {
+            assert.equal(tx.gasPrice, conf.minGasPrice)
+        }
+
         let txReceipt = await web3.eth.getTransactionReceipt(tx.hash)
         assert.isNotNull(txReceipt)
         assert.equal(txReceipt.blockNumber, block.number)
@@ -68,6 +75,13 @@ it('should get block', async () => {
         assert.isString(txReceipt.transactionHash)
         assert.equal(txReceipt.transactionIndex, txIndex)
         assert.isNotNull(txReceipt.from)
+
+        // COA interactions
+        if (tx.v === 255n) {
+            assert.equal(txReceipt.effectiveGasPrice, 1n)
+        } else {
+            assert.equal(txReceipt.effectiveGasPrice, conf.minGasPrice)
+        }
 
         // first transaction is the COA resource creation,
         // which also does the contract deployment


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/748

## Description

Update the `gasPrice` for COA transactions, to the `baseFeePerGas` (currently `1`), to comply with EIP-1559 .

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 