### PR TITLE
Add a CLI utility to verify integrity of EVM blocks DB

### DIFF
--- a/cmd/blocks/cmd.go
+++ b/cmd/blocks/cmd.go
@@ -1,0 +1,69 @@
+package blocks
+
+import (
+	"errors"
+	"fmt"
+
+	errs "github.com/onflow/flow-evm-gateway/models/errors"
+	"github.com/onflow/flow-evm-gateway/storage/pebble"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	flowGo "github.com/onflow/flow-go/model/flow"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "check-blocks-integrity",
+	Short: "Checks the EVM blocks integrity",
+	RunE: func(*cobra.Command, []string) error {
+		if databaseDir == "" || chain == "" {
+			return fmt.Errorf("databaseDir, chain flags must be provided")
+		}
+
+		pebbleDB, err := pebble.OpenDB(databaseDir)
+		if err != nil {
+			return fmt.Errorf("failed to open pebble db: %w", err)
+		}
+		defer pebbleDB.Close()
+		store := pebble.New(pebbleDB, log.Logger)
+
+		chainID := flowGo.ChainID(chain)
+		blocks := pebble.NewBlocks(store, chainID)
+
+		latestHeight, err := blocks.LatestEVMHeight()
+		if err != nil {
+			return fmt.Errorf("failed to get latest EVM height: %w", err)
+		}
+		log.Info().Msgf("Checking for missing EVM blocks up to EVM height %d", latestHeight)
+
+		var missingBlocks []uint64
+		for height := uint64(0); height <= latestHeight; height++ {
+			_, err := blocks.GetByHeight(height)
+			if errors.Is(err, errs.ErrEntityNotFound) {
+				log.Error().Msgf("missing EVM block with height: %d", height)
+				missingBlocks = append(missingBlocks, height)
+			} else if err != nil {
+				log.Error().Err(err).Msgf("failed to get block at height: %d", height)
+			}
+		}
+
+		if len(missingBlocks) > 0 {
+			log.Error().Msgf("Found %d missing blocks in the EVM blocks database", len(missingBlocks))
+			return nil
+		}
+
+		log.Info().Msg("EVM blocks DB has no integrity issues. All blocks are indexed.")
+
+		return nil
+	},
+}
+
+var (
+	databaseDir string
+	chain       string
+)
+
+func init() {
+	Cmd.Flags().StringVar(&databaseDir, "database-dir", "./db", "Path to the directory for the database")
+	Cmd.Flags().StringVar(&chain, "chain-id", "testnet", "Chain ID for the EVM network")
+}

--- a/cmd/blocks/cmd.go
+++ b/cmd/blocks/cmd.go
@@ -29,7 +29,7 @@ var Cmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to get latest EVM height: %w", err)
 		}
-		log.Info().Msgf("Checking for missing EVM blocks up to EVM height %d", latestHeight)
+		log.Info().Msgf("Checking for missing EVM blocks from genesis up to EVM height %d", latestHeight)
 
 		var missingBlocks []uint64
 		for height := uint64(0); height <= latestHeight; height++ {

--- a/cmd/blocks/cmd.go
+++ b/cmd/blocks/cmd.go
@@ -61,6 +61,11 @@ var (
 func init() {
 	Cmd.Flags().StringVar(&databaseDir, "database-dir", "./db", "Path to the directory for the database")
 	Cmd.Flags().StringVar(&chainID, "chain-id", "testnet", "Chain ID for the EVM network")
-	Cmd.MarkFlagRequired("database-dir")
-	Cmd.MarkFlagRequired("chain-id")
+
+	if err := Cmd.MarkFlagRequired("database-dir"); err != nil {
+		panic(err)
+	}
+	if err := Cmd.MarkFlagRequired("chain-id"); err != nil {
+		panic(err)
+	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"github.com/onflow/flow-evm-gateway/cmd/blocks"
 	"github.com/onflow/flow-evm-gateway/cmd/export"
 	"github.com/onflow/flow-evm-gateway/cmd/run"
 	"github.com/onflow/flow-evm-gateway/cmd/version"
@@ -25,6 +26,7 @@ func Execute() {
 func main() {
 	rootCmd.AddCommand(version.Cmd)
 	rootCmd.AddCommand(export.Cmd)
+	rootCmd.AddCommand(blocks.Cmd)
 	rootCmd.AddCommand(run.Cmd)
 
 	Execute()


### PR DESCRIPTION
Related: https://github.com/onflow/flow-evm-gateway/issues/766

## Description

Health check utility to detect missing EVM blocks from pebbleDB. Run with:
```bash
./flow-evm-gateway check-blocks-integrity --chain-id="flow-emulator" --database-dir=./evm-db/
```
**Note:** The dir provided in `--database-dir` flag, shouldn't be currently in use by a running EVM GW instance.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new CLI command, "check-blocks-integrity", for verifying the integrity of EVM blocks.
	- Users can specify the database directory and network chain identifier via command-line options, which are now marked as required with improved error handling.
	- The command checks for missing blocks and logs the results, enhancing data integrity assurance.
	- Integrated the "blocks" command into the application's command-line interface for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->