### PR TITLE
Revert "Merge pull request #759 from onflow/mpeter/consolidate-tx-max-gas-limit"

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -575,7 +575,7 @@ func (b *BlockChainAPI) Call(
 
 	res, err := b.evm.Call(tx, from, height, stateOverrides, blockOverrides)
 	if err != nil {
-		return nil, err
+		return handleError[hexutil.Bytes](err, l, b.collector)
 	}
 
 	return res, nil
@@ -724,8 +724,7 @@ func (b *BlockChainAPI) EstimateGas(
 
 	tx, err := encodeTxFromArgs(args)
 	if err != nil {
-		// return max tx gas limit
-		return hexutil.Uint64(models.TxMaxGasLimit), nil
+		return hexutil.Uint64(BlockGasLimit), nil // return block gas limit
 	}
 
 	// Default address in case user does not provide one
@@ -745,7 +744,7 @@ func (b *BlockChainAPI) EstimateGas(
 
 	estimatedGas, err := b.evm.EstimateGas(tx, from, height, stateOverrides)
 	if err != nil {
-		return 0, err
+		return handleError[hexutil.Uint64](err, l, b.collector)
 	}
 
 	return hexutil.Uint64(estimatedGas), nil

--- a/api/debug.go
+++ b/api/debug.go
@@ -189,7 +189,7 @@ func (d *DebugAPI) TraceCall(
 		flowEVM.StorageAccountAddress(d.config.FlowNetworkID),
 		d.registerStore,
 		blocksProvider,
-		models.TxMaxGasLimit,
+		BlockGasLimit,
 	)
 
 	view, err := viewProvider.GetBlockView(block.Height)

--- a/api/utils.go
+++ b/api/utils.go
@@ -9,7 +9,6 @@ import (
 
 	ethTypes "github.com/onflow/flow-evm-gateway/eth/types"
 	"github.com/onflow/flow-evm-gateway/metrics"
-	"github.com/onflow/flow-evm-gateway/models"
 	errs "github.com/onflow/flow-evm-gateway/models/errors"
 	"github.com/onflow/flow-evm-gateway/storage"
 	"github.com/onflow/go-ethereum/common"
@@ -156,7 +155,7 @@ func encodeTxFromArgs(args ethTypes.TransactionArgs) (*types.DynamicFeeTx, error
 
 	// provide a high enough gas for the tx to be able to execute,
 	// capped by the gas set in transaction args.
-	gasLimit := models.TxMaxGasLimit
+	gasLimit := BlockGasLimit
 	if args.Gas != nil {
 		gasLimit = uint64(*args.Gas)
 	}

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 
 	"github.com/onflow/cadence"
-	errs "github.com/onflow/flow-evm-gateway/models/errors"
 	"github.com/onflow/flow-go/fvm/evm/events"
 	"github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/go-ethereum/common"
@@ -28,11 +27,6 @@ const (
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
 	TxMaxSize = 4 * TxSlotSize // 128KB
-
-	// TxMaxSize is the maximum valid gas limit for EVM transactions that are
-	// wrapped within a Cadence transaction, configured with 9999 as the
-	// computation limit.
-	TxMaxGasLimit = uint64(50_000_000)
 )
 
 var BaseFeePerGas = big.NewInt(1)
@@ -276,10 +270,6 @@ func ValidateTransaction(
 	signer gethTypes.Signer,
 	opts *txpool.ValidationOptions,
 ) error {
-	if tx.Gas() > TxMaxGasLimit {
-		return errs.NewTxGasLimitTooHighError(TxMaxGasLimit)
-	}
-
 	txDataLen := len(tx.Data())
 
 	// Contract creation doesn't validate call data, handle first

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -303,20 +303,6 @@ func TestValidateTransaction(t *testing.T) {
 			valid:  true,
 			errMsg: "",
 		},
-		"gas limit exceeds max allowed value": {
-			tx: gethTypes.NewTx(
-				&gethTypes.LegacyTx{
-					Nonce:    1,
-					To:       &validToAddress,
-					Value:    big.NewInt(0),
-					Gas:      TxMaxGasLimit + 25_000,
-					GasPrice: big.NewInt(0),
-					Data:     []byte{},
-				},
-			),
-			valid:  false,
-			errMsg: "invalid: failed transaction: tx gas limit exceeds the max value of 50000000",
-		},
 		"send to 0 address": {
 			tx: gethTypes.NewTx(
 				&gethTypes.LegacyTx{

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -46,6 +46,7 @@ var (
 
 const minFlowBalance = 2
 const blockGasLimit = 120_000_000
+const txMaxGasLimit = 50_000_000
 
 // estimateGasErrorRatio is the amount of overestimation eth_estimateGas
 // is allowed to produce in order to speed up calculations.
@@ -202,6 +203,10 @@ func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash,
 		return common.Hash{}, err
 	}
 
+	if tx.Gas() > txMaxGasLimit {
+		return common.Hash{}, errs.NewTxGasLimitTooHighError(txMaxGasLimit)
+	}
+
 	if err := models.ValidateTransaction(tx, e.head, e.evmSigner, e.validationOptions); err != nil {
 		return common.Hash{}, err
 	}
@@ -353,7 +358,7 @@ func (e *EVM) EstimateGas(
 		passingGasLimit uint64 // lowest-known gas limit where tx execution succeeds
 	)
 	// Determine the highest gas limit that can be used during the estimation.
-	passingGasLimit = models.TxMaxGasLimit
+	passingGasLimit = blockGasLimit
 	if tx.Gas >= gethParams.TxGas {
 		passingGasLimit = tx.Gas
 	}
@@ -493,7 +498,7 @@ func (e *EVM) getBlockView(
 		evm.StorageAccountAddress(e.config.FlowNetworkID),
 		e.registerStore,
 		blocksProvider,
-		models.TxMaxGasLimit,
+		blockGasLimit,
 	)
 
 	return viewProvider.GetBlockView(height)

--- a/tests/web3js/debug_traces_test.js
+++ b/tests/web3js/debug_traces_test.js
@@ -656,25 +656,4 @@ it('should retrieve call traces', async () => {
     )
     assert.equal(updateTrace.value, '0x0')
     assert.equal(updateTrace.type, 'CALL')
-
-    // test that `gas` limit does not exceed the `50M` value
-    traceCall = {
-        from: conf.eoa.address,
-        to: contractAddress,
-        data: callData,
-        value: '0x0',
-        gasPrice: web3.utils.toHex(conf.minGasPrice),
-        gas: '0x6CB8080'
-    }
-    response = await helpers.callRPCMethod(
-        'debug_traceCall',
-        [traceCall, 'latest', callTracer]
-    )
-    assert.equal(response.status, 200)
-    assert.isDefined(response.body)
-
-    assert.equal(
-        response.body.error.message,
-        'gas limit is bigger than max gas limit allowed 114000000 > 50000000'
-    )
 })

--- a/tests/web3js/eth_failure_handling_test.js
+++ b/tests/web3js/eth_failure_handling_test.js
@@ -6,31 +6,8 @@ const web3 = conf.web3
 it('should fail when tx gas limit higher than the max value', async () => {
     let receiver = web3.eth.accounts.create()
 
-    let signedTx = await receiver.signTransaction({
-        from: receiver.address,
-        to: conf.eoa.address,
-        value: 10,
-        gasPrice: conf.minGasPrice,
-        gasLimit: 51_000_000, // max tx gas limit is 50_000_000
-    })
-    let response = await helpers.callRPCMethod(
-        'eth_sendRawTransaction',
-        [signedTx.rawTransaction]
-    )
-    assert.equal(200, response.status)
-    assert.isDefined(response.body)
-
-    assert.include(
-        response.body.error.message,
-        'tx gas limit exceeds the max value of 50000000'
-    )
-})
-
-it('should fail when eth_call gas limit higher than the max value', async () => {
-    let receiver = web3.eth.accounts.create()
-
     try {
-        await web3.eth.call({
+        await helpers.signAndSend({
             from: conf.eoa.address,
             to: receiver.address,
             value: 10,
@@ -38,32 +15,7 @@ it('should fail when eth_call gas limit higher than the max value', async () => 
             gasLimit: 51_000_000, // max tx gas limit is 50_000_000
         })
     } catch (e) {
-        assert.include(
-            e.message,
-            'gas limit is bigger than max gas limit allowed 51000000 > 50000000'
-        )
-        return
-    }
-
-    assert.fail('should not reach')
-})
-
-it('should fail when eth_estimateGas gas limit higher than the max value', async () => {
-    let receiver = web3.eth.accounts.create()
-
-    try {
-        await web3.eth.estimateGas({
-            from: conf.eoa.address,
-            to: receiver.address,
-            value: 10,
-            gasPrice: conf.minGasPrice,
-            gasLimit: 51_000_000, // max tx gas limit is 50_000_000
-        })
-    } catch (e) {
-        assert.include(
-            e.message,
-            'gas limit is bigger than max gas limit allowed 51000000 > 50000000'
-        )
+        assert.include(e.message, 'tx gas limit exceeds the max value of 50000000')
         return
     }
 


### PR DESCRIPTION
## Description

This reverts commit 7274b59bec76c3a6284c8d86ef33fb4bf987e501, reversing changes made to da6552b369f4b9c6dc95402cd9c3f9505c230dbd.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a unified gas limit threshold for processing raw transactions, ensuring that transaction gas limits exceeding the set maximum are clearly rejected.
  
- **Refactor**
	- Standardized error reporting across transaction operations, resulting in consistent and structured error messages.

- **Tests**
	- Updated and streamlined tests for transaction validations to align with the new gas limit control and error handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->