### PR TITLE
Allow WebSocket connections in local environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ EMULATOR_ARGS := --flow-network-id=flow-emulator \
 		--log-writer=console \
 		--tx-state-validation=local-index \
 		--profiler-enabled=true \
-		--profiler-port=6060
+		--profiler-port=6060 \
+		--ws-enabled=true
 
 # Set VERSION from command line, environment, or default to SHORT_COMMIT
 VERSION ?= $(SHORT_COMMIT)


### PR DESCRIPTION
## Description

Update `make start-local` make recipe to allow WebSocket connections.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled WebSocket support in the emulator for enhanced connectivity without altering existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->