### PR TITLE
Adjust histogram buckets for block_ingestion_time_seconds metric

### DIFF
--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -69,7 +69,7 @@ var gasEstimationIterations = prometheus.NewGauge(prometheus.GaugeOpts{
 var blockIngestionTime = prometheus.NewHistogram(prometheus.HistogramOpts{
 	Name:    prefixedName("block_ingestion_time_seconds"),
 	Help:    "Time taken to fully ingest an EVM block in the local state index",
-	Buckets: prometheus.DefBuckets,
+	Buckets: []float64{.5, 1, 2.5, 5, 10, 15, 20, 30, 45},
 })
 
 var requestRateLimitedCounters = prometheus.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
Closes: #???

## Description

Ingestion time averages around 5 for soft-finality, and 13 for sealed data. The previous buckets were `[]float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}`, which had many points on the far low range, and stopped in the middle of the expected range.

This PR adjusts to use fewer buckets, with better coverage of the expected  value range.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted performance tracking by updating the measurement configuration, enabling a more precise view of block processing times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->