### PR TITLE
Increase `WriteTimeout` for JSON-RPC API server

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -60,6 +60,9 @@ const (
 	shutdownTimeout      = 5 * time.Second
 	batchRequestLimit    = 50
 	batchResponseMaxSize = 10 * 1000 * 1000 // 10 MB
+	// setting this to 10 minutes, so it can handle lengthy
+	// requests for `debug_trace*` JSON-RPC endpoints
+	writeTimeout = 10 * time.Minute
 )
 
 func NewServer(
@@ -187,7 +190,7 @@ func (h *Server) Start() error {
 		CheckTimeouts(h.logger, &h.timeouts)
 		h.server.ReadTimeout = h.timeouts.ReadTimeout
 		h.server.ReadHeaderTimeout = h.timeouts.ReadHeaderTimeout
-		h.server.WriteTimeout = h.timeouts.WriteTimeout
+		h.server.WriteTimeout = writeTimeout
 		h.server.IdleTimeout = h.timeouts.IdleTimeout
 	}
 


### PR DESCRIPTION
## Description

Given that certain endpoints, such as `debug_trace*` can take more than `30` seconds to produce a response, we need to update the `WriteTimeout` appropriately.
Example:
```bash
curl -v -v -v -X POST 'https://docs-demo.flow-mainnet.quiknode.pro/' --header  'Content-Type: application/json' --data '{ "jsonrpc" : "2.0", "method" : "debug_traceBlockByNumber", "params" : [ "0x17713D2", { "timeout" : "10m", "tracer" : "callTracer", "tracerConfig" : { "onlyTopCall" : false, "withLog" : true } } ], "id" : 1 }'
```

The above `debug_traceBlockByNumber` JSON-RPC call, is sent with `"timeout" : "10m"`, so it was doomed to fail, due to the default `30` second `WriteTimeout`.

We update it to `10` minutes, so it can handle such requests.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased server write timeout to 10 minutes to better support lengthy requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->