### PR TITLE
add system to verify soft finality events were eventually sealed

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -156,13 +156,16 @@ func (b *Bootstrap) StartEventIngestion(ctx context.Context) error {
 	// create event subscriber
 	var subscriber ingestion.EventSubscriber
 	if b.config.ExperimentalSoftFinalityEnabled {
-		verifier := ingestion.NewSealingVerifier(
-			b.logger,
-			b.client,
-			chainID,
-			b.storages.EventsHash,
-			nextCadenceHeight,
-		)
+		var verifier *ingestion.SealingVerifier
+		if b.config.ExperimentalSealingVerificationEnabled {
+			verifier = ingestion.NewSealingVerifier(
+				b.logger,
+				b.client,
+				chainID,
+				b.storages.EventsHash,
+				nextCadenceHeight,
+			)
+		}
 
 		subscriber = ingestion.NewRPCBlockTrackingSubscriber(
 			b.logger,

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -161,8 +161,8 @@ func (b *Bootstrap) StartEventIngestion(ctx context.Context) error {
 			b.client,
 			chainID,
 			b.storages.EventsHash,
+			nextCadenceHeight,
 		)
-		go StartEngine(ctx, verifier, b.logger)
 
 		subscriber = ingestion.NewRPCBlockTrackingSubscriber(
 			b.logger,

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -56,6 +56,7 @@ type Storages struct {
 	Transactions storage.TransactionIndexer
 	Receipts     storage.ReceiptIndexer
 	Traces       storage.TraceIndexer
+	EventsHash   *pebble.EventsHash
 }
 
 type Publishers struct {
@@ -155,12 +156,21 @@ func (b *Bootstrap) StartEventIngestion(ctx context.Context) error {
 	// create event subscriber
 	var subscriber ingestion.EventSubscriber
 	if b.config.ExperimentalSoftFinalityEnabled {
+		verifier := ingestion.NewSealingVerifier(
+			b.logger,
+			b.client,
+			chainID,
+			b.storages.EventsHash,
+		)
+		go StartEngine(ctx, verifier, b.logger)
+
 		subscriber = ingestion.NewRPCBlockTrackingSubscriber(
 			b.logger,
 			b.client,
 			chainID,
 			b.keystore,
 			nextCadenceHeight,
+			verifier,
 		)
 	} else {
 		subscriber = ingestion.NewRPCEventSubscriber(
@@ -597,6 +607,7 @@ func setupStorage(
 	blocks := pebble.NewBlocks(store, config.FlowNetworkID)
 	storageAddress := evm.StorageAccountAddress(config.FlowNetworkID)
 	registerStore := pebble.NewRegisterStorage(store, storageAddress)
+	eventsHash := pebble.NewEventsHash(store)
 
 	batch := store.NewBatch()
 	defer func() {
@@ -676,6 +687,7 @@ func setupStorage(
 		Transactions: pebble.NewTransactions(store),
 		Receipts:     pebble.NewReceipts(store),
 		Traces:       pebble.NewTraces(store),
+		EventsHash:   eventsHash,
 	}, nil
 }
 

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -12,8 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/onflow/flow-evm-gateway/bootstrap"
-	"github.com/onflow/flow-evm-gateway/config"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
 	flowGoKMS "github.com/onflow/flow-go-sdk/crypto/cloudkms"
@@ -24,6 +22,9 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-evm-gateway/bootstrap"
+	"github.com/onflow/flow-evm-gateway/config"
 )
 
 var Cmd = &cobra.Command{
@@ -223,6 +224,7 @@ func parseConfigFromFlags() error {
 	}
 
 	cfg.ExperimentalSoftFinalityEnabled = experimentalSoftFinalityEnabled
+	cfg.ExperimentalSealingVerificationEnabled = experimentalSealingVerificationEnabled
 
 	return nil
 }
@@ -249,7 +251,8 @@ var (
 	initHeight,
 	forceStartHeight uint64
 
-	experimentalSoftFinalityEnabled bool
+	experimentalSoftFinalityEnabled,
+	experimentalSealingVerificationEnabled bool
 )
 
 func init() {
@@ -285,4 +288,5 @@ func init() {
 	Cmd.Flags().IntVar(&cfg.ProfilerPort, "profiler-port", 6060, "Port for the Profiler server")
 	Cmd.Flags().StringVar(&txStateValidation, "tx-state-validation", "tx-seal", "Sets the transaction validation mechanism. It can validate using the local state index, or wait for the outer Flow transaction to seal. Available values ('local-index' / 'tx-seal'), defaults to 'tx-seal'.")
 	Cmd.Flags().BoolVar(&experimentalSoftFinalityEnabled, "experimental-soft-finality-enabled", false, "Sets whether the gateway should use the experimental soft finality feature. WARNING: This may result in incorrect results being returned in certain circumstances. Use only if you know what you are doing.")
+	Cmd.Flags().BoolVar(&experimentalSealingVerificationEnabled, "experimental-sealing-verification-enabled", true, "Sets whether the gateway should use the experimental soft finality sealing verification feature. WARNING: This may result in indexing halts if events do not match. Use only if you know what you are doing.")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -93,4 +93,9 @@ type Config struct {
 	// EVM block and transaction data from the upstream Access node before the block is sealed.
 	// CAUTION: This feature is experimental and may return incorrect data in certain circumstances.
 	ExperimentalSoftFinalityEnabled bool
+	// ExperimentalSealingVerificationEnabled enables the experimental sealing verification feature
+	// which verifies the hash of the EVM events ingested by the requester engine match the hash
+	// of the events from the sealed block in the Flow network.
+	// CAUTION: This feature is experimental and will cause the node to halt if the events don't match.
+	ExperimentalSealingVerificationEnabled bool
 }

--- a/services/ingestion/block_tracking_subscriber.go
+++ b/services/ingestion/block_tracking_subscriber.go
@@ -188,7 +188,7 @@ func (r *RPCBlockTrackingSubscriber) subscribe(ctx context.Context, height uint6
 
 				if r.verifier != nil {
 					// submit the block events to the verifier for future sealing verification
-					if err := r.verifier.AddBlock(blockEvents); err != nil {
+					if err := r.verifier.AddFinalizedBlock(blockEvents); err != nil {
 						eventsChan <- models.NewBlockEventsError(err)
 						return
 					}

--- a/services/ingestion/block_tracking_subscriber.go
+++ b/services/ingestion/block_tracking_subscriber.go
@@ -6,9 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onflow/flow-evm-gateway/models"
-	errs "github.com/onflow/flow-evm-gateway/models/errors"
-	"github.com/onflow/flow-evm-gateway/services/requester"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go/fvm/evm/events"
 	flowGo "github.com/onflow/flow-go/model/flow"
@@ -16,6 +13,10 @@ import (
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/onflow/flow-evm-gateway/models"
+	errs "github.com/onflow/flow-evm-gateway/models/errors"
+	"github.com/onflow/flow-evm-gateway/services/requester"
 )
 
 var _ EventSubscriber = &RPCBlockTrackingSubscriber{}
@@ -35,6 +36,8 @@ var _ EventSubscriber = &RPCBlockTrackingSubscriber{}
 // at which point this subscriber will be removed.
 type RPCBlockTrackingSubscriber struct {
 	*RPCEventSubscriber
+
+	verifier *SealingVerifier
 }
 
 func NewRPCBlockTrackingSubscriber(
@@ -43,6 +46,7 @@ func NewRPCBlockTrackingSubscriber(
 	chainID flowGo.ChainID,
 	keyLock requester.KeyLock,
 	startHeight uint64,
+	verifier *SealingVerifier,
 ) *RPCBlockTrackingSubscriber {
 	return &RPCBlockTrackingSubscriber{
 		RPCEventSubscriber: NewRPCEventSubscriber(
@@ -52,6 +56,7 @@ func NewRPCBlockTrackingSubscriber(
 			keyLock,
 			startHeight,
 		),
+		verifier: verifier,
 	}
 }
 
@@ -166,6 +171,12 @@ func (r *RPCBlockTrackingSubscriber) subscribe(ctx context.Context, height uint6
 
 				blockEvents, err := r.evmEventsForBlock(ctx, blockHeader)
 				if err != nil {
+					eventsChan <- models.NewBlockEventsError(err)
+					return
+				}
+
+				// submit the block events to the verifier for future sealing verification
+				if err := r.verifier.AddBlock(blockEvents); err != nil {
 					eventsChan <- models.NewBlockEventsError(err)
 					return
 				}

--- a/services/ingestion/sealing_verifier.go
+++ b/services/ingestion/sealing_verifier.go
@@ -1,0 +1,256 @@
+package ingestion
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go-sdk/access"
+	flowGo "github.com/onflow/flow-go/model/flow"
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/onflow/flow-evm-gateway/models"
+	errs "github.com/onflow/flow-evm-gateway/models/errors"
+	"github.com/onflow/flow-evm-gateway/services/requester"
+	"github.com/onflow/flow-evm-gateway/storage/pebble"
+)
+
+var _ models.Engine = &SealingVerifier{}
+
+// SealingVerifier verifies that soft finality events received over the Access polling API match the
+// actually sealed results from the event stream.
+type SealingVerifier struct {
+	*models.EngineStatus
+
+	logger zerolog.Logger
+
+	client *requester.CrossSporkClient
+	chain  flowGo.ChainID
+
+	eventsHash     *pebble.EventsHash
+	blocksToVerify map[uint64]flow.Identifier
+
+	mu sync.Mutex
+}
+
+// NewSealingVerifier creates a new sealing verifier.
+func NewSealingVerifier(
+	logger zerolog.Logger,
+	client *requester.CrossSporkClient,
+	chain flowGo.ChainID,
+	eventsHash *pebble.EventsHash,
+) *SealingVerifier {
+	return &SealingVerifier{
+		EngineStatus: models.NewEngineStatus(),
+		logger:       logger,
+		client:       client,
+		chain:        chain,
+		eventsHash:   eventsHash,
+	}
+}
+
+// Stop the engine.
+func (v *SealingVerifier) Stop() {
+	v.MarkDone()
+	<-v.Stopped()
+}
+
+// AddBlock adds a block to the sealing verifier for verification when the sealed data is received.
+func (v *SealingVerifier) AddBlock(events flow.BlockEvents) error {
+	hash, err := CalculateHash(events)
+	if err != nil {
+		return fmt.Errorf("failed to calculate hash for block %d: %w", events.Height, err)
+	}
+
+	if err := v.eventsHash.Store(events.Height, hash); err != nil {
+		return fmt.Errorf("failed to store events hash for block %d: %w", events.Height, err)
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.blocksToVerify[events.Height] = hash
+
+	return nil
+}
+
+// Run executes the sealing verifier.
+// This method will block until the context is canceled or an error occurs.
+func (v *SealingVerifier) Run(ctx context.Context) error {
+	defer v.MarkStopped()
+
+	lastVerifiedHeight, err := v.eventsHash.ProcessedSealedHeight()
+	if err != nil {
+		return fmt.Errorf("failed to get processed sealed height: %w", err)
+	}
+
+	var eventsChan <-chan flow.BlockEvents
+	var errChan <-chan error
+
+	subscriptionCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	lastReceivedHeight := lastVerifiedHeight + 1
+	connect := func(height uint64) error {
+		var err error
+		eventsChan, errChan, err = v.client.SubscribeEventsByBlockHeight(
+			subscriptionCtx,
+			height,
+			blocksFilter(v.chain),
+			access.WithHeartbeatInterval(1),
+		)
+		return err
+	}
+
+	if err := connect(lastReceivedHeight); err != nil {
+		return fmt.Errorf("failed to subscribe for finalized block events on height: %d, with: %w", lastReceivedHeight, err)
+	}
+
+	v.MarkReady()
+	for {
+		select {
+		case <-ctx.Done():
+			v.logger.Info().Msg("sealing verifier received done signal")
+			return nil
+
+		case <-v.Done():
+			v.logger.Info().Msg("sealing verifier received stop signal")
+			cancel()
+			return nil
+
+		case blockEvents, ok := <-eventsChan:
+			if !ok {
+				if ctx.Err() != nil {
+					return nil
+				}
+				return fmt.Errorf("failed to receive block events: %w", err)
+			}
+
+			if err := v.verifyBlock(blockEvents); err != nil {
+				v.logger.Fatal().Err(err).
+					Uint64("height", blockEvents.Height).
+					Str("block_id", blockEvents.BlockID.String()).
+					Msg("failed to verify block events")
+				return fmt.Errorf("failed to verify block events for %d: %w", blockEvents.Height, err)
+			}
+
+			if err := v.eventsHash.SetProcessedSealedHeight(blockEvents.Height); err != nil {
+				return fmt.Errorf("failed to store processed sealed height: %w", err)
+			}
+
+		case err, ok := <-errChan:
+			if !ok {
+				if ctx.Err() != nil {
+					return nil
+				}
+				return fmt.Errorf("failed to receive block events: %w", err)
+			}
+
+			switch status.Code(err) {
+			case codes.NotFound:
+				// we can get not found when reconnecting after a disconnect/restart before the
+				// next block is finalized. just wait briefly and try again
+				time.Sleep(200 * time.Millisecond)
+			case codes.DeadlineExceeded, codes.Internal:
+				// these are sometimes returned when the stream is disconnected by a middleware or the server
+			default:
+				// skip reconnect on all other errors
+				return fmt.Errorf("%w: %w", errs.ErrDisconnected, err)
+			}
+
+			if err := connect(lastReceivedHeight + 1); err != nil {
+				return fmt.Errorf("failed to resubscribe for finalized block headers on height: %d, with: %w", lastReceivedHeight+1, err)
+			}
+		}
+	}
+}
+
+// getEventsHash returns the events hash for the given height
+func (v *SealingVerifier) getEventsHash(height uint64) (flow.Identifier, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if hash, ok := v.blocksToVerify[height]; ok {
+		return hash, nil
+	}
+
+	hash, err := v.eventsHash.GetByHeight(height)
+	if err != nil {
+		return flow.Identifier{}, fmt.Errorf("failed to get events hash for block %d: %w", height, err)
+	}
+
+	// note: don't cache it here since we will not revisit this height
+
+	return hash, nil
+}
+
+// verifyBlock verifies that the hash of the sealed events matches the hash of unsealed events stored
+// for the same height.
+func (v *SealingVerifier) verifyBlock(sealedEvents flow.BlockEvents) error {
+	unsealedHash, err := v.getEventsHash(sealedEvents.Height)
+	if err != nil {
+		return fmt.Errorf("no unsealed events found for height %d: %w", sealedEvents.Height, err)
+	}
+
+	sealedHash, err := CalculateHash(sealedEvents)
+	if err != nil {
+		return fmt.Errorf("failed to calculate hash for sealed events: %w", err)
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	// always delete since we will crash on error anyway
+	defer delete(v.blocksToVerify, sealedEvents.Height)
+
+	if sealedHash != unsealedHash {
+		return fmt.Errorf("event hash mismatch: expected %s, got %s", sealedHash, unsealedHash)
+	}
+
+	return nil
+}
+
+// CalculateHash calculates the hash of the given block events object.
+func CalculateHash(events flow.BlockEvents) (flow.Identifier, error) {
+	// convert to strip cadence payload objects
+	converted, err := convertFlowBlockEvents(events)
+	if err != nil {
+		return flow.Identifier{}, err
+	}
+
+	hash := flowGo.MakeID(converted)
+	return flow.BytesToID(hash[:]), nil
+}
+
+// convertFlowBlockEvents converts a flow.BlockEvents (flow-go-sdk) to a flowGo.BlockEvents (flow-go).
+func convertFlowBlockEvents(events flow.BlockEvents) (flowGo.BlockEvents, error) {
+	blockID, err := flowGo.ByteSliceToId(events.BlockID.Bytes())
+	if err != nil {
+		return flowGo.BlockEvents{}, fmt.Errorf("failed to convert block ID: %w", err)
+	}
+
+	flowEvents := make([]flowGo.Event, len(events.Events))
+	for i, e := range events.Events {
+		txID, err := flowGo.ByteSliceToId(e.TransactionID.Bytes())
+		if err != nil {
+			return flowGo.BlockEvents{}, fmt.Errorf("failed to convert transaction ID %s: %w", e.TransactionID.Hex(), err)
+		}
+		flowEvents[i] = flowGo.Event{
+			Type:             flowGo.EventType(e.Type),
+			TransactionID:    txID,
+			TransactionIndex: uint32(e.TransactionIndex),
+			EventIndex:       uint32(e.EventIndex),
+			Payload:          e.Payload,
+		}
+	}
+
+	return flowGo.BlockEvents{
+		BlockID:        blockID,
+		BlockHeight:    events.Height,
+		BlockTimestamp: events.BlockTimestamp,
+		Events:         flowEvents,
+	}, nil
+}

--- a/storage/pebble/db.go
+++ b/storage/pebble/db.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/bloom"
-	"github.com/onflow/flow-emulator/storage"
 	"github.com/rs/zerolog/log"
 )
 

--- a/storage/pebble/events_hash.go
+++ b/storage/pebble/events_hash.go
@@ -1,0 +1,65 @@
+package pebble
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	pebbleDB "github.com/cockroachdb/pebble"
+	"github.com/onflow/flow-go-sdk"
+
+	errs "github.com/onflow/flow-evm-gateway/models/errors"
+)
+
+type EventsHash struct {
+	store *Storage
+}
+
+func NewEventsHash(store *Storage) *EventsHash {
+	return &EventsHash{
+		store: store,
+	}
+}
+
+func (e *EventsHash) Store(height uint64, hash flow.Identifier) error {
+	return WithBatch(e.store, func(batch *pebbleDB.Batch) error {
+		if err := e.store.set(eventsHashKey, uint64Bytes(height), hash.Bytes(), batch); err != nil {
+			return fmt.Errorf(
+				"failed to store events hash for block %d, with: %w",
+				height,
+				err,
+			)
+		}
+		return nil
+	})
+}
+
+func (e *EventsHash) GetByHeight(height uint64) (flow.Identifier, error) {
+	hash, err := e.store.get(eventsHashKey, uint64Bytes(height))
+	if err != nil {
+		return flow.Identifier{}, fmt.Errorf("failed to get events hash for block %d, with: %w", height, err)
+	}
+
+	return flow.BytesToID(hash), nil
+}
+
+func (e *EventsHash) ProcessedSealedHeight() (uint64, error) {
+	val, err := e.store.get(sealedEventsHeightKey)
+	if err != nil {
+		if errors.Is(err, errs.ErrEntityNotFound) {
+			return 0, errs.ErrStorageNotInitialized
+		}
+		return 0, fmt.Errorf("failed to get latest processed sealed height: %w", err)
+	}
+
+	return binary.BigEndian.Uint64(val), nil
+}
+
+func (e *EventsHash) SetProcessedSealedHeight(height uint64) error {
+	return WithBatch(e.store, func(batch *pebbleDB.Batch) error {
+		if err := e.store.set(sealedEventsHeightKey, nil, uint64Bytes(height), batch); err != nil {
+			return fmt.Errorf("failed to store latest processed sealed height: %d, with: %w", height, err)
+		}
+		return nil
+	})
+}

--- a/storage/pebble/keys.go
+++ b/storage/pebble/keys.go
@@ -30,6 +30,9 @@ const (
 	// special keys
 	latestEVMHeightKey     = byte(100)
 	latestCadenceHeightKey = byte(102)
+
+	eventsHashKey         = byte(150)
+	sealedEventsHeightKey = byte(151)
 )
 
 // makePrefix makes a key used internally to store the values


### PR DESCRIPTION
Closes: #???

## Description

This PR adds a new subsystem `SealingVerifier` that tracks the unsealed events processed by the ingestion engine, and compares them against the events that were eventually sealed. If there is a mismatch, the node crashes with an error.

This adds a layer of protection in the event that there was an execution fork, and the node ingested data from the unsealed fork. In this case, the node will stop reploying to requests over it's API until it has been rolled back

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 