### PR TITLE
Return authorization list for `SetCodeTx` type

### DIFF
--- a/eth/types/types.go
+++ b/eth/types/types.go
@@ -274,28 +274,29 @@ type StorageResult struct {
 
 // Transaction represents a transaction that will serialize to the RPC representation of a transaction
 type Transaction struct {
-	BlockHash           *common.Hash             `json:"blockHash"`
-	BlockNumber         *hexutil.Big             `json:"blockNumber"`
-	From                common.MixedcaseAddress  `json:"from"`
-	Gas                 hexutil.Uint64           `json:"gas"`
-	GasPrice            *hexutil.Big             `json:"gasPrice"`
-	GasFeeCap           *hexutil.Big             `json:"maxFeePerGas,omitempty"`
-	GasTipCap           *hexutil.Big             `json:"maxPriorityFeePerGas,omitempty"`
-	MaxFeePerBlobGas    *hexutil.Big             `json:"maxFeePerBlobGas,omitempty"`
-	Hash                common.Hash              `json:"hash"`
-	Input               hexutil.Bytes            `json:"input"`
-	Nonce               hexutil.Uint64           `json:"nonce"`
-	To                  *common.MixedcaseAddress `json:"to"`
-	TransactionIndex    *hexutil.Uint64          `json:"transactionIndex"`
-	Value               *hexutil.Big             `json:"value"`
-	Type                hexutil.Uint64           `json:"type"`
-	Accesses            *types.AccessList        `json:"accessList,omitempty"`
-	ChainID             *hexutil.Big             `json:"chainId,omitempty"`
-	BlobVersionedHashes []common.Hash            `json:"blobVersionedHashes,omitempty"`
-	V                   *hexutil.Big             `json:"v"`
-	R                   *hexutil.Big             `json:"r"`
-	S                   *hexutil.Big             `json:"s"`
-	YParity             *hexutil.Uint64          `json:"yParity,omitempty"`
+	BlockHash           *common.Hash                 `json:"blockHash"`
+	BlockNumber         *hexutil.Big                 `json:"blockNumber"`
+	From                common.MixedcaseAddress      `json:"from"`
+	Gas                 hexutil.Uint64               `json:"gas"`
+	GasPrice            *hexutil.Big                 `json:"gasPrice"`
+	GasFeeCap           *hexutil.Big                 `json:"maxFeePerGas,omitempty"`
+	GasTipCap           *hexutil.Big                 `json:"maxPriorityFeePerGas,omitempty"`
+	MaxFeePerBlobGas    *hexutil.Big                 `json:"maxFeePerBlobGas,omitempty"`
+	Hash                common.Hash                  `json:"hash"`
+	Input               hexutil.Bytes                `json:"input"`
+	Nonce               hexutil.Uint64               `json:"nonce"`
+	To                  *common.MixedcaseAddress     `json:"to"`
+	TransactionIndex    *hexutil.Uint64              `json:"transactionIndex"`
+	Value               *hexutil.Big                 `json:"value"`
+	Type                hexutil.Uint64               `json:"type"`
+	Accesses            *types.AccessList            `json:"accessList,omitempty"`
+	ChainID             *hexutil.Big                 `json:"chainId,omitempty"`
+	BlobVersionedHashes []common.Hash                `json:"blobVersionedHashes,omitempty"`
+	AuthorizationList   []types.SetCodeAuthorization `json:"authorizationList,omitempty"`
+	V                   *hexutil.Big                 `json:"v"`
+	R                   *hexutil.Big                 `json:"r"`
+	S                   *hexutil.Big                 `json:"s"`
+	YParity             *hexutil.Uint64              `json:"yParity,omitempty"`
 
 	size uint64
 }
@@ -379,6 +380,10 @@ func NewTransaction(
 	if tx.Type() > types.DynamicFeeTxType {
 		result.MaxFeePerBlobGas = (*hexutil.Big)(tx.BlobGasFeeCap())
 		result.BlobVersionedHashes = tx.BlobHashes()
+	}
+
+	if tx.Type() > types.BlobTxType {
+		result.AuthorizationList = tx.SetCodeAuthorizations()
 	}
 
 	return result, nil

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -49,6 +49,7 @@ type Transaction interface {
 	BlobHashes() []common.Hash
 	Size() uint64
 	AccessList() gethTypes.AccessList
+	SetCodeAuthorizations() []gethTypes.SetCodeAuthorization
 	MarshalBinary() ([]byte, error)
 }
 
@@ -138,6 +139,10 @@ func (dc DirectCall) Size() uint64 {
 
 func (dc DirectCall) AccessList() gethTypes.AccessList {
 	return gethTypes.AccessList{}
+}
+
+func (dc DirectCall) SetCodeAuthorizations() []gethTypes.SetCodeAuthorization {
+	return []gethTypes.SetCodeAuthorization{}
 }
 
 func (dc DirectCall) MarshalBinary() ([]byte, error) {

--- a/tests/web3js/eth_eip_7702_contract_write_test.js
+++ b/tests/web3js/eth_eip_7702_contract_write_test.js
@@ -54,11 +54,31 @@ it('should perform contract writes with relay account', async () => {
     })
 
     await new Promise((res) => setTimeout(() => res(), 1500))
-    let transaction = await publicClient.getTransactionReceipt({
+
+    let transaction = await publicClient.getTransaction({ hash: hash })
+    assert.equal(transaction.from, relay.address)
+    assert.equal(transaction.type, 'eip7702')
+    assert.equal(transaction.input, '0x8129fc1c')
+    assert.deepEqual(
+        transaction.authorizationList,
+        [
+            {
+                address: '0x313af46a48eeb56d200fae0edb741628255d379f',
+                chainId: 646,
+                nonce: 1,
+                r: '0xa79ca044cfc5754e1fcd7e0007755dc1a98894f40a2a60436fd007fe3e0298d1',
+                s: '0x2897829f726104b4175474d2100d6b11d7a26498debb1917d24fae324e91275c',
+                yParity: 0
+            }
+        ]
+    )
+
+    let txReceipt = await publicClient.getTransactionReceipt({
         hash: hash
     })
-    assert.equal(transaction.status, 'success')
-    assert.equal(transaction.type, 'eip7702')
+    assert.equal(txReceipt.from, relay.address)
+    assert.equal(txReceipt.status, 'success')
+    assert.equal(txReceipt.type, 'eip7702')
 
     hash = await walletClient.writeContract({
         abi,
@@ -67,11 +87,18 @@ it('should perform contract writes with relay account', async () => {
     })
 
     await new Promise((res) => setTimeout(() => res(), 1500))
-    transaction = await publicClient.getTransactionReceipt({
+
+    transaction = await publicClient.getTransaction({ hash: hash })
+    assert.equal(transaction.from, relay.address)
+    assert.equal(transaction.type, 'eip1559')
+    assert.equal(transaction.input, '0x5c36b186')
+
+    txReceipt = await publicClient.getTransactionReceipt({
         hash: hash
     })
-    assert.equal(transaction.status, 'success')
-    assert.equal(transaction.type, 'eip1559')
+    assert.equal(txReceipt.from, relay.address)
+    assert.equal(txReceipt.status, 'success')
+    assert.equal(txReceipt.type, 'eip1559')
 })
 
 it('should perform contract writes with self-execution', async () => {
@@ -90,11 +117,31 @@ it('should perform contract writes with self-execution', async () => {
     })
 
     await new Promise((res) => setTimeout(() => res(), 1500))
-    transaction = await publicClient.getTransactionReceipt({
+
+    let transaction = await publicClient.getTransaction({ hash: hash })
+    assert.equal(transaction.from, relay.address)
+    assert.equal(transaction.type, 'eip7702')
+    assert.equal(transaction.input, '0x8129fc1c')
+    assert.deepEqual(
+        transaction.authorizationList,
+        [
+            {
+                address: '0x313af46a48eeb56d200fae0edb741628255d379f',
+                chainId: 646,
+                nonce: 4,
+                r: '0xf4bc19cca28390f3628cfcda9076a8744b77cc87fa4f7745efa83b7a06cc3514',
+                s: '0x1d736fecc68ee92ab6fd805d91a3e3dbf27097d3578561402d7105eeeee00bb7',
+                yParity: 0
+            }
+        ]
+    )
+
+    let txReceipt = await publicClient.getTransactionReceipt({
         hash: hash
     })
-    assert.equal(transaction.status, 'success')
-    assert.equal(transaction.type, 'eip7702')
+    assert.equal(txReceipt.from, relay.address)
+    assert.equal(txReceipt.status, 'success')
+    assert.equal(txReceipt.type, 'eip7702')
 
     hash = await walletClient.writeContract({
         abi,
@@ -103,9 +150,11 @@ it('should perform contract writes with self-execution', async () => {
     })
 
     await new Promise((res) => setTimeout(() => res(), 1500))
-    transaction = await publicClient.getTransactionReceipt({
+
+    txReceipt = await publicClient.getTransactionReceipt({
         hash: hash
     })
-    assert.equal(transaction.status, 'success')
-    assert.equal(transaction.type, 'eip1559')
+    assert.equal(txReceipt.from, relay.address)
+    assert.equal(txReceipt.status, 'success')
+    assert.equal(txReceipt.type, 'eip1559')
 })

--- a/tests/web3js/eth_eip_7702_sending_transactions_test.js
+++ b/tests/web3js/eth_eip_7702_sending_transactions_test.js
@@ -57,11 +57,31 @@ it('should send transactions with relay account', async () => {
     })
 
     await new Promise((res) => setTimeout(() => res(), 1500))
-    let transaction = await publicClient.getTransactionReceipt({
+
+    let transaction = await publicClient.getTransaction({ hash: hash })
+    assert.equal(transaction.from, relay.address)
+    assert.equal(transaction.type, 'eip7702')
+    assert.equal(transaction.input, '0x8129fc1c')
+    assert.deepEqual(
+        transaction.authorizationList,
+        [
+            {
+                address: '0x313af46a48eeb56d200fae0edb741628255d379f',
+                chainId: 646,
+                nonce: 1,
+                r: '0xa79ca044cfc5754e1fcd7e0007755dc1a98894f40a2a60436fd007fe3e0298d1',
+                s: '0x2897829f726104b4175474d2100d6b11d7a26498debb1917d24fae324e91275c',
+                yParity: 0
+            }
+        ]
+    )
+
+    let txReceipt = await publicClient.getTransactionReceipt({
         hash: hash
     })
-    assert.equal(transaction.status, 'success')
-    assert.equal(transaction.type, 'eip7702')
+    assert.equal(txReceipt.from, relay.address)
+    assert.equal(txReceipt.status, 'success')
+    assert.equal(txReceipt.type, 'eip7702')
 
     hash = await walletClient.sendTransaction({
         data: encodeFunctionData({
@@ -72,11 +92,13 @@ it('should send transactions with relay account', async () => {
     })
 
     await new Promise((res) => setTimeout(() => res(), 1500))
-    transaction = await publicClient.getTransactionReceipt({
+
+    txReceipt = await publicClient.getTransactionReceipt({
         hash: hash
     })
-    assert.equal(transaction.status, 'success')
-    assert.equal(transaction.type, 'eip1559')
+    assert.equal(txReceipt.from, relay.address)
+    assert.equal(txReceipt.status, 'success')
+    assert.equal(txReceipt.type, 'eip1559')
 })
 
 it('should send self-executing transactions', async () => {
@@ -97,11 +119,31 @@ it('should send self-executing transactions', async () => {
     })
 
     await new Promise((res) => setTimeout(() => res(), 1500))
-    let transaction = await publicClient.getTransactionReceipt({
+
+    let transaction = await publicClient.getTransaction({ hash: hash })
+    assert.equal(transaction.from, relay.address)
+    assert.equal(transaction.type, 'eip7702')
+    assert.equal(transaction.input, '0x8129fc1c')
+    assert.deepEqual(
+        transaction.authorizationList,
+        [
+            {
+                address: '0x313af46a48eeb56d200fae0edb741628255d379f',
+                chainId: 646,
+                nonce: 4,
+                r: '0xf4bc19cca28390f3628cfcda9076a8744b77cc87fa4f7745efa83b7a06cc3514',
+                s: '0x1d736fecc68ee92ab6fd805d91a3e3dbf27097d3578561402d7105eeeee00bb7',
+                yParity: 0
+            }
+        ]
+    )
+
+    let txReceipt = await publicClient.getTransactionReceipt({
         hash: hash
     })
-    assert.equal(transaction.status, 'success')
-    assert.equal(transaction.type, 'eip7702')
+    assert.equal(txReceipt.from, relay.address)
+    assert.equal(txReceipt.status, 'success')
+    assert.equal(txReceipt.type, 'eip7702')
 
     hash = await walletClient.sendTransaction({
         data: encodeFunctionData({
@@ -112,9 +154,11 @@ it('should send self-executing transactions', async () => {
     })
 
     await new Promise((res) => setTimeout(() => res(), 1500))
-    transaction = await publicClient.getTransactionReceipt({
+
+    txReceipt = await publicClient.getTransactionReceipt({
         hash: hash
     })
-    assert.equal(transaction.status, 'success')
-    assert.equal(transaction.type, 'eip1559')
+    assert.equal(txReceipt.from, relay.address)
+    assert.equal(txReceipt.status, 'success')
+    assert.equal(txReceipt.type, 'eip1559')
 })


### PR DESCRIPTION
## Description

As described in the specification: https://eip7702.io/#specification, the new `SetCodeTx` type, has an authorization list:
```bash
authorization_list = [[chain_id, address, nonce, y_parity, r, s], ...]
```

Example:
```bash
{
    address: '0x313af46a48eeb56d200fae0edb741628255d379f',
    chainId: 646,
    nonce: 4,
    r: '0xf4bc19cca28390f3628cfcda9076a8744b77cc87fa4f7745efa83b7a06cc3514',
    s: '0x1d736fecc68ee92ab6fd805d91a3e3dbf27097d3578561402d7105eeeee00bb7',
    yParity: 0
}
```

We need to include this information in the result of `eth_getTransactionByHash` JSON-RPC endpoint.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Transactions now include an authorization list for enhanced detail and verification in supported transaction types.

- **Tests**
  - Enhanced transaction tests with detailed validation of transaction properties, including authorization lists and cryptographic signatures, before receipt verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->