### PR TITLE
Always re-index latest Cadence block

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -143,23 +143,13 @@ func (b *Bootstrap) StartEventIngestion(ctx context.Context) error {
 
 	chainID := b.config.FlowNetworkID
 
-	// the event subscriber takes the first block to sync from the Access node, which is the block
-	// after the latest cadence block
-	nextCadenceHeight := latestCadenceHeight + 1
-	// Special case when using a local Emulator as Access Node. The Emulator
-	// always starts at block height 0, so if we try to subscribe at block
-	// height 1, we'll get an error, as it doesn't exist.
-	if latestCadenceHeight == config.EmulatorInitCadenceHeight {
-		nextCadenceHeight -= 1
-	}
-
 	// create event subscriber
 	subscriber := ingestion.NewRPCEventSubscriber(
 		b.logger,
 		b.client,
 		chainID,
 		b.keystore,
-		nextCadenceHeight,
+		latestCadenceHeight,
 	)
 
 	callTracerCollector, err := replayer.NewCallTracerCollector(b.logger)


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/766

## Description

Now that we have merged:
- https://github.com/onflow/flow-evm-gateway/pull/760
- https://github.com/onflow/flow-go/pull/7050

I believe that we can always subscribe to EVM events by using the latest Cadence block. There's been reports of missing EVM blocks, and it seems this behavior manifests after restarts of the EVM GW node.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 