### PR TITLE
Fix panic in debug_traceBlockByNumber when tracer is not set

### DIFF
--- a/api/debug.go
+++ b/api/debug.go
@@ -25,8 +25,8 @@ import (
 	"github.com/onflow/flow-evm-gateway/services/requester"
 	"github.com/onflow/flow-evm-gateway/storage"
 	"github.com/onflow/flow-evm-gateway/storage/pebble"
-	flowEVM "github.com/onflow/flow-go/fvm/evm"
 
+	flowEVM "github.com/onflow/flow-go/fvm/evm"
 	offchain "github.com/onflow/flow-go/fvm/evm/offchain/storage"
 
 	// this import is needed for side-effects, because the
@@ -472,7 +472,7 @@ func isDefaultCallTracer(config *tracers.TraceConfig) bool {
 		return false
 	}
 
-	if *config.Tracer != replayer.TracerName {
+	if config.Tracer == nil || *config.Tracer != replayer.TracerName {
 		return false
 	}
 


### PR DESCRIPTION
Closes: #???

## Description

Fixes panic in `debug_traceBlockByNumber` when the tracer name is not set.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by adding a safety check to prevent potential errors when a tracer is not set in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->