### PR TITLE
Initialize keys and balance metrics on startup

### DIFF
--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -127,6 +127,7 @@ func NewEVM(
 ) (*EVM, error) {
 	logger = logger.With().Str("component", "requester").Logger()
 
+	// initialize the available keys metric since it is only updated when sending a tx
 	collector.AvailableSigningKeys(keystore.AvailableKeys())
 
 	if !config.IndexOnly {
@@ -139,6 +140,7 @@ func NewEVM(
 				err,
 			)
 		}
+		// initialize the operator balance metric since it is only updated when sending a tx
 		collector.OperatorBalance(acc)
 
 		if acc.Balance < minFlowBalance {

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -126,6 +126,8 @@ func NewEVM(
 ) (*EVM, error) {
 	logger = logger.With().Str("component", "requester").Logger()
 
+	collector.AvailableSigningKeys(keystore.AvailableKeys())
+
 	if !config.IndexOnly {
 		address := config.COAAddress
 		acc, err := client.GetAccount(context.Background(), address)
@@ -136,6 +138,7 @@ func NewEVM(
 				err,
 			)
 		}
+		collector.OperatorBalance(acc)
 
 		if acc.Balance < minFlowBalance {
 			return nil, fmt.Errorf(
@@ -178,7 +181,7 @@ func NewEVM(
 		return nil, fmt.Errorf("failed to create TX rate limiter: %w", err)
 	}
 
-	evm := &EVM{
+	return &EVM{
 		registerStore:     registerStore,
 		client:            client,
 		config:            config,
@@ -191,9 +194,7 @@ func NewEVM(
 		collector:         collector,
 		keystore:          keystore,
 		rateLimiter:       rateLimiter,
-	}
-
-	return evm, nil
+	}, nil
 }
 
 func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash, error) {


### PR DESCRIPTION
Closes: #???

## Description

The available keys and operator balance metrics are currently only updated when transactions are sent. This makes it may take several minutes before they are initialized after a reboot, or never if the node sees little traffic. That's caused problems using these metrics for alerting.

This PR updates the EVM module to initialize them during startup.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the initialization process to ensure up-to-date account balance and security key information.

- **Refactor**
	- Streamlined the return process for the component creation flow, improving efficiency and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->