### PR TITLE
Create `ValidationOptions` for each tx submission

### DIFF
--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -184,7 +184,15 @@ func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash,
 	}
 
 	head := &types.Header{
-		Number:     big.NewInt(20_182_324),
+		// `Number` is only useful to detect hard-forks which were
+		// activated with block numbers. However, Ethereum now
+		// activates hard-forks with timestamps, so the `Number`
+		// field is not really necessary. Anyway, we set it to
+		// the latest finalized block on Ethereum mainnet.
+		Number: big.NewInt(22_446_370),
+		// The `Time` field is what's actually used for detecting
+		// whether we're in a certain hard-fork, and what kind of
+		// tx validations to run.
 		Time:       uint64(time.Now().Unix()),
 		GasLimit:   blockGasLimit,
 		Difficulty: big.NewInt(0),


### PR DESCRIPTION
## Description

Previously this Header time was only created during startup, so it never got updated. This makes the EVM GW think that we're not yet in Pectra:
```bash
curl -XPOST 'https://testnet.evm.nodes.onflow.org' --header 'Content-Type: application/json' --data-raw '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0x04f8c982022101800183016b1e94fe847d8bebe46799fce83eb52f38ef4b907996a680848129fc1cc0f85ef85c82022194313af46a48eeb56d200fae0edb741628255d379f0101a0f354c695f1a6fe9bc7655aa220bbc51a6c000a4221efb5d2e848f85918353524a0693de7bd731004910396bc7753ad13e11b90a350fb84128fda6d6439584836d880a0bdade120008921fd57b6d6999e983c84e0a8efdfb3bb282c80886b05e8b1fc3ea074c4362fd383323f7efc166ebe1ebc869c8909d97f8a8d6414b03a020a60d92b"],"id":2}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 2,
  "error": {
    "code": -32000,
    "message": "transaction type not supported: type 4 rejected, pool not yet in Prague"
  }
}
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Improved transaction processing reliability by using a fresh context for each transaction submission, reducing reliance on stored state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->