### PR TITLE
Move RPC calls to constants to reduce string object allocations

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -116,7 +116,7 @@ func NewBlockChainAPI(
 
 // BlockNumber returns the block number of the chain head.
 func (b *BlockChainAPI) BlockNumber(ctx context.Context) (hexutil.Uint64, error) {
-	if err := b.rateLimiter.Apply(ctx, "BlockNumber"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthBlockNumber); err != nil {
 		return 0, err
 	}
 
@@ -135,7 +135,7 @@ func (b *BlockChainAPI) BlockNumber(ctx context.Context) (hexutil.Uint64, error)
 // - currentBlock:  block number this node is currently importing
 // - highestBlock:  block number of the highest block header this node has received from peers
 func (b *BlockChainAPI) Syncing(ctx context.Context) (interface{}, error) {
-	if err := b.rateLimiter.Apply(ctx, "Syncing"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthSyncing); err != nil {
 		return nil, err
 	}
 
@@ -171,11 +171,11 @@ func (b *BlockChainAPI) SendRawTransaction(
 	}
 
 	l := b.logger.With().
-		Str("endpoint", "sendRawTransaction").
+		Str("endpoint", EthSendRawTransaction).
 		Str("input", input.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "SendRawTransaction"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthSendRawTransaction); err != nil {
 		return common.Hash{}, err
 	}
 
@@ -196,11 +196,11 @@ func (b *BlockChainAPI) GetBalance(
 	blockNumberOrHash rpc.BlockNumberOrHash,
 ) (*hexutil.Big, error) {
 	l := b.logger.With().
-		Str("endpoint", "getBalance").
+		Str("endpoint", EthGetBalance).
 		Str("address", address.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetBalance"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetBalance); err != nil {
 		return nil, err
 	}
 
@@ -223,11 +223,11 @@ func (b *BlockChainAPI) GetTransactionByHash(
 	hash common.Hash,
 ) (*ethTypes.Transaction, error) {
 	l := b.logger.With().
-		Str("endpoint", "getTransactionByHash").
+		Str("endpoint", EthGetTransactionByHash).
 		Str("hash", hash.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetTransactionByHash"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetTransactionByHash); err != nil {
 		return nil, err
 	}
 
@@ -251,12 +251,12 @@ func (b *BlockChainAPI) GetTransactionByBlockHashAndIndex(
 	index hexutil.Uint,
 ) (*ethTypes.Transaction, error) {
 	l := b.logger.With().
-		Str("endpoint", "getTransactionByBlockHashAndIndex").
+		Str("endpoint", EthGetTransactionByBlockHashAndIndex).
 		Str("hash", blockHash.String()).
 		Str("index", index.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetTransactionByBlockHashAndIndex"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetTransactionByBlockHashAndIndex); err != nil {
 		return nil, err
 	}
 
@@ -286,12 +286,12 @@ func (b *BlockChainAPI) GetTransactionByBlockNumberAndIndex(
 	index hexutil.Uint,
 ) (*ethTypes.Transaction, error) {
 	l := b.logger.With().
-		Str("endpoint", "getTransactionByBlockNumberAndIndex").
+		Str("endpoint", EthGetTransactionByBlockNumberAndIndex).
 		Str("number", blockNumber.String()).
 		Str("index", index.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetTransactionByBlockNumberAndIndex"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetTransactionByBlockNumberAndIndex); err != nil {
 		return nil, err
 	}
 
@@ -324,11 +324,11 @@ func (b *BlockChainAPI) GetTransactionReceipt(
 	hash common.Hash,
 ) (map[string]interface{}, error) {
 	l := b.logger.With().
-		Str("endpoint", "getTransactionReceipt").
+		Str("endpoint", EthGetTransactionReceipt).
 		Str("hash", hash.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetTransactionReceipt"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetTransactionReceipt); err != nil {
 		return nil, err
 	}
 
@@ -358,11 +358,11 @@ func (b *BlockChainAPI) GetBlockByHash(
 	fullTx bool,
 ) (*ethTypes.Block, error) {
 	l := b.logger.With().
-		Str("endpoint", "getBlockByHash").
+		Str("endpoint", EthGetBlockByHash).
 		Str("hash", hash.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetBlockByHash"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetBlockByHash); err != nil {
 		return nil, err
 	}
 
@@ -393,11 +393,11 @@ func (b *BlockChainAPI) GetBlockByNumber(
 	fullTx bool,
 ) (*ethTypes.Block, error) {
 	l := b.logger.With().
-		Str("endpoint", "getBlockByNumber").
+		Str("endpoint", EthGetBlockByNumber).
 		Str("blockNumber", blockNumber.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetBlockByNumber"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetBlockByNumber); err != nil {
 		return nil, err
 	}
 
@@ -426,11 +426,11 @@ func (b *BlockChainAPI) GetBlockReceipts(
 	blockNumberOrHash rpc.BlockNumberOrHash,
 ) ([]map[string]any, error) {
 	l := b.logger.With().
-		Str("endpoint", "getBlockReceipts").
+		Str("endpoint", EthGetBlockReceipts).
 		Str("hash", blockNumberOrHash.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetBlockReceipts"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetBlockReceipts); err != nil {
 		return nil, err
 	}
 
@@ -472,11 +472,11 @@ func (b *BlockChainAPI) GetBlockTransactionCountByHash(
 	blockHash common.Hash,
 ) (*hexutil.Uint, error) {
 	l := b.logger.With().
-		Str("endpoint", "getBlockTransactionCountByHash").
+		Str("endpoint", EthGetBlockTransactionCountByHash).
 		Str("hash", blockHash.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetBlockTransactionCountByHash"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetBlockTransactionCountByHash); err != nil {
 		return nil, err
 	}
 
@@ -496,11 +496,11 @@ func (b *BlockChainAPI) GetBlockTransactionCountByNumber(
 	blockNumber rpc.BlockNumber,
 ) (*hexutil.Uint, error) {
 	l := b.logger.With().
-		Str("endpoint", "getBlockTransactionCountByNumber").
+		Str("endpoint", EthGetBlockTransactionCountByNumber).
 		Str("number", blockNumber.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetBlockTransactionCountByNumber"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetBlockTransactionCountByNumber); err != nil {
 		return nil, err
 	}
 
@@ -530,11 +530,11 @@ func (b *BlockChainAPI) Call(
 	blockOverrides *ethTypes.BlockOverrides,
 ) (hexutil.Bytes, error) {
 	l := b.logger.With().
-		Str("endpoint", "call").
+		Str("endpoint", EthCall).
 		Str("args", fmt.Sprintf("%v", args)).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "Call"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthCall); err != nil {
 		return nil, err
 	}
 
@@ -573,11 +573,11 @@ func (b *BlockChainAPI) GetLogs(
 	criteria filters.FilterCriteria,
 ) ([]*types.Log, error) {
 	l := b.logger.With().
-		Str("endpoint", "getLogs").
+		Str("endpoint", EthGetLogs).
 		Str("criteria", fmt.Sprintf("%v", criteria)).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetLogs"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetLogs); err != nil {
 		return nil, err
 	}
 
@@ -667,11 +667,11 @@ func (b *BlockChainAPI) GetTransactionCount(
 	blockNumberOrHash rpc.BlockNumberOrHash,
 ) (*hexutil.Uint64, error) {
 	l := b.logger.With().
-		Str("endpoint", "getTransactionCount").
+		Str("endpoint", EthGetTransactionCount).
 		Str("address", address.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetTransactionCount"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetTransactionCount); err != nil {
 		return nil, err
 	}
 
@@ -700,11 +700,11 @@ func (b *BlockChainAPI) EstimateGas(
 	stateOverrides *ethTypes.StateOverride,
 ) (hexutil.Uint64, error) {
 	l := b.logger.With().
-		Str("endpoint", "estimateGas").
+		Str("endpoint", EthEstimateGas).
 		Str("args", fmt.Sprintf("%v", args)).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "EstimateGas"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthEstimateGas); err != nil {
 		return 0, err
 	}
 
@@ -744,11 +744,11 @@ func (b *BlockChainAPI) GetCode(
 	blockNumberOrHash rpc.BlockNumberOrHash,
 ) (hexutil.Bytes, error) {
 	l := b.logger.With().
-		Str("endpoint", "getCode").
+		Str("endpoint", EthGetCode).
 		Str("address", address.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetCode"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetCode); err != nil {
 		return nil, err
 	}
 
@@ -781,7 +781,7 @@ func (b *BlockChainAPI) FeeHistory(
 	rewardPercentiles []float64,
 ) (*ethTypes.FeeHistoryResult, error) {
 	l := b.logger.With().
-		Str("endpoint", "feeHistory").
+		Str("endpoint", EthFeeHistory).
 		Str("block", lastBlock.String()).
 		Logger()
 
@@ -855,11 +855,11 @@ func (b *BlockChainAPI) GetStorageAt(
 	blockNumberOrHash rpc.BlockNumberOrHash,
 ) (hexutil.Bytes, error) {
 	l := b.logger.With().
-		Str("endpoint", "getStorageAt").
+		Str("endpoint", EthGetStorageAt).
 		Str("address", address.String()).
 		Logger()
 
-	if err := b.rateLimiter.Apply(ctx, "GetStorageAt"); err != nil {
+	if err := b.rateLimiter.Apply(ctx, EthGetStorageAt); err != nil {
 		return nil, err
 	}
 

--- a/api/api.go
+++ b/api/api.go
@@ -785,6 +785,10 @@ func (b *BlockChainAPI) FeeHistory(
 		Str("block", lastBlock.String()).
 		Logger()
 
+	if err := b.rateLimiter.Apply(ctx, EthFeeHistory); err != nil {
+		return nil, err
+	}
+
 	if blockCount > maxFeeHistoryBlockCount {
 		return handleError[*ethTypes.FeeHistoryResult](
 			fmt.Errorf("block count has to be between 1 and %d, got: %d", maxFeeHistoryBlockCount, blockCount),

--- a/api/debug.go
+++ b/api/debug.go
@@ -90,7 +90,7 @@ func (d *DebugAPI) TraceTransaction(
 	hash gethCommon.Hash,
 	config *tracers.TraceConfig,
 ) (json.RawMessage, error) {
-	if err := d.rateLimiter.Apply(ctx, "TraceTransaction"); err != nil {
+	if err := d.rateLimiter.Apply(ctx, DebugTraceTransaction); err != nil {
 		return nil, err
 	}
 
@@ -102,7 +102,7 @@ func (d *DebugAPI) TraceBlockByNumber(
 	number rpc.BlockNumber,
 	config *tracers.TraceConfig,
 ) ([]*txTraceResult, error) {
-	if err := d.rateLimiter.Apply(ctx, "TraceBlockByNumber"); err != nil {
+	if err := d.rateLimiter.Apply(ctx, DebugTraceBlockByNumber); err != nil {
 		return nil, err
 	}
 
@@ -119,7 +119,7 @@ func (d *DebugAPI) TraceBlockByHash(
 	hash gethCommon.Hash,
 	config *tracers.TraceConfig,
 ) ([]*txTraceResult, error) {
-	if err := d.rateLimiter.Apply(ctx, "TraceBlockByHash"); err != nil {
+	if err := d.rateLimiter.Apply(ctx, DebugTraceBlockByHash); err != nil {
 		return nil, err
 	}
 
@@ -137,7 +137,7 @@ func (d *DebugAPI) TraceCall(
 	blockNrOrHash rpc.BlockNumberOrHash,
 	config *tracers.TraceCallConfig,
 ) (any, error) {
-	if err := d.rateLimiter.Apply(ctx, "TraceCall"); err != nil {
+	if err := d.rateLimiter.Apply(ctx, DebugTraceCall); err != nil {
 		return nil, err
 	}
 
@@ -257,7 +257,7 @@ func (d *DebugAPI) FlowHeightByBlock(
 	ctx context.Context,
 	blockNrOrHash rpc.BlockNumberOrHash,
 ) (uint64, error) {
-	if err := d.rateLimiter.Apply(ctx, "FlowHeightByBlock"); err != nil {
+	if err := d.rateLimiter.Apply(ctx, DebugFlowHeightByBlock); err != nil {
 		return 0, err
 	}
 

--- a/api/pull.go
+++ b/api/pull.go
@@ -169,7 +169,7 @@ func (api *PullAPI) NewPendingTransactionFilter(
 	ctx context.Context,
 	fullTx *bool,
 ) (rpc.ID, error) {
-	if err := api.rateLimiter.Apply(ctx, "NewPendingTransactionFilter"); err != nil {
+	if err := api.rateLimiter.Apply(ctx, EthNewPendingTransactionFilter); err != nil {
 		return "", err
 	}
 
@@ -197,7 +197,7 @@ func (api *PullAPI) NewPendingTransactionFilter(
 // NewBlockFilter creates a filter that fetches blocks that are imported into the chain.
 // It is part of the filter package since polling goes with eth_getFilterChanges.
 func (api *PullAPI) NewBlockFilter(ctx context.Context) (rpc.ID, error) {
-	if err := api.rateLimiter.Apply(ctx, "NewBlockFilter"); err != nil {
+	if err := api.rateLimiter.Apply(ctx, EthNewBlockFilter); err != nil {
 		return "", err
 	}
 
@@ -246,7 +246,7 @@ func (api *PullAPI) uninstallFilter(id rpc.ID) bool {
 //
 // In case "fromBlock" > "toBlock" an error is returned.
 func (api *PullAPI) NewFilter(ctx context.Context, criteria filters.FilterCriteria) (rpc.ID, error) {
-	if err := api.rateLimiter.Apply(ctx, "NewFilter"); err != nil {
+	if err := api.rateLimiter.Apply(ctx, EthNewFilter); err != nil {
 		return "", err
 	}
 
@@ -290,7 +290,7 @@ func (api *PullAPI) GetFilterLogs(
 	ctx context.Context,
 	id rpc.ID,
 ) ([]*gethTypes.Log, error) {
-	if err := api.rateLimiter.Apply(ctx, "GetFilterLogs"); err != nil {
+	if err := api.rateLimiter.Apply(ctx, EthGetFilterLogs); err != nil {
 		return nil, err
 	}
 
@@ -340,7 +340,7 @@ func (api *PullAPI) GetFilterLogs(
 // For pending transaction and block filters the result is []common.Hash.
 // (pending)Log filters return []Log.
 func (api *PullAPI) GetFilterChanges(ctx context.Context, id rpc.ID) (any, error) {
-	if err := api.rateLimiter.Apply(ctx, "GetFilterChanges"); err != nil {
+	if err := api.rateLimiter.Apply(ctx, EthGetFilterChanges); err != nil {
 		return nil, err
 	}
 

--- a/api/rpc_calls.go
+++ b/api/rpc_calls.go
@@ -1,0 +1,37 @@
+package api
+
+const (
+	// JSON-RPC calls under the `eth_` namespace
+	EthBlockNumber                         = "BlockNumber"
+	EthSyncing                             = "Syncing"
+	EthSendRawTransaction                  = "SendRawTransaction"
+	EthGetBalance                          = "GetBalance"
+	EthGetTransactionByHash                = "GetTransactionByHash"
+	EthGetTransactionByBlockHashAndIndex   = "GetTransactionByBlockHashAndIndex"
+	EthGetTransactionByBlockNumberAndIndex = "GetTransactionByBlockNumberAndIndex"
+	EthGetTransactionReceipt               = "GetTransactionReceipt"
+	EthGetBlockByHash                      = "GetBlockByHash"
+	EthGetBlockByNumber                    = "GetBlockByNumber"
+	EthGetBlockReceipts                    = "GetBlockReceipts"
+	EthGetBlockTransactionCountByHash      = "GetBlockTransactionCountByHash"
+	EthGetBlockTransactionCountByNumber    = "GetBlockTransactionCountByNumber"
+	EthCall                                = "Call"
+	EthGetLogs                             = "GetLogs"
+	EthGetTransactionCount                 = "GetTransactionCount"
+	EthEstimateGas                         = "EstimateGas"
+	EthGetCode                             = "GetCode"
+	EthGetStorageAt                        = "GetStorageAt"
+	EthNewPendingTransactionFilter         = "NewPendingTransactionFilter"
+	EthNewBlockFilter                      = "NewBlockFilter"
+	EthNewFilter                           = "NewFilter"
+	EthGetFilterLogs                       = "GetFilterLogs"
+	EthGetFilterChanges                    = "GetFilterChanges"
+	EthFeeHistory                          = "FeeHistory"
+
+	// JSON-RPC calls under the `debug_` namespace
+	DebugTraceTransaction   = "TraceTransaction"
+	DebugTraceBlockByNumber = "TraceBlockByNumber"
+	DebugTraceBlockByHash   = "TraceBlockByHash"
+	DebugTraceCall          = "TraceCall"
+	DebugFlowHeightByBlock  = "FlowHeightByBlock"
+)


### PR DESCRIPTION
## Description

The RPC calls are known and unlikely to change, so we should use constants for them.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved internal consistency by standardizing the use of predefined constants for Ethereum and debug RPC method names across the application. This change does not affect user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->