### PR TITLE
Add some E2E tests for `debug_*` endpoints with unset tracer

### DIFF
--- a/api/debug.go
+++ b/api/debug.go
@@ -38,7 +38,7 @@ import (
 // txTraceResult is the result of a single transaction trace.
 type txTraceResult struct {
 	TxHash gethCommon.Hash `json:"txHash"`           // transaction hash
-	Result interface{}     `json:"result,omitempty"` // Trace results produced by the tracer
+	Result any             `json:"result,omitempty"` // Trace results produced by the tracer
 	Error  string          `json:"error,omitempty"`  // Trace failure produced by the tracer
 }
 
@@ -130,7 +130,7 @@ func (d *DebugAPI) TraceCall(
 	args ethTypes.TransactionArgs,
 	blockNrOrHash rpc.BlockNumberOrHash,
 	config *tracers.TraceCallConfig,
-) (interface{}, error) {
+) (any, error) {
 	if err := d.rateLimiter.Apply(ctx, "TraceCall"); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description



______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded debug tracing tests to include scenarios with the tracer option set to null, adding detailed assertions for trace results on transactions, blocks, and calls.
- **Style**
  - Updated internal type usage for improved code modernity, with no impact on user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->