### PR TITLE
Allow resetting sealing verification height

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -608,15 +608,10 @@ func setupStorage(
 			return nil, nil, fmt.Errorf("failed to set latest cadence height: %w", err)
 		}
 
-		verifiedHeight, err := eventsHash.ProcessedSealedHeight()
-		if err != nil && !errors.Is(err, errs.ErrStorageNotInitialized) {
-			return nil, nil, fmt.Errorf("failed to get latest verified sealed height: %w", err)
+		if err := eventsHash.SetProcessedSealedHeight(config.ForceStartCadenceHeight); err != nil {
+			return nil, nil, fmt.Errorf("failed to set latest verified sealed height: %w", err)
 		}
-		if verifiedHeight > config.ForceStartCadenceHeight {
-			if err := eventsHash.SetProcessedSealedHeight(config.ForceStartCadenceHeight); err != nil {
-				return nil, nil, fmt.Errorf("failed to set latest verified sealed height: %w", err)
-			}
-		}
+		logger.Fatal().Msgf("SetProcessedSealedHeight to %v", config.ForceStartCadenceHeight)
 	}
 
 	// if database is not initialized require init height


### PR DESCRIPTION
Closes: #???

## Description

This PR updates the bootstrapping logic to allow an operator to force set the sealing verifier's last height value. After setting the value, the node will crash. The operator must remove the flag and change the version to continue

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 