### PR TITLE
Ignore nonce mismatch errors on Cadence tx that runs EVM transactions

### DIFF
--- a/services/requester/cadence/run.cdc
+++ b/services/requester/cadence/run.cdc
@@ -6,6 +6,22 @@ transaction(hexEncodedTx: String, coinbase: String) {
             tx: hexEncodedTx.decodeHex(),
             coinbase: EVM.addressFromString(coinbase)
         )
+
+        // It is quite common for EVM transactions to be invalid due to nonce
+        // mismatch (nonce too high / nonce too low). This is a user error,
+        // as it is the sender's responsibility to sign the transaction with
+        // the correct nonce.
+        // We check if the error code is related to nonce mismatch, and simply
+        // return early, before aborting the Cadence transaction.
+        // This will reduce the error noise on the internal panels/metrics about
+        // failed transaction rate etc.
+        //
+        // errorCode for "nonce too low" is 201
+        // errorCode for "nonce too high" is 202
+        if txResult.errorCode == 201 || txResult.errorCode == 202 {
+            return
+        }
+
         assert(
             txResult.status == EVM.Status.failed || txResult.status == EVM.Status.successful,
             message: "evm_error=".concat(txResult.errorMessage).concat("\n")


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/827

## Description

Currently, the Cadence transaction that wraps `EVM.run` for executing EVM transactions, expects the transaction result status to be either `failed` or `successful`.

If that is not the case, it will fail the entire Cadence transaction (see: https://github.com/onflow/flow-evm-gateway/blob/main/services/requester/cadence/run.cdc#L9-L12).

However, it is quite common for EVM transactions to be invalid due to nonce mismatch (nonce too high / nonce too low). This is a user error, as it is the sender's responsibility to sign the transaction with the correct nonce.

Now we check if the error code is related to nonce mismatch, and simply return early, before aborting the Cadence transaction. This will reduce the error noise on the internal panels/metrics about failed transaction rate etc.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of EVM transactions by preventing failures and error noise when nonce mismatch errors occur, resulting in a smoother user experience and clearer error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->