### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/services/logs/filter.go
+++ b/services/logs/filter.go
@@ -2,13 +2,12 @@ package logs
 
 import (
 	"fmt"
-
-	"github.com/onflow/go-ethereum/common"
-	gethTypes "github.com/onflow/go-ethereum/core/types"
-	"golang.org/x/exp/slices"
+	"slices"
 
 	errs "github.com/onflow/flow-evm-gateway/models/errors"
 	"github.com/onflow/flow-evm-gateway/storage"
+	"github.com/onflow/go-ethereum/common"
+	gethTypes "github.com/onflow/go-ethereum/core/types"
 )
 
 // The maximum number of topic criteria allowed

--- a/services/requester/cross-spork_client.go
+++ b/services/requester/cross-spork_client.go
@@ -3,6 +3,7 @@ package requester
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/onflow/cadence"
@@ -12,7 +13,6 @@ import (
 	flowGo "github.com/onflow/flow-go/model/flow"
 	"github.com/rs/zerolog"
 	"go.uber.org/ratelimit"
-	"golang.org/x/exp/slices"
 )
 
 type sporkClient struct {


### PR DESCRIPTION
Closes: #???

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated internal dependencies for slice operations to use a standard library module. These changes improve internal consistency without impacting any user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->