### PR TITLE
Update to `flow-go` with `go-ethereum@v1.15.2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onflow/atree v0.9.0
 	github.com/onflow/cadence v1.3.3
-	github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250330092800-a43e5ece9c55
+	github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250331070246-0a1b938b4f05
 	github.com/onflow/flow-go-sdk v1.3.3
-	github.com/onflow/go-ethereum v1.14.8-0.20250327095627-0e03f79f9bfd
+	github.com/onflow/go-ethereum v1.14.8-0.20250327095906-66cfed12c882
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rs/cors v1.8.0
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -562,8 +562,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.1 h1:Ts5ob+CoCY2EjEd0W6vdLJ7hLL3
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1 h1:FDYKAiGowABtoMNusLuRCILIZDtVqJ/5tYI4VkF5zfM=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250330092800-a43e5ece9c55 h1:oAuFqbBmxg5p/vOGTOIW8Ur4Mj3F00UIOxcilaM7d3M=
-github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250330092800-a43e5ece9c55/go.mod h1:/jh6QSva0hC88LPZbkMQ9iwcowqvdQDhnGS2JKM9nm4=
+github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250331070246-0a1b938b4f05 h1:+9OBTMkZM1PhI1CuHrWOx/C0FfC3zob8+MBPGVfI564=
+github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250331070246-0a1b938b4f05/go.mod h1:ChWk04tbIgVSS8zEbXD+hOluHzP1QTtf9L2YTk+JmH0=
 github.com/onflow/flow-go-sdk v1.3.3 h1:wj7llql3wesQYBePh3lEFI+jk3Df1sa13bRsL139JDo=
 github.com/onflow/flow-go-sdk v1.3.3/go.mod h1:tSLvYIac9DlmUEqKHSHbVRyv4mSB0va4AuiV3XB9ENc=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.3 h1:4ju20g1xgDKWBT63rOj5f/Sa4Lc+naCSWT4p31x9yQk=
@@ -572,8 +572,8 @@ github.com/onflow/flow-nft/lib/go/templates v1.2.1 h1:SAALMZPDw9Eb9p5kSLnmnFxjyi
 github.com/onflow/flow-nft/lib/go/templates v1.2.1/go.mod h1:W6hOWU0xltPqNpv9gQX8Pj8Jtf0OmRxc1XX2V0kzJaI=
 github.com/onflow/flow/protobuf/go/flow v0.4.10 h1:CGEO3n96XZQd/k5HtkZyb90ouem9G+8fNcKyt8s2fvs=
 github.com/onflow/flow/protobuf/go/flow v0.4.10/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
-github.com/onflow/go-ethereum v1.14.8-0.20250327095627-0e03f79f9bfd h1:LqOCGUPOScOOF5ZPHLTOYdMB7bqOcYyaakjnqcXAvxc=
-github.com/onflow/go-ethereum v1.14.8-0.20250327095627-0e03f79f9bfd/go.mod h1:C4h5VtFDrnrtWYPGTR1lcSbroTZ5KahCfQkssg/W6as=
+github.com/onflow/go-ethereum v1.14.8-0.20250327095906-66cfed12c882 h1:BChGl9LW2qEQMqo0/7hyHXKZn/7055zyKSgNKKzdyX4=
+github.com/onflow/go-ethereum v1.14.8-0.20250327095906-66cfed12c882/go.mod h1:C4h5VtFDrnrtWYPGTR1lcSbroTZ5KahCfQkssg/W6as=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0 h1:sxyWLqGm/p4EKT6DUlQESDG1ZNMN9GjPCm1gTq7NGfc=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0/go.mod h1:kMeq9zUwCrgrSojEbTUTTJpZ4WwacVm2pA7LVFr+glk=
 github.com/onflow/sdks v0.6.0-preview.1 h1:mb/cUezuqWEP1gFZNAgUI4boBltudv4nlfxke1KBp9k=

--- a/models/receipt.go
+++ b/models/receipt.go
@@ -35,6 +35,26 @@ type Receipt struct {
 	PrecompiledCalls  []byte
 }
 
+func (r *Receipt) ToGethReceipt() *gethTypes.Receipt {
+	return &gethTypes.Receipt{
+		Type:              r.Type,
+		PostState:         r.PostState,
+		Status:            r.Status,
+		CumulativeGasUsed: r.CumulativeGasUsed,
+		Bloom:             r.Bloom,
+		Logs:              r.Logs,
+		TxHash:            r.TxHash,
+		ContractAddress:   r.ContractAddress,
+		GasUsed:           r.GasUsed,
+		EffectiveGasPrice: r.EffectiveGasPrice,
+		BlobGasUsed:       r.BlobGasUsed,
+		BlobGasPrice:      r.BlobGasPrice,
+		BlockHash:         r.BlockHash,
+		BlockNumber:       r.BlockNumber,
+		TransactionIndex:  r.TransactionIndex,
+	}
+}
+
 func NewReceipt(
 	receipt *gethTypes.Receipt,
 	revertReason []byte,

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -207,7 +207,7 @@ func decodeTransactionEvent(event cadence.Event) (
 		gethReceipt.Status = gethTypes.ReceiptStatusFailed
 	}
 
-	gethReceipt.Bloom = gethTypes.CreateBloom([]*gethTypes.Receipt{gethReceipt})
+	gethReceipt.Bloom = gethTypes.CreateBloom(gethReceipt)
 
 	var revertReason []byte
 	if txEvent.ErrorCode == uint16(types.ExecutionErrCodeExecutionReverted) {

--- a/services/logs/filter_test.go
+++ b/services/logs/filter_test.go
@@ -113,7 +113,7 @@ func blockStorage() storage.BlockIndexer {
 func receiptStorage() storage.ReceiptIndexer {
 	for _, r := range receipts { // calculate bloom filters
 		rcp := toGethReceipt(r)
-		r.Bloom = gethTypes.CreateBloom(gethTypes.Receipts{rcp})
+		r.Bloom = gethTypes.CreateBloom(rcp)
 	}
 
 	receiptStorage := &mocks.ReceiptIndexer{}

--- a/tests/e2e_web3js_test.go
+++ b/tests/e2e_web3js_test.go
@@ -195,8 +195,8 @@ func TestWeb3_E2E(t *testing.T) {
 			payloads[0] = deployPayload
 			contractAddress := common.HexToAddress("99a64c993965f8d69f985b5171bc20065cc32fab")
 			// contract call transactions, these emit logs/events
-			for i := 1; i <= 5; i++ {
-				callData := storageContract.MakeCallData(t, "sum", big.NewInt(10), big.NewInt(20))
+			for i := int64(1); i <= 5; i++ {
+				callData := storageContract.MakeCallData(t, "sum", big.NewInt(i*10), big.NewInt(i*20))
 				callPayload, _, err := evmSign(big.NewInt(0), 55_000, accountKey, nonce, &contractAddress, callData)
 				require.NoError(t, err)
 				payloads[i] = callPayload

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/onflow/crypto v0.25.2
 	github.com/onflow/flow-emulator v1.2.1-0.20250314161500-c55d0b34c1dc
 	github.com/onflow/flow-evm-gateway v0.0.0-20240201154855-4d4d3d3f19c7
-	github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250330092800-a43e5ece9c55
+	github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250331070246-0a1b938b4f05
 	github.com/onflow/flow-go-sdk v1.3.3
-	github.com/onflow/go-ethereum v1.14.8-0.20250327095627-0e03f79f9bfd
+	github.com/onflow/go-ethereum v1.14.8-0.20250327095906-66cfed12c882
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.10.0
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -798,8 +798,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.1 h1:Ts5ob+CoCY2EjEd0W6vdLJ7hLL3
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1 h1:FDYKAiGowABtoMNusLuRCILIZDtVqJ/5tYI4VkF5zfM=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250330092800-a43e5ece9c55 h1:oAuFqbBmxg5p/vOGTOIW8Ur4Mj3F00UIOxcilaM7d3M=
-github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250330092800-a43e5ece9c55/go.mod h1:/jh6QSva0hC88LPZbkMQ9iwcowqvdQDhnGS2JKM9nm4=
+github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250331070246-0a1b938b4f05 h1:+9OBTMkZM1PhI1CuHrWOx/C0FfC3zob8+MBPGVfI564=
+github.com/onflow/flow-go v0.39.3-unsafe-cdp.0.0.20250331070246-0a1b938b4f05/go.mod h1:ChWk04tbIgVSS8zEbXD+hOluHzP1QTtf9L2YTk+JmH0=
 github.com/onflow/flow-go-sdk v1.3.3 h1:wj7llql3wesQYBePh3lEFI+jk3Df1sa13bRsL139JDo=
 github.com/onflow/flow-go-sdk v1.3.3/go.mod h1:tSLvYIac9DlmUEqKHSHbVRyv4mSB0va4AuiV3XB9ENc=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.3 h1:4ju20g1xgDKWBT63rOj5f/Sa4Lc+naCSWT4p31x9yQk=
@@ -808,8 +808,8 @@ github.com/onflow/flow-nft/lib/go/templates v1.2.1 h1:SAALMZPDw9Eb9p5kSLnmnFxjyi
 github.com/onflow/flow-nft/lib/go/templates v1.2.1/go.mod h1:W6hOWU0xltPqNpv9gQX8Pj8Jtf0OmRxc1XX2V0kzJaI=
 github.com/onflow/flow/protobuf/go/flow v0.4.10 h1:CGEO3n96XZQd/k5HtkZyb90ouem9G+8fNcKyt8s2fvs=
 github.com/onflow/flow/protobuf/go/flow v0.4.10/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
-github.com/onflow/go-ethereum v1.14.8-0.20250327095627-0e03f79f9bfd h1:LqOCGUPOScOOF5ZPHLTOYdMB7bqOcYyaakjnqcXAvxc=
-github.com/onflow/go-ethereum v1.14.8-0.20250327095627-0e03f79f9bfd/go.mod h1:C4h5VtFDrnrtWYPGTR1lcSbroTZ5KahCfQkssg/W6as=
+github.com/onflow/go-ethereum v1.14.8-0.20250327095906-66cfed12c882 h1:BChGl9LW2qEQMqo0/7hyHXKZn/7055zyKSgNKKzdyX4=
+github.com/onflow/go-ethereum v1.14.8-0.20250327095906-66cfed12c882/go.mod h1:C4h5VtFDrnrtWYPGTR1lcSbroTZ5KahCfQkssg/W6as=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0 h1:sxyWLqGm/p4EKT6DUlQESDG1ZNMN9GjPCm1gTq7NGfc=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0/go.mod h1:kMeq9zUwCrgrSojEbTUTTJpZ4WwacVm2pA7LVFr+glk=
 github.com/onflow/sdks v0.6.0-preview.1 h1:mb/cUezuqWEP1gFZNAgUI4boBltudv4nlfxke1KBp9k=

--- a/tests/web3js/eth_batch_tx_logs_test.js
+++ b/tests/web3js/eth_batch_tx_logs_test.js
@@ -12,6 +12,7 @@ it('should retrieve batch transactions with logs', async () => {
     assert.lengthOf(block.transactions, batchSize)
 
     let blockLogs = []
+    let logsBlooms = []
 
     for (let i = 0; i < block.transactions.length; i++) {
         let tx = await web3.eth.getTransactionFromBlock(latestHeight, i)
@@ -41,6 +42,20 @@ it('should retrieve batch transactions with logs', async () => {
 
             blockLogs.push(log)
         }
+        logsBlooms.push(receipt.logsBloom)
+    }
+
+    let expectedBlockLogsBloom = '0x00000000008000000000004000040000000000000000000000000000000000000002000000000800080000000420000000012200040000000020000000080000000000000000008000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010001000000000010000000000010000000080000000000000000400000000000000000000000000000100000020000000000000000000000000000002000000000000000000000000800000000000000000000000000020000000000000000028000800000000000000000000080000400000000000000000000000008000000000000000'
+    assert.equal(
+        block.logsBloom,
+        expectedBlockLogsBloom
+    )
+
+    for (const logsBloom of logsBlooms) {
+        assert.notEqual(
+            logsBloom,
+            expectedBlockLogsBloom
+        )
     }
 
     let logs = await web3.eth.getPastLogs({


### PR DESCRIPTION
Work towards: https://github.com/onflow/flow-go/issues/7152
Depends on: https://github.com/onflow/go-ethereum/pull/16

## Description

Updates to `flow-go` version using `go-ethereum@v1.15.2` .

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 