### PR TITLE
Add flag to disable enforcing the minimum gas price

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ The application can be configured using the following flags at runtime:
 | `coinbase`                     | `""`             | Coinbase address to use for fee collection                                                 |
 | `init-cadence-height`          | `0`              | Cadence block height to start indexing; avoid using on a new network                       |
 | `gas-price`                    | `1`              | Static gas price for EVM transactions                                                      |
+| `enforce-gas-price`            | `true`           | Enable enforcing minimum gas price for EVM transactions. When true (default), transactions must specify a gas price greater than or equal to the configured gas price. |
 | `coa-address`                  | `""`             | Flow address holding COA account for submitting transactions                               |
 | `coa-key`                      | `""`             | Private key for the COA address used for transactions                                      |
 | `coa-key-file`                 | `""`             | Path to a JSON file of COA keys for key-rotation (exclusive with `coa-key` flag)           |

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -247,7 +247,6 @@ var (
 	cloudKMSKeyRingID,
 	walletKey,
 	txStateValidation string
-
 	initHeight,
 	forceStartHeight uint64
 
@@ -267,6 +266,7 @@ func init() {
 	Cmd.Flags().StringVar(&coinbase, "coinbase", "", "Coinbase address to use for fee collection")
 	Cmd.Flags().Uint64Var(&initHeight, "init-cadence-height", 0, "Define the Cadence block height at which to start the indexing, if starting on a new network this flag should not be used.")
 	Cmd.Flags().StringVar(&gas, "gas-price", "1", "Static gas price used for EVM transactions")
+	Cmd.Flags().BoolVar(&cfg.EnforceGasPrice, "enforce-gas-price", true, "Enable enforcing minimum gas price for EVM transactions. When true (default), transactions must specify a gas price greater than or equal to the configured gas price.")
 	Cmd.Flags().StringVar(&coa, "coa-address", "", "Flow address that holds COA account used for submitting transactions")
 	Cmd.Flags().StringVar(&key, "coa-key", "", "Private key value for the COA address used for submitting transactions")
 	Cmd.Flags().StringVar(&keyAlg, "coa-key-alg", "ECDSA_P256", "Private key algorithm for the COA private key, only effective if coa-key/coa-key-file is present. Available values (ECDSA_P256 / ECDSA_secp256k1 / BLS_BLS12_381), defaults to ECDSA_P256.")

--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,8 @@ type Config struct {
 	COACloudKMSKey *flowGoKMS.Key
 	// GasPrice is a fixed gas price that will be used when submitting transactions.
 	GasPrice *big.Int
+	// EnforceGasPrice defines whether the minimum gas price should be enforced.
+	EnforceGasPrice bool
 	// InitCadenceHeight is used for initializing the database on a local emulator or a live network.
 	InitCadenceHeight uint64
 	// LogLevel defines how verbose the output log is

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -230,7 +230,7 @@ func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash,
 		}
 	}
 
-	if tx.GasPrice().Cmp(e.config.GasPrice) < 0 {
+	if tx.GasPrice().Cmp(e.config.GasPrice) < 0 && e.config.EnforceGasPrice {
 		return common.Hash{}, errs.NewTxGasPriceTooLowError(e.config.GasPrice)
 	}
 

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -165,6 +165,7 @@ func servicesSetup(t *testing.T) (emulator.Emulator, func()) {
 		COAAddress:        *coaAddress,
 		COAKey:            privateKey,
 		GasPrice:          new(big.Int).SetUint64(150),
+		EnforceGasPrice:   true,
 		LogLevel:          zerolog.DebugLevel,
 		LogWriter:         testLogWriter(),
 		RateLimit:         500,

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -71,6 +71,7 @@ func Test_ConcurrentTransactionSubmissionWithTxSeal(t *testing.T) {
 		COAAddress:        *createdAddr,
 		COAKey:            privateKey,
 		GasPrice:          new(big.Int).SetUint64(0),
+		EnforceGasPrice:   true,
 		LogLevel:          zerolog.DebugLevel,
 		LogWriter:         testLogWriter(),
 		TxStateValidation: config.TxSealValidation,
@@ -181,6 +182,7 @@ func Test_ConcurrentTransactionSubmissionWithLocalIndex(t *testing.T) {
 		COAAddress:        *createdAddr,
 		COAKey:            privateKey,
 		GasPrice:          new(big.Int).SetUint64(0),
+		EnforceGasPrice:   true,
 		LogLevel:          zerolog.DebugLevel,
 		LogWriter:         testLogWriter(),
 		TxStateValidation: config.LocalIndexValidation,
@@ -275,18 +277,19 @@ func Test_EthClientTest(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := config.Config{
-		DatabaseDir:    t.TempDir(),
-		AccessNodeHost: grpcHost,
-		RPCPort:        8545,
-		RPCHost:        "127.0.0.1",
-		FlowNetworkID:  "flow-emulator",
-		EVMNetworkID:   types.FlowEVMPreviewNetChainID,
-		Coinbase:       eoaTestAccount,
-		COAAddress:     *createdAddr,
-		COAKey:         privateKey,
-		GasPrice:       new(big.Int).SetUint64(150),
-		LogLevel:       zerolog.DebugLevel,
-		LogWriter:      testLogWriter(),
+		DatabaseDir:     t.TempDir(),
+		AccessNodeHost:  grpcHost,
+		RPCPort:         8545,
+		RPCHost:         "127.0.0.1",
+		FlowNetworkID:   "flow-emulator",
+		EVMNetworkID:    types.FlowEVMPreviewNetChainID,
+		Coinbase:        eoaTestAccount,
+		COAAddress:      *createdAddr,
+		COAKey:          privateKey,
+		GasPrice:        new(big.Int).SetUint64(150),
+		EnforceGasPrice: true,
+		LogLevel:        zerolog.DebugLevel,
+		LogWriter:       testLogWriter(),
 	}
 
 	ready := make(chan struct{})
@@ -371,18 +374,19 @@ func Test_CloudKMSConcurrentTransactionSubmission(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := config.Config{
-		DatabaseDir:    t.TempDir(),
-		AccessNodeHost: grpcHost,
-		RPCPort:        8545,
-		RPCHost:        "127.0.0.1",
-		FlowNetworkID:  "flow-emulator",
-		EVMNetworkID:   types.FlowEVMPreviewNetChainID,
-		Coinbase:       eoaTestAccount,
-		COAAddress:     *createdAddr,
-		COACloudKMSKey: &kmsKey,
-		GasPrice:       new(big.Int).SetUint64(0),
-		LogLevel:       zerolog.DebugLevel,
-		LogWriter:      testLogWriter(),
+		DatabaseDir:     t.TempDir(),
+		AccessNodeHost:  grpcHost,
+		RPCPort:         8545,
+		RPCHost:         "127.0.0.1",
+		FlowNetworkID:   "flow-emulator",
+		EVMNetworkID:    types.FlowEVMPreviewNetChainID,
+		Coinbase:        eoaTestAccount,
+		COAAddress:      *createdAddr,
+		COACloudKMSKey:  &kmsKey,
+		GasPrice:        new(big.Int).SetUint64(0),
+		EnforceGasPrice: true,
+		LogLevel:        zerolog.DebugLevel,
+		LogWriter:       testLogWriter(),
 	}
 
 	// todo change this test to use ingestion and emulator directly so we can completely remove
@@ -486,6 +490,7 @@ func Test_ForceStartHeightIdempotency(t *testing.T) {
 		COAAddress:        *createdAddr,
 		COAKey:            privateKey,
 		GasPrice:          new(big.Int).SetUint64(0),
+		EnforceGasPrice:   true,
 		LogLevel:          zerolog.DebugLevel,
 		LogWriter:         testLogWriter(),
 		TxStateValidation: config.LocalIndexValidation,


### PR DESCRIPTION
Backports: https://github.com/onflow/flow-evm-gateway/pull/810

Backports PR to add `enforce-gas-price` flag to PoC branch