### PR TITLE
Replace all `internal error` occurrences with actual error messages

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -950,7 +950,7 @@ func (b *BlockChainAPI) prepareBlockResponse(
 	h, err := block.Hash()
 	if err != nil {
 		b.logger.Error().Err(err).Msg("failed to calculate hash for block by number")
-		return nil, errs.ErrInternal
+		return nil, err
 	}
 
 	blockResponse := &ethTypes.Block{

--- a/api/server.go
+++ b/api/server.go
@@ -435,7 +435,6 @@ type responseHandler struct {
 }
 
 var knownErrors = []error{
-	errs.ErrInternal,
 	errs.ErrRateLimit,
 	errs.ErrInvalid,
 	errs.ErrFailedTransaction,

--- a/api/stream.go
+++ b/api/stream.go
@@ -14,7 +14,6 @@ import (
 	"github.com/onflow/flow-evm-gateway/config"
 	ethTypes "github.com/onflow/flow-evm-gateway/eth/types"
 	"github.com/onflow/flow-evm-gateway/models"
-	errs "github.com/onflow/flow-evm-gateway/models/errors"
 	"github.com/onflow/flow-evm-gateway/services/logs"
 	"github.com/onflow/flow-evm-gateway/storage"
 )
@@ -128,7 +127,7 @@ func (s *StreamAPI) prepareBlockHeader(
 	h, err := block.Hash()
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to calculate hash for block by number")
-		return nil, errs.ErrInternal
+		return nil, err
 	}
 
 	blockHeader := &ethTypes.BlockHeader{

--- a/api/utils.go
+++ b/api/utils.go
@@ -136,7 +136,7 @@ func handleError[T any](err error, log zerolog.Logger, collector metrics.Collect
 	default:
 		collector.ApiErrorOccurred()
 		log.Error().Err(err).Msg("api error")
-		return zero, errs.ErrInternal
+		return zero, err
 	}
 }
 

--- a/eth/types/types.go
+++ b/eth/types/types.go
@@ -176,8 +176,7 @@ func NewTransaction(
 	f, err := tx.From()
 	if err != nil {
 		return nil, fmt.Errorf(
-			"%w: failed to get from address for tx: %s, with: %w",
-			errs.ErrInternal,
+			"failed to get from address for tx: %s, with: %w",
 			tx.Hash(),
 			err,
 		)

--- a/models/errors/errors.go
+++ b/models/errors/errors.go
@@ -19,7 +19,6 @@ var (
 
 	// General errors
 
-	ErrInternal            = errors.New("internal error")
 	ErrInvalid             = errors.New("invalid")
 	ErrRecoverable         = errors.New("recoverable")
 	ErrDisconnected        = NewRecoverableError(errors.New("disconnected"))

--- a/services/requester/key_store.go
+++ b/services/requester/key_store.go
@@ -9,7 +9,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-var ErrNoKeysAvailable = fmt.Errorf("no keys available")
+var ErrNoKeysAvailable = fmt.Errorf("no signing keys available")
 
 const accountKeyBlockExpiration = flow.DefaultTransactionExpiry
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/765

## Description

The `internal error` is quite vague, and it makes debugging much harder, so we completely remove it.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced error reporting to provide more specific and useful feedback when issues occur.
	- Streamlined logging and error detection, reducing generic messages in favor of detailed error information.
	- Simplified error handling logic by removing unnecessary complexity and focusing on panic-related errors.

- **Chores**
	- Cleaned up redundant error definitions and dependencies.
	- Updated error messages for clarity in key-related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->