### PR TITLE
Consolidate the validations for max TX gas limit

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -578,7 +578,7 @@ func (b *BlockChainAPI) Call(
 
 	res, err := b.evm.Call(tx, from, height, stateOverrides, blockOverrides)
 	if err != nil {
-		return handleError[hexutil.Bytes](err, l, b.collector)
+		return nil, err
 	}
 
 	return res, nil
@@ -727,7 +727,8 @@ func (b *BlockChainAPI) EstimateGas(
 
 	tx, err := encodeTxFromArgs(args)
 	if err != nil {
-		return hexutil.Uint64(BlockGasLimit), nil // return block gas limit
+		// return max tx gas limit
+		return hexutil.Uint64(models.TxMaxGasLimit), nil
 	}
 
 	// Default address in case user does not provide one
@@ -747,7 +748,7 @@ func (b *BlockChainAPI) EstimateGas(
 
 	estimatedGas, err := b.evm.EstimateGas(tx, from, height, stateOverrides)
 	if err != nil {
-		return handleError[hexutil.Uint64](err, l, b.collector)
+		return 0, err
 	}
 
 	return hexutil.Uint64(estimatedGas), nil

--- a/api/debug.go
+++ b/api/debug.go
@@ -194,7 +194,7 @@ func (d *DebugAPI) TraceCall(
 		flowEVM.StorageAccountAddress(d.config.FlowNetworkID),
 		d.registerStore,
 		blocksProvider,
-		BlockGasLimit,
+		models.TxMaxGasLimit,
 	)
 
 	view, err := viewProvider.GetBlockView(block.Height)

--- a/api/utils.go
+++ b/api/utils.go
@@ -9,6 +9,7 @@ import (
 
 	ethTypes "github.com/onflow/flow-evm-gateway/eth/types"
 	"github.com/onflow/flow-evm-gateway/metrics"
+	"github.com/onflow/flow-evm-gateway/models"
 	errs "github.com/onflow/flow-evm-gateway/models/errors"
 	"github.com/onflow/flow-evm-gateway/storage"
 	"github.com/onflow/go-ethereum/common"
@@ -153,7 +154,7 @@ func encodeTxFromArgs(args ethTypes.TransactionArgs) (*types.DynamicFeeTx, error
 
 	// provide a high enough gas for the tx to be able to execute,
 	// capped by the gas set in transaction args.
-	gasLimit := BlockGasLimit
+	gasLimit := models.TxMaxGasLimit
 	if args.Gas != nil {
 		gasLimit = uint64(*args.Gas)
 	}

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	"github.com/onflow/cadence"
+	errs "github.com/onflow/flow-evm-gateway/models/errors"
 	"github.com/onflow/flow-go/fvm/evm/events"
 	"github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/go-ethereum/common"
@@ -27,6 +28,11 @@ const (
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
 	TxMaxSize = 4 * TxSlotSize // 128KB
+
+	// TxMaxSize is the maximum valid gas limit for EVM transactions that are
+	// wrapped within a Cadence transaction, configured with 9999 as the
+	// computation limit.
+	TxMaxGasLimit = uint64(50_000_000)
 )
 
 type Transaction interface {
@@ -267,6 +273,10 @@ func ValidateTransaction(
 	signer gethTypes.Signer,
 	opts *txpool.ValidationOptions,
 ) error {
+	if tx.Gas() > TxMaxGasLimit {
+		return errs.NewTxGasLimitTooHighError(TxMaxGasLimit)
+	}
+
 	txDataLen := len(tx.Data())
 
 	// Contract creation doesn't validate call data, handle first

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -303,6 +303,20 @@ func TestValidateTransaction(t *testing.T) {
 			valid:  true,
 			errMsg: "",
 		},
+		"gas limit exceeds max allowed value": {
+			tx: gethTypes.NewTx(
+				&gethTypes.LegacyTx{
+					Nonce:    1,
+					To:       &validToAddress,
+					Value:    big.NewInt(0),
+					Gas:      TxMaxGasLimit + 25_000,
+					GasPrice: big.NewInt(0),
+					Data:     []byte{},
+				},
+			),
+			valid:  false,
+			errMsg: "invalid: failed transaction: tx gas limit exceeds the max value of 50000000",
+		},
 		"send to 0 address": {
 			tx: gethTypes.NewTx(
 				&gethTypes.LegacyTx{

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -44,7 +44,6 @@ var (
 
 const minFlowBalance = 2
 const blockGasLimit = 120_000_000
-const txMaxGasLimit = 50_000_000
 
 // estimateGasErrorRatio is the amount of overestimation eth_estimateGas
 // is allowed to produce in order to speed up calculations.
@@ -189,10 +188,6 @@ func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash,
 		return common.Hash{}, err
 	}
 
-	if tx.Gas() > txMaxGasLimit {
-		return common.Hash{}, errs.NewTxGasLimitTooHighError(txMaxGasLimit)
-	}
-
 	if err := models.ValidateTransaction(tx, e.head, e.evmSigner, e.validationOptions); err != nil {
 		return common.Hash{}, err
 	}
@@ -333,7 +328,7 @@ func (e *EVM) EstimateGas(
 		passingGasLimit uint64 // lowest-known gas limit where tx execution succeeds
 	)
 	// Determine the highest gas limit that can be used during the estimation.
-	passingGasLimit = blockGasLimit
+	passingGasLimit = models.TxMaxGasLimit
 	if tx.Gas >= gethParams.TxGas {
 		passingGasLimit = tx.Gas
 	}
@@ -473,7 +468,7 @@ func (e *EVM) getBlockView(
 		evm.StorageAccountAddress(e.config.FlowNetworkID),
 		e.registerStore,
 		blocksProvider,
-		blockGasLimit,
+		models.TxMaxGasLimit,
 	)
 
 	return viewProvider.GetBlockView(height)

--- a/tests/web3js/debug_traces_test.js
+++ b/tests/web3js/debug_traces_test.js
@@ -656,4 +656,25 @@ it('should retrieve call traces', async () => {
     )
     assert.equal(updateTrace.value, '0x0')
     assert.equal(updateTrace.type, 'CALL')
+
+    // test that `gas` limit does not exceed the `50M` value
+    traceCall = {
+        from: conf.eoa.address,
+        to: contractAddress,
+        data: callData,
+        value: '0x0',
+        gasPrice: web3.utils.toHex(conf.minGasPrice),
+        gas: '0x6CB8080'
+    }
+    response = await helpers.callRPCMethod(
+        'debug_traceCall',
+        [traceCall, 'latest', callTracer]
+    )
+    assert.equal(response.status, 200)
+    assert.isDefined(response.body)
+
+    assert.equal(
+        response.body.error.message,
+        'gas limit is bigger than max gas limit allowed 114000000 > 50000000'
+    )
 })

--- a/tests/web3js/eth_failure_handling_test.js
+++ b/tests/web3js/eth_failure_handling_test.js
@@ -6,8 +6,31 @@ const web3 = conf.web3
 it('should fail when tx gas limit higher than the max value', async () => {
     let receiver = web3.eth.accounts.create()
 
+    let signedTx = await receiver.signTransaction({
+        from: receiver.address,
+        to: conf.eoa.address,
+        value: 10,
+        gasPrice: conf.minGasPrice,
+        gasLimit: 51_000_000, // max tx gas limit is 50_000_000
+    })
+    let response = await helpers.callRPCMethod(
+        'eth_sendRawTransaction',
+        [signedTx.rawTransaction]
+    )
+    assert.equal(200, response.status)
+    assert.isDefined(response.body)
+
+    assert.include(
+        response.body.error.message,
+        'tx gas limit exceeds the max value of 50000000'
+    )
+})
+
+it('should fail when eth_call gas limit higher than the max value', async () => {
+    let receiver = web3.eth.accounts.create()
+
     try {
-        await helpers.signAndSend({
+        await web3.eth.call({
             from: conf.eoa.address,
             to: receiver.address,
             value: 10,
@@ -15,7 +38,32 @@ it('should fail when tx gas limit higher than the max value', async () => {
             gasLimit: 51_000_000, // max tx gas limit is 50_000_000
         })
     } catch (e) {
-        assert.include(e.message, 'tx gas limit exceeds the max value of 50000000')
+        assert.include(
+            e.message,
+            'gas limit is bigger than max gas limit allowed 51000000 > 50000000'
+        )
+        return
+    }
+
+    assert.fail('should not reach')
+})
+
+it('should fail when eth_estimateGas gas limit higher than the max value', async () => {
+    let receiver = web3.eth.accounts.create()
+
+    try {
+        await web3.eth.estimateGas({
+            from: conf.eoa.address,
+            to: receiver.address,
+            value: 10,
+            gasPrice: conf.minGasPrice,
+            gasLimit: 51_000_000, // max tx gas limit is 50_000_000
+        })
+    } catch (e) {
+        assert.include(
+            e.message,
+            'gas limit is bigger than max gas limit allowed 51000000 > 50000000'
+        )
         return
     }
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/758

## Description

The max TX gas limit for `eth_sendRawTransaction` was recently set to `50M`.
Now we apply this same limit to the following endpoints:
- `eth_call`
- `eth_estimateGas`
- `debug_traceCall`


______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined error handling in transaction processing, enhancing clarity in feedback when operations exceed allowed gas limits.

- **Tests**
  - Added new test cases to ensure transactions with gas limits above the maximum are correctly identified as invalid and that appropriate error messages are returned across various methods.
  - Enhanced testing for gas limit scenarios in Ethereum transactions, ensuring proper error handling for exceeded limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->