### PR TITLE
Update to `flow-go` with `go-ethereum@v1.14.13`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onflow/atree v0.9.0
 	github.com/onflow/cadence v1.3.3
-	github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250324074443-e6846a9071d1
+	github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250324151152-711870039f5b
 	github.com/onflow/flow-go-sdk v1.3.3
-	github.com/onflow/go-ethereum v1.14.8-0.20250320104444-963b8ea1b09d
+	github.com/onflow/go-ethereum v1.14.8-0.20250321083631-c17e334a7940
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rs/cors v1.8.0
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -562,8 +562,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.1 h1:Ts5ob+CoCY2EjEd0W6vdLJ7hLL3
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1 h1:FDYKAiGowABtoMNusLuRCILIZDtVqJ/5tYI4VkF5zfM=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250324074443-e6846a9071d1 h1:yPpT/js/a5fIcbBXeeszgsozTR64qeieyI+eDR8JMtM=
-github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250324074443-e6846a9071d1/go.mod h1:9zy+mqerOv/YZuHW/t1tfCFfMR8evSVAoOYaBnaTZiA=
+github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250324151152-711870039f5b h1:G4JQU14BZ69f6Wwrat3bJmzZyO1rMKu0X/+L0gFM0gI=
+github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250324151152-711870039f5b/go.mod h1:+kC8Bg4G0bS5KZsQmONv3GwXbVSnQEa3HK1I8rfkN24=
 github.com/onflow/flow-go-sdk v1.3.3 h1:wj7llql3wesQYBePh3lEFI+jk3Df1sa13bRsL139JDo=
 github.com/onflow/flow-go-sdk v1.3.3/go.mod h1:tSLvYIac9DlmUEqKHSHbVRyv4mSB0va4AuiV3XB9ENc=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.3 h1:4ju20g1xgDKWBT63rOj5f/Sa4Lc+naCSWT4p31x9yQk=
@@ -572,8 +572,8 @@ github.com/onflow/flow-nft/lib/go/templates v1.2.1 h1:SAALMZPDw9Eb9p5kSLnmnFxjyi
 github.com/onflow/flow-nft/lib/go/templates v1.2.1/go.mod h1:W6hOWU0xltPqNpv9gQX8Pj8Jtf0OmRxc1XX2V0kzJaI=
 github.com/onflow/flow/protobuf/go/flow v0.4.10 h1:CGEO3n96XZQd/k5HtkZyb90ouem9G+8fNcKyt8s2fvs=
 github.com/onflow/flow/protobuf/go/flow v0.4.10/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
-github.com/onflow/go-ethereum v1.14.8-0.20250320104444-963b8ea1b09d h1:qx3FMwXOFcQfPw+B9UVli8yvzdFNnT69bw0KoN/G7so=
-github.com/onflow/go-ethereum v1.14.8-0.20250320104444-963b8ea1b09d/go.mod h1:UUZh+WQQU9wbVYX8F5sId/Zl9ZHW0Mj6inVomcsmXOo=
+github.com/onflow/go-ethereum v1.14.8-0.20250321083631-c17e334a7940 h1:FgsV6iscE6rkuDXSM8X65OJdnu3A+oOev399iJEKb0M=
+github.com/onflow/go-ethereum v1.14.8-0.20250321083631-c17e334a7940/go.mod h1:UUZh+WQQU9wbVYX8F5sId/Zl9ZHW0Mj6inVomcsmXOo=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0 h1:sxyWLqGm/p4EKT6DUlQESDG1ZNMN9GjPCm1gTq7NGfc=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0/go.mod h1:kMeq9zUwCrgrSojEbTUTTJpZ4WwacVm2pA7LVFr+glk=
 github.com/onflow/sdks v0.6.0-preview.1 h1:mb/cUezuqWEP1gFZNAgUI4boBltudv4nlfxke1KBp9k=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/onflow/crypto v0.25.2
 	github.com/onflow/flow-emulator v1.2.1-0.20250314161500-c55d0b34c1dc
 	github.com/onflow/flow-evm-gateway v0.0.0-20240201154855-4d4d3d3f19c7
-	github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250324074443-e6846a9071d1
+	github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250324151152-711870039f5b
 	github.com/onflow/flow-go-sdk v1.3.3
-	github.com/onflow/go-ethereum v1.14.8-0.20250320104444-963b8ea1b09d
+	github.com/onflow/go-ethereum v1.14.8-0.20250321083631-c17e334a7940
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.10.0
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -798,8 +798,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.1 h1:Ts5ob+CoCY2EjEd0W6vdLJ7hLL3
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1 h1:FDYKAiGowABtoMNusLuRCILIZDtVqJ/5tYI4VkF5zfM=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250324074443-e6846a9071d1 h1:yPpT/js/a5fIcbBXeeszgsozTR64qeieyI+eDR8JMtM=
-github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250324074443-e6846a9071d1/go.mod h1:9zy+mqerOv/YZuHW/t1tfCFfMR8evSVAoOYaBnaTZiA=
+github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250324151152-711870039f5b h1:G4JQU14BZ69f6Wwrat3bJmzZyO1rMKu0X/+L0gFM0gI=
+github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250324151152-711870039f5b/go.mod h1:+kC8Bg4G0bS5KZsQmONv3GwXbVSnQEa3HK1I8rfkN24=
 github.com/onflow/flow-go-sdk v1.3.3 h1:wj7llql3wesQYBePh3lEFI+jk3Df1sa13bRsL139JDo=
 github.com/onflow/flow-go-sdk v1.3.3/go.mod h1:tSLvYIac9DlmUEqKHSHbVRyv4mSB0va4AuiV3XB9ENc=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.3 h1:4ju20g1xgDKWBT63rOj5f/Sa4Lc+naCSWT4p31x9yQk=
@@ -808,8 +808,8 @@ github.com/onflow/flow-nft/lib/go/templates v1.2.1 h1:SAALMZPDw9Eb9p5kSLnmnFxjyi
 github.com/onflow/flow-nft/lib/go/templates v1.2.1/go.mod h1:W6hOWU0xltPqNpv9gQX8Pj8Jtf0OmRxc1XX2V0kzJaI=
 github.com/onflow/flow/protobuf/go/flow v0.4.10 h1:CGEO3n96XZQd/k5HtkZyb90ouem9G+8fNcKyt8s2fvs=
 github.com/onflow/flow/protobuf/go/flow v0.4.10/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
-github.com/onflow/go-ethereum v1.14.8-0.20250320104444-963b8ea1b09d h1:qx3FMwXOFcQfPw+B9UVli8yvzdFNnT69bw0KoN/G7so=
-github.com/onflow/go-ethereum v1.14.8-0.20250320104444-963b8ea1b09d/go.mod h1:UUZh+WQQU9wbVYX8F5sId/Zl9ZHW0Mj6inVomcsmXOo=
+github.com/onflow/go-ethereum v1.14.8-0.20250321083631-c17e334a7940 h1:FgsV6iscE6rkuDXSM8X65OJdnu3A+oOev399iJEKb0M=
+github.com/onflow/go-ethereum v1.14.8-0.20250321083631-c17e334a7940/go.mod h1:UUZh+WQQU9wbVYX8F5sId/Zl9ZHW0Mj6inVomcsmXOo=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0 h1:sxyWLqGm/p4EKT6DUlQESDG1ZNMN9GjPCm1gTq7NGfc=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0/go.mod h1:kMeq9zUwCrgrSojEbTUTTJpZ4WwacVm2pA7LVFr+glk=
 github.com/onflow/sdks v0.6.0-preview.1 h1:mb/cUezuqWEP1gFZNAgUI4boBltudv4nlfxke1KBp9k=


### PR DESCRIPTION
Work towards: https://github.com/onflow/flow-go/issues/7152
Depends on: https://github.com/onflow/go-ethereum/pull/13

## Description

Updates to `flow-go` version using `go-ethereum@v1.14.13` .

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 