### PR TITLE
Update eth_syncing to return false for currentBlock >= highestBlock

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -149,7 +149,7 @@ func (b *BlockChainAPI) Syncing(ctx context.Context) (interface{}, error) {
 		return handleError[any](err, b.logger, b.collector)
 	}
 
-	if currentBlock == highestBlock {
+	if currentBlock >= highestBlock {
 		return false, nil
 	}
 


### PR DESCRIPTION
Closes: #???

## Description

Currently, the `eth_syncing` returns false (not syncing) only when the latest indexed block is the same as the latest EVM block on the Access node in the latest _sealed_ block. This means that if the node is using soft-finality data, it will always appear to be syncing.

This PR updates the check to only return a syncing status if the latest indexed block is less than the latest sealed EVM block.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the syncing status logic to more accurately reflect when the node is fully synced. The node is now considered synced when it has reached or surpassed the highest known block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->