### PR TITLE
Update to `flow-go` with `go-ethereum@v1.15.1`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onflow/atree v0.9.0
 	github.com/onflow/cadence v1.3.3
-	github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250327094703-46ae92d4713b
+	github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250330092800-a43e5ece9c55
 	github.com/onflow/flow-go-sdk v1.3.3
-	github.com/onflow/go-ethereum v1.14.8-0.20250327092350-88fbc940c1b0
+	github.com/onflow/go-ethereum v1.14.8-0.20250327095627-0e03f79f9bfd
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rs/cors v1.8.0
 	github.com/rs/zerolog v1.33.0
@@ -177,7 +177,7 @@ require (
 	github.com/spf13/viper v1.15.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
-	github.com/supranational/blst v0.3.13 // indirect
+	github.com/supranational/blst v0.3.14 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -562,8 +562,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.1 h1:Ts5ob+CoCY2EjEd0W6vdLJ7hLL3
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1 h1:FDYKAiGowABtoMNusLuRCILIZDtVqJ/5tYI4VkF5zfM=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250327094703-46ae92d4713b h1:UN3ZT+/kB9QyknD7YgyqxNGwfU6Oc0AhYB4qnVvc6Is=
-github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250327094703-46ae92d4713b/go.mod h1:FXCPkwUyDmzmuylaO4c3wJ/4x1dora3geZMOiQ1YT0Q=
+github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250330092800-a43e5ece9c55 h1:oAuFqbBmxg5p/vOGTOIW8Ur4Mj3F00UIOxcilaM7d3M=
+github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250330092800-a43e5ece9c55/go.mod h1:/jh6QSva0hC88LPZbkMQ9iwcowqvdQDhnGS2JKM9nm4=
 github.com/onflow/flow-go-sdk v1.3.3 h1:wj7llql3wesQYBePh3lEFI+jk3Df1sa13bRsL139JDo=
 github.com/onflow/flow-go-sdk v1.3.3/go.mod h1:tSLvYIac9DlmUEqKHSHbVRyv4mSB0va4AuiV3XB9ENc=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.3 h1:4ju20g1xgDKWBT63rOj5f/Sa4Lc+naCSWT4p31x9yQk=
@@ -572,8 +572,8 @@ github.com/onflow/flow-nft/lib/go/templates v1.2.1 h1:SAALMZPDw9Eb9p5kSLnmnFxjyi
 github.com/onflow/flow-nft/lib/go/templates v1.2.1/go.mod h1:W6hOWU0xltPqNpv9gQX8Pj8Jtf0OmRxc1XX2V0kzJaI=
 github.com/onflow/flow/protobuf/go/flow v0.4.10 h1:CGEO3n96XZQd/k5HtkZyb90ouem9G+8fNcKyt8s2fvs=
 github.com/onflow/flow/protobuf/go/flow v0.4.10/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
-github.com/onflow/go-ethereum v1.14.8-0.20250327092350-88fbc940c1b0 h1:Hngy47NBUOfw+T339/w/WvnYD+VGtUaChpmwa9y15rA=
-github.com/onflow/go-ethereum v1.14.8-0.20250327092350-88fbc940c1b0/go.mod h1:fP5JeGyXJn1ClVNZpSBgq//PupeeguMrN38RvNvSD5g=
+github.com/onflow/go-ethereum v1.14.8-0.20250327095627-0e03f79f9bfd h1:LqOCGUPOScOOF5ZPHLTOYdMB7bqOcYyaakjnqcXAvxc=
+github.com/onflow/go-ethereum v1.14.8-0.20250327095627-0e03f79f9bfd/go.mod h1:C4h5VtFDrnrtWYPGTR1lcSbroTZ5KahCfQkssg/W6as=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0 h1:sxyWLqGm/p4EKT6DUlQESDG1ZNMN9GjPCm1gTq7NGfc=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0/go.mod h1:kMeq9zUwCrgrSojEbTUTTJpZ4WwacVm2pA7LVFr+glk=
 github.com/onflow/sdks v0.6.0-preview.1 h1:mb/cUezuqWEP1gFZNAgUI4boBltudv4nlfxke1KBp9k=
@@ -759,8 +759,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
-github.com/supranational/blst v0.3.13 h1:AYeSxdOMacwu7FBmpfloBz5pbFXDmJL33RuwnKtmTjk=
-github.com/supranational/blst v0.3.13/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/supranational/blst v0.3.14 h1:xNMoHRJOTwMn63ip6qoWJ2Ymgvj7E2b9jY2FAwY+qRo=
+github.com/supranational/blst v0.3.14/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c h1:HelZ2kAFadG0La9d+4htN4HzQ68Bm2iM9qKMSMES6xg=

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -362,9 +362,10 @@ func TestValidateTransaction(t *testing.T) {
 	}
 
 	head := &gethTypes.Header{
-		Number:   big.NewInt(20_182_324),
-		Time:     uint64(time.Now().Unix()),
-		GasLimit: 30_000_000,
+		Number:     big.NewInt(20_182_324),
+		Time:       uint64(time.Now().Unix()),
+		GasLimit:   30_000_000,
+		Difficulty: big.NewInt(0),
 	}
 	emulatorConfig := emulator.NewConfig(
 		emulator.WithChainID(types.FlowEVMPreviewNetChainID),
@@ -410,9 +411,10 @@ func TestValidateTransaction(t *testing.T) {
 func TestValidateConsensusRules(t *testing.T) {
 
 	head := &gethTypes.Header{
-		Number:   big.NewInt(20_182_324),
-		Time:     uint64(time.Now().Unix()),
-		GasLimit: 30_000_000,
+		Number:     big.NewInt(20_182_324),
+		Time:       uint64(time.Now().Unix()),
+		GasLimit:   30_000_000,
+		Difficulty: big.NewInt(0),
 	}
 	emulatorConfig := emulator.NewConfig(
 		emulator.WithChainID(types.FlowEVMPreviewNetChainID),

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -153,9 +153,10 @@ func NewEVM(
 	}
 
 	head := &types.Header{
-		Number:   big.NewInt(20_182_324),
-		Time:     uint64(time.Now().Unix()),
-		GasLimit: blockGasLimit,
+		Number:     big.NewInt(20_182_324),
+		Time:       uint64(time.Now().Unix()),
+		GasLimit:   blockGasLimit,
+		Difficulty: big.NewInt(0),
 	}
 	emulatorConfig := emulator.NewConfig(
 		emulator.WithChainID(config.EVMNetworkID),

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/onflow/crypto v0.25.2
 	github.com/onflow/flow-emulator v1.2.1-0.20250314161500-c55d0b34c1dc
 	github.com/onflow/flow-evm-gateway v0.0.0-20240201154855-4d4d3d3f19c7
-	github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250327094703-46ae92d4713b
+	github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250330092800-a43e5ece9c55
 	github.com/onflow/flow-go-sdk v1.3.3
-	github.com/onflow/go-ethereum v1.14.8-0.20250327092350-88fbc940c1b0
+	github.com/onflow/go-ethereum v1.14.8-0.20250327095627-0e03f79f9bfd
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.10.0
 )
@@ -195,7 +195,7 @@ require (
 	github.com/spf13/viper v1.15.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
-	github.com/supranational/blst v0.3.13 // indirect
+	github.com/supranational/blst v0.3.14 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -798,8 +798,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.1 h1:Ts5ob+CoCY2EjEd0W6vdLJ7hLL3
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1 h1:FDYKAiGowABtoMNusLuRCILIZDtVqJ/5tYI4VkF5zfM=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250327094703-46ae92d4713b h1:UN3ZT+/kB9QyknD7YgyqxNGwfU6Oc0AhYB4qnVvc6Is=
-github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250327094703-46ae92d4713b/go.mod h1:FXCPkwUyDmzmuylaO4c3wJ/4x1dora3geZMOiQ1YT0Q=
+github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250330092800-a43e5ece9c55 h1:oAuFqbBmxg5p/vOGTOIW8Ur4Mj3F00UIOxcilaM7d3M=
+github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250330092800-a43e5ece9c55/go.mod h1:/jh6QSva0hC88LPZbkMQ9iwcowqvdQDhnGS2JKM9nm4=
 github.com/onflow/flow-go-sdk v1.3.3 h1:wj7llql3wesQYBePh3lEFI+jk3Df1sa13bRsL139JDo=
 github.com/onflow/flow-go-sdk v1.3.3/go.mod h1:tSLvYIac9DlmUEqKHSHbVRyv4mSB0va4AuiV3XB9ENc=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.3 h1:4ju20g1xgDKWBT63rOj5f/Sa4Lc+naCSWT4p31x9yQk=
@@ -808,8 +808,8 @@ github.com/onflow/flow-nft/lib/go/templates v1.2.1 h1:SAALMZPDw9Eb9p5kSLnmnFxjyi
 github.com/onflow/flow-nft/lib/go/templates v1.2.1/go.mod h1:W6hOWU0xltPqNpv9gQX8Pj8Jtf0OmRxc1XX2V0kzJaI=
 github.com/onflow/flow/protobuf/go/flow v0.4.10 h1:CGEO3n96XZQd/k5HtkZyb90ouem9G+8fNcKyt8s2fvs=
 github.com/onflow/flow/protobuf/go/flow v0.4.10/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
-github.com/onflow/go-ethereum v1.14.8-0.20250327092350-88fbc940c1b0 h1:Hngy47NBUOfw+T339/w/WvnYD+VGtUaChpmwa9y15rA=
-github.com/onflow/go-ethereum v1.14.8-0.20250327092350-88fbc940c1b0/go.mod h1:fP5JeGyXJn1ClVNZpSBgq//PupeeguMrN38RvNvSD5g=
+github.com/onflow/go-ethereum v1.14.8-0.20250327095627-0e03f79f9bfd h1:LqOCGUPOScOOF5ZPHLTOYdMB7bqOcYyaakjnqcXAvxc=
+github.com/onflow/go-ethereum v1.14.8-0.20250327095627-0e03f79f9bfd/go.mod h1:C4h5VtFDrnrtWYPGTR1lcSbroTZ5KahCfQkssg/W6as=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0 h1:sxyWLqGm/p4EKT6DUlQESDG1ZNMN9GjPCm1gTq7NGfc=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0/go.mod h1:kMeq9zUwCrgrSojEbTUTTJpZ4WwacVm2pA7LVFr+glk=
 github.com/onflow/sdks v0.6.0-preview.1 h1:mb/cUezuqWEP1gFZNAgUI4boBltudv4nlfxke1KBp9k=
@@ -1058,8 +1058,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
-github.com/supranational/blst v0.3.13 h1:AYeSxdOMacwu7FBmpfloBz5pbFXDmJL33RuwnKtmTjk=
-github.com/supranational/blst v0.3.13/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/supranational/blst v0.3.14 h1:xNMoHRJOTwMn63ip6qoWJ2Ymgvj7E2b9jY2FAwY+qRo=
+github.com/supranational/blst v0.3.14/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c h1:HelZ2kAFadG0La9d+4htN4HzQ68Bm2iM9qKMSMES6xg=


### PR DESCRIPTION
Work towards: https://github.com/onflow/flow-go/issues/7152
Depends on: https://github.com/onflow/go-ethereum/pull/15

## Description

Updates to `flow-go` version using `go-ethereum@v1.15.1` .

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 