### PR TITLE
Implement `BatchTxPool` to handle nonce mismatch issues

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -255,6 +255,7 @@ func (b *Bootstrap) StartAPIServer(ctx context.Context) error {
 			b.config,
 			b.collector,
 			b.keystore,
+			ctx,
 		)
 	} else {
 		txPool = requester.NewSingleTxPool(

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -249,13 +249,13 @@ func (b *Bootstrap) StartAPIServer(ctx context.Context) error {
 	var txPool requester.TxPool
 	if b.config.TxBatchMode {
 		txPool = requester.NewBatchTxPool(
+			ctx,
 			b.client,
 			b.publishers.Transaction,
 			b.logger,
 			b.config,
 			b.collector,
 			b.keystore,
-			ctx,
 		)
 	} else {
 		txPool = requester.NewSingleTxPool(

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -227,6 +227,10 @@ func parseConfigFromFlags() error {
 		return fmt.Errorf("tx-batch-interval must be > 0 when tx-batch-mode is enabled")
 	}
 
+	if cfg.TxBatchMode && cfg.TxStateValidation == config.TxSealValidation {
+		return fmt.Errorf("tx-batch-mode should be enabled with tx-state-validation=local-index")
+	}
+
 	return nil
 }
 

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -283,4 +283,6 @@ func init() {
 	Cmd.Flags().StringVar(&txStateValidation, "tx-state-validation", "tx-seal", "Sets the transaction validation mechanism. It can validate using the local state index, or wait for the outer Flow transaction to seal. Available values ('local-index' / 'tx-seal'), defaults to 'tx-seal'.")
 	Cmd.Flags().Uint64Var(&cfg.TxRequestLimit, "tx-request-limit", 0, "Number of transaction submissions to allow per the specified interval.")
 	Cmd.Flags().DurationVar(&cfg.TxRequestLimitDuration, "tx-request-limit-duration", time.Second*3, "Time interval upon which to enforce transaction submission rate limiting.")
+	Cmd.Flags().BoolVar(&cfg.TxBatchMode, "tx-batch-mode", false, "Enable batch transaction submission, to avoid nonce mismatch issues for high-volume EOAs.")
+	Cmd.Flags().DurationVar(&cfg.TxBatchInterval, "tx-batch-interval", time.Millisecond*1200, "Time interval upon which to submit the transaction batches to the Flow network.")
 }

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -223,6 +223,10 @@ func parseConfigFromFlags() error {
 		return fmt.Errorf("unknown tx state validation: %s", txStateValidation)
 	}
 
+	if cfg.TxBatchMode && cfg.TxBatchInterval <= 0 {
+		return fmt.Errorf("tx-batch-interval must be > 0 when tx-batch-mode is enabled")
+	}
+
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -96,4 +96,11 @@ type Config struct {
 	// TxRequestLimitDuration is the time interval upon which to enforce transaction submission
 	// rate limiting.
 	TxRequestLimitDuration time.Duration
+	// TxBatchMode configures the gateway to send transactions in batches grouped by EOA address,
+	// to avoid the re-ordering issue for EOAs with a high-volume of transaction submission
+	// in small intervals.
+	TxBatchMode bool
+	// TxBatchInterval is the time interval upon which to submit the transaction batches to the
+	// Flow network.
+	TxBatchInterval time.Duration
 }

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"regexp"
 	"sort"
 	"sync"
 	"time"
@@ -15,208 +14,13 @@ import (
 	gethCommon "github.com/onflow/go-ethereum/common"
 	gethTypes "github.com/onflow/go-ethereum/core/types"
 	"github.com/rs/zerolog"
-	"github.com/sethvargo/go-retry"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/onflow/flow-evm-gateway/config"
 	"github.com/onflow/flow-evm-gateway/metrics"
 	"github.com/onflow/flow-evm-gateway/models"
-	errs "github.com/onflow/flow-evm-gateway/models/errors"
 	"github.com/onflow/flow-evm-gateway/services/requester/keystore"
 )
-
-const (
-	evmErrorRegex = `evm_error=(.*)\n`
-)
-
-// TxPool is the minimum interface that needs to be implemented by
-// the various transaction pool strategies.
-type TxPool interface {
-	Add(ctx context.Context, tx *gethTypes.Transaction) error
-}
-
-// SingleTxPool is a simple implementation of the `TxPool` interface that submits
-// transactions as soon as they arrive, without any delays or batching strategies.
-type SingleTxPool struct {
-	logger      zerolog.Logger
-	client      *CrossSporkClient
-	pool        *sync.Map
-	txPublisher *models.Publisher[*gethTypes.Transaction]
-	config      config.Config
-	mux         sync.Mutex
-	keystore    *keystore.KeyStore
-	collector   metrics.Collector
-	// todo add methods to inspect transaction pool state
-}
-
-var _ TxPool = &SingleTxPool{}
-
-func NewSingleTxPool(
-	client *CrossSporkClient,
-	transactionsPublisher *models.Publisher[*gethTypes.Transaction],
-	logger zerolog.Logger,
-	config config.Config,
-	collector metrics.Collector,
-	keystore *keystore.KeyStore,
-) *SingleTxPool {
-	// initialize the available keys metric since it is only updated when sending a tx
-	collector.AvailableSigningKeys(keystore.AvailableKeys())
-
-	return &SingleTxPool{
-		logger:      logger.With().Str("component", "tx-pool").Logger(),
-		client:      client,
-		txPublisher: transactionsPublisher,
-		pool:        &sync.Map{},
-		config:      config,
-		collector:   collector,
-		keystore:    keystore,
-	}
-}
-
-// Add creates a Cadence transaction that wraps the given EVM transaction in
-// an `EVM.run` function call for execution.
-//
-// The Cadence transaction is submitted to the Flow network right away.
-//
-// If the transaction state validation is configured to run with the
-// "tx-seal" strategy, the Cadence transaction status is awaited and an error
-// is returned in case of a failure in submission or an EVM validation error.
-// Until the Cadence transaction is sealed the transaction will stay in the
-// pool and marked as pending.
-//
-// If the transaction state validation is configured to run with the
-// "local-index" strategy, the Cadence transaction status is not awaited,
-// as the necessary EVM validation checks, such as nonce/balance checks,
-// have been checked against the EVM state of the local index.
-func (t *SingleTxPool) Add(
-	ctx context.Context,
-	tx *gethTypes.Transaction,
-) error {
-	t.txPublisher.Publish(tx) // publish pending transaction event
-
-	txData, err := tx.MarshalBinary()
-	if err != nil {
-		return err
-	}
-	hexEncodedTx, err := cadence.NewString(hex.EncodeToString(txData))
-	if err != nil {
-		return err
-	}
-	coinbaseAddress, err := cadence.NewString(t.config.Coinbase.Hex())
-	if err != nil {
-		return err
-	}
-
-	script := replaceAddresses(runTxScript, t.config.FlowNetworkID)
-	flowTx, err := t.buildTransaction(ctx, script, hexEncodedTx, coinbaseAddress)
-	if err != nil {
-		return err
-	}
-
-	if err := t.client.SendTransaction(ctx, *flowTx); err != nil {
-		return err
-	}
-
-	if t.config.TxStateValidation == config.TxSealValidation {
-		// add to pool and delete after transaction is sealed or errored out
-		t.pool.Store(tx.Hash(), tx)
-		defer t.pool.Delete(tx.Hash())
-
-		backoff := retry.WithMaxDuration(time.Minute*1, retry.NewConstant(time.Second*1))
-		return retry.Do(ctx, backoff, func(ctx context.Context) error {
-			res, err := t.client.GetTransactionResult(ctx, flowTx.ID())
-			if err != nil {
-				return fmt.Errorf("failed to retrieve flow transaction result %s: %w", flowTx.ID(), err)
-			}
-			// retry until transaction is sealed
-			if res.Status < flow.TransactionStatusSealed {
-				return retry.RetryableError(fmt.Errorf("transaction %s not sealed", flowTx.ID()))
-			}
-
-			if res.Error != nil {
-				if err, ok := parseInvalidError(res.Error); ok {
-					return err
-				}
-
-				t.logger.Error().Err(res.Error).
-					Str("flow-id", flowTx.ID().String()).
-					Str("evm-id", tx.Hash().Hex()).
-					Msg("flow transaction error")
-
-				// hide specific cause since it's an implementation issue
-				return fmt.Errorf("failed to submit flow evm transaction %s", tx.Hash())
-			}
-
-			return nil
-		})
-	}
-
-	return nil
-}
-
-// buildTransaction creates a Cadence transaction from the provided script,
-// with the given arguments and signs it with the configured COA account.
-func (t *SingleTxPool) buildTransaction(
-	ctx context.Context,
-	script []byte,
-	args ...cadence.Value,
-) (*flow.Transaction, error) {
-	defer func() {
-		t.collector.AvailableSigningKeys(t.keystore.AvailableKeys())
-	}()
-
-	var (
-		g           = errgroup.Group{}
-		err1, err2  error
-		latestBlock *flow.Block
-		account     *flow.Account
-	)
-	// execute concurrently so we can speed up all the information we need for tx
-	g.Go(func() error {
-		latestBlock, err1 = t.client.GetLatestBlock(ctx, true)
-		return err1
-	})
-	g.Go(func() error {
-		account, err2 = t.client.GetAccount(ctx, t.config.COAAddress)
-		return err2
-	})
-	if err := g.Wait(); err != nil {
-		return nil, err
-	}
-
-	flowTx := flow.NewTransaction().
-		SetScript(script).
-		SetReferenceBlockID(latestBlock.ID).
-		SetComputeLimit(flowGo.DefaultMaxTransactionGasLimit)
-
-	for _, arg := range args {
-		if err := flowTx.AddArgument(arg); err != nil {
-			return nil, fmt.Errorf("failed to add argument: %s, with %w", arg, err)
-		}
-	}
-
-	// building and signing transactions should be blocking,
-	// so we don't have keys conflict
-	t.mux.Lock()
-	defer t.mux.Unlock()
-
-	accKey, err := t.keystore.Take()
-	if err != nil {
-		return nil, err
-	}
-
-	if err := accKey.SetProposerPayerAndSign(flowTx, account); err != nil {
-		accKey.Done()
-		return nil, err
-	}
-
-	// now that the transaction is prepared, store the transaction's metadata
-	accKey.SetLockMetadata(flowTx.ID(), latestBlock.Height)
-
-	t.collector.OperatorBalance(account)
-
-	return flowTx, nil
-}
 
 type pooledEvmTx struct {
 	txPayload cadence.String
@@ -463,18 +267,4 @@ func (t *BatchTxPool) fetchFlowLatestBlockAndCOA() (
 	}
 
 	return latestBlock, account, nil
-}
-
-// this will extract the evm specific error from the Flow transaction error message
-// the run.cdc script panics with the evm specific error as the message which we
-// extract and return to the client. Any error returned that is evm specific
-// is a validation error due to assert statement in the run.cdc script.
-func parseInvalidError(err error) (error, bool) {
-	r := regexp.MustCompile(evmErrorRegex)
-	matches := r.FindStringSubmatch(err.Error())
-	if len(matches) != 2 {
-		return nil, false
-	}
-
-	return errs.NewFailedTransactionError(matches[1]), true
 }

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -135,9 +135,13 @@ func (t *BatchTxPool) processPooledTransactions() {
 			snapshot := func() map[gethCommon.Address][]pooledEvmTx {
 				t.txMux.Lock()
 				defer t.txMux.Unlock()
-				copy := t.pooledTxs
+				poolCopy := make(map[gethCommon.Address][]pooledEvmTx)
+				for addr, txs := range t.pooledTxs {
+					poolCopy[addr] = make([]pooledEvmTx, len(txs))
+					copy(poolCopy[addr], txs)
+				}
 				t.pooledTxs = make(map[gethCommon.Address][]pooledEvmTx)
-				return copy
+				return poolCopy
 			}
 			// Take a snapshot here to allow `Add()` to continue accept
 			// incoming EVM transactions, without blocking until the

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -14,7 +14,6 @@ import (
 	gethCommon "github.com/onflow/go-ethereum/common"
 	gethTypes "github.com/onflow/go-ethereum/core/types"
 	"github.com/rs/zerolog"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/onflow/flow-evm-gateway/config"
 	"github.com/onflow/flow-evm-gateway/metrics"
@@ -242,32 +241,4 @@ func (t *BatchTxPool) buildTransaction(
 	t.collector.OperatorBalance(account)
 
 	return flowTx, nil
-}
-
-func (t *BatchTxPool) fetchFlowLatestBlockAndCOA(ctx context.Context) (
-	*flow.Block,
-	*flow.Account,
-	error,
-) {
-	var (
-		g           = errgroup.Group{}
-		err1, err2  error
-		latestBlock *flow.Block
-		account     *flow.Account
-	)
-
-	// execute concurrently so we can speed up all the information we need for tx
-	g.Go(func() error {
-		latestBlock, err1 = t.client.GetLatestBlock(ctx, true)
-		return err1
-	})
-	g.Go(func() error {
-		account, err2 = t.client.GetAccount(ctx, t.config.COAAddress)
-		return err2
-	})
-	if err := g.Wait(); err != nil {
-		return nil, nil, err
-	}
-
-	return latestBlock, account, nil
 }

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -132,16 +132,17 @@ func (t *BatchTxPool) processPooledTransactions() {
 				continue
 			}
 
-			// Take a snapshot here to allow `Add()` to continue accept
-			// incoming EVM transactions, without blocking until the
-			// batch transactions are submitted.
-			txsGroupedByAddress := func() map[gethCommon.Address][]pooledEvmTx {
+			snapshot := func() map[gethCommon.Address][]pooledEvmTx {
 				t.txMux.Lock()
 				defer t.txMux.Unlock()
 				copy := t.pooledTxs
 				t.pooledTxs = make(map[gethCommon.Address][]pooledEvmTx)
 				return copy
-			}()
+			}
+			// Take a snapshot here to allow `Add()` to continue accept
+			// incoming EVM transactions, without blocking until the
+			// batch transactions are submitted.
+			txsGroupedByAddress := snapshot()
 
 			for address, pooledTxs := range txsGroupedByAddress {
 				err := t.batchSubmitTransactionsForSameAddress(

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -35,7 +35,7 @@ type pooledEvmTx struct {
 //
 // The main advantage of this implementation over the `SingleTxPool`, is the
 // guarantee that transactions originated from the same EOA address, which
-// arrive in a short time interval (about the same as Flow's block productionrate),
+// arrive in a short time interval (about the same as Flow's block production rate),
 // will be executed in the same order their arrived.
 // This helps to reduce the nonce mismatch errors which mainly occur from the
 // re-ordering of Cadence transactions that happens from Collection nodes.
@@ -88,7 +88,7 @@ func (t *BatchTxPool) Add(
 ) error {
 	t.txPublisher.Publish(tx) // publish pending transaction event
 
-	// tx sending should be blocking, so we don't have races when
+	// tx adding should be blocking, so we don't have races when
 	// pooled transactions are being processed in the background.
 	t.txMux.Lock()
 	defer t.txMux.Unlock()
@@ -146,7 +146,7 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 				)
 				if err != nil {
 					t.logger.Error().Err(err).Msgf(
-						"failed to send Flow transaction from BatchPool for EOA: %s",
+						"failed to send Flow transaction from BatchTxPool for EOA: %s",
 						address.Hex(),
 					)
 					continue

--- a/services/requester/cadence/batch_run.cdc
+++ b/services/requester/cadence/batch_run.cdc
@@ -12,7 +12,7 @@ transaction(hexEncodedTxs: [String], coinbase: String) {
             coinbase: EVM.addressFromString(coinbase)
         )
 
-        // If at least one of the EVM transactions in the batch was either
+        // If at least one of the EVM transactions in the batch is either
         // failed or successful, in other words not invalid, we let the
         // Cadence transaction succeed.
         for txResult in txResults {
@@ -21,11 +21,13 @@ transaction(hexEncodedTxs: [String], coinbase: String) {
             }
         }
 
-        // Otherwise, all EVM transactions are invalid txs, can't be executed (such as nonce too low). In this case, 
-        // we fail the Cadence transaction with the error message from the first EVM transaction.
+        // Otherwise, all EVM transactions are invalid txs and can't be
+        // executed (such as nonce too low).
+        // In this case, we fail the Cadence transaction with the error
+        // message from the first EVM transaction.
         var invalidTx: EVM.Result? = nil
         for txResult in txResults {
-            if txResult.status == EVM.Status.unknown || txResult.status == EVM.Status.invalid {
+            if !(txResult.status == EVM.Status.failed || txResult.status == EVM.Status.successful) {
                 invalidTx = txResult
                 break
             }

--- a/services/requester/cadence/batch_run.cdc
+++ b/services/requester/cadence/batch_run.cdc
@@ -25,18 +25,10 @@ transaction(hexEncodedTxs: [String], coinbase: String) {
         // executed (such as nonce too low).
         // In this case, we fail the Cadence transaction with the error
         // message from the first EVM transaction.
-        var invalidTx: EVM.Result? = nil
         for txResult in txResults {
-            if !(txResult.status == EVM.Status.failed || txResult.status == EVM.Status.successful) {
-                invalidTx = txResult
-                break
-            }
-        }
-
-        if invalidTx != nil {
             assert(
-                false,
-                message: "evm_error=".concat(invalidTx?.errorMessage!).concat("\n")
+                txResult.status == EVM.Status.failed || txResult.status == EVM.Status.successful,
+                message: "evm_error=".concat(txResult.errorMessage).concat("\n")
             )
         }
     }

--- a/services/requester/cadence/batch_run.cdc
+++ b/services/requester/cadence/batch_run.cdc
@@ -21,8 +21,8 @@ transaction(hexEncodedTxs: [String], coinbase: String) {
             }
         }
 
-        // Otherwise, we fail the Cadence transaction with the error message
-        // from the first invalid EVM transaction.
+        // Otherwise, all EVM transactions are invalid txs, can't be executed (such as nonce too low). In this case, 
+        // we fail the Cadence transaction with the error message from the first EVM transaction.
         var invalidTx: EVM.Result? = nil
         for txResult in txResults {
             if txResult.status == EVM.Status.unknown || txResult.status == EVM.Status.invalid {

--- a/services/requester/pool.go
+++ b/services/requester/pool.go
@@ -333,7 +333,7 @@ func (t *BatchTxPool) processPooledTransactions() {
 	}
 }
 
-func (t *BatchTxPool) batchSubmitTransactions(
+func (t *BatchTxPool) batchSubmitTransactionsForSameAccount(
 	pooledTxs []pooledEvmTx,
 ) error {
 	// Sort the transactions based on their nonce, to make sure

--- a/services/requester/pool.go
+++ b/services/requester/pool.go
@@ -321,8 +321,11 @@ func (t *BatchTxPool) processPooledTransactions() {
 		}()
 
 		for address, pooledTxs := range snapshot {
-			if err := t.batchSubmitTransactions(address, pooledTxs); err != nil {
-				t.logger.Error().Err(err).Msg("failed to send Flow transaction from BatchPool")
+			if err := t.batchSubmitTransactions(pooledTxs); err != nil {
+				t.logger.Error().Err(err).Msgf(
+					"failed to send Flow transaction from BatchPool for EOA: %s",
+					address.Hex(),
+				)
 				continue
 			}
 		}
@@ -330,7 +333,6 @@ func (t *BatchTxPool) processPooledTransactions() {
 }
 
 func (t *BatchTxPool) batchSubmitTransactions(
-	address gethCommon.Address,
 	pooledTxs []pooledEvmTx,
 ) error {
 	// Sort the transactions based on their nonce, to make sure
@@ -364,7 +366,6 @@ func (t *BatchTxPool) batchSubmitTransactions(
 	if err := t.client.SendTransaction(ctx, *flowTx); err != nil {
 		return err
 	}
-	delete(t.pooledTxs, address)
 
 	return nil
 }

--- a/services/requester/pool.go
+++ b/services/requester/pool.go
@@ -2,64 +2,116 @@ package requester
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"regexp"
+	"sort"
 	"sync"
 	"time"
 
+	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
+	flowGo "github.com/onflow/flow-go/model/flow"
+	gethCommon "github.com/onflow/go-ethereum/common"
 	gethTypes "github.com/onflow/go-ethereum/core/types"
 	"github.com/rs/zerolog"
 	"github.com/sethvargo/go-retry"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/onflow/flow-evm-gateway/config"
+	"github.com/onflow/flow-evm-gateway/metrics"
 	"github.com/onflow/flow-evm-gateway/models"
 	errs "github.com/onflow/flow-evm-gateway/models/errors"
+	"github.com/onflow/flow-evm-gateway/services/requester/keystore"
 )
 
 const (
 	evmErrorRegex = `evm_error=(.*)\n`
 )
 
-// todo this is a simple implementation of the transaction pool that is mostly used
-// to track the status of submitted transaction, but transactions will always be submitted
-// right away, future improvements can make it so the transactions are collected in the pool
-// and after submitted based on different strategies.
+// TxPool is the minimum interface that needs to be implemented by
+// the various transaction pool strategies.
+type TxPool interface {
+	Add(ctx context.Context, tx *gethTypes.Transaction) error
+}
 
-type TxPool struct {
+// SingleTxPool is a simple implementation of the `TxPool` interface that submits
+// transactions as soon as they arrive, without any delays or batching strategies.
+type SingleTxPool struct {
 	logger      zerolog.Logger
 	client      *CrossSporkClient
 	pool        *sync.Map
 	txPublisher *models.Publisher[*gethTypes.Transaction]
 	config      config.Config
+	mux         sync.Mutex
+	keystore    *keystore.KeyStore
+	collector   metrics.Collector
 	// todo add methods to inspect transaction pool state
 }
 
-func NewTxPool(
+var _ TxPool = &SingleTxPool{}
+
+func NewSingleTxPool(
 	client *CrossSporkClient,
 	transactionsPublisher *models.Publisher[*gethTypes.Transaction],
 	logger zerolog.Logger,
 	config config.Config,
-) *TxPool {
-	return &TxPool{
+	collector metrics.Collector,
+	keystore *keystore.KeyStore,
+) *SingleTxPool {
+	// initialize the available keys metric since it is only updated when sending a tx
+	collector.AvailableSigningKeys(keystore.AvailableKeys())
+
+	return &SingleTxPool{
 		logger:      logger.With().Str("component", "tx-pool").Logger(),
 		client:      client,
 		txPublisher: transactionsPublisher,
 		pool:        &sync.Map{},
 		config:      config,
+		collector:   collector,
+		keystore:    keystore,
 	}
 }
 
-// Send flow transaction that executes EVM run function which takes in the encoded EVM transaction.
-// The flow transaction status is awaited and an error is returned in case of a failure in submission,
-// or an EVM validation error.
-// Until the flow transaction is sealed the transaction will stay in the transaction pool marked as pending.
-func (t *TxPool) Send(
+// Add creates a Cadence transaction that wraps the given EVM transaction in
+// an `EVM.run` function call for execution.
+//
+// The Cadence transaction is submitted to the Flow network right away.
+//
+// If the transaction state validation is configured to run with the
+// "tx-seal" strategy, the Cadence transaction status is awaited and an error
+// is returned in case of a failure in submission or an EVM validation error.
+// Until the Cadence transaction is sealed the transaction will stay in the
+// pool and marked as pending.
+//
+// If the transaction state validation is configured to run with the
+// "local-index" strategy, the Cadence transaction status is not awaited,
+// as the necessary EVM validation checks, such as nonce/balance checks,
+// have been checked against the EVM state of the local index.
+func (t *SingleTxPool) Add(
 	ctx context.Context,
-	flowTx *flow.Transaction,
-	evmTx *gethTypes.Transaction,
+	tx *gethTypes.Transaction,
 ) error {
-	t.txPublisher.Publish(evmTx) // publish pending transaction event
+	t.txPublisher.Publish(tx) // publish pending transaction event
+
+	txData, err := tx.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	hexEncodedTx, err := cadence.NewString(hex.EncodeToString(txData))
+	if err != nil {
+		return err
+	}
+	coinbaseAddress, err := cadence.NewString(t.config.Coinbase.Hex())
+	if err != nil {
+		return err
+	}
+
+	script := replaceAddresses(runTxScript, t.config.FlowNetworkID)
+	flowTx, err := t.buildTransaction(ctx, script, hexEncodedTx, coinbaseAddress)
+	if err != nil {
+		return err
+	}
 
 	if err := t.client.SendTransaction(ctx, *flowTx); err != nil {
 		return err
@@ -67,8 +119,8 @@ func (t *TxPool) Send(
 
 	if t.config.TxStateValidation == config.TxSealValidation {
 		// add to pool and delete after transaction is sealed or errored out
-		t.pool.Store(evmTx.Hash(), evmTx)
-		defer t.pool.Delete(evmTx.Hash())
+		t.pool.Store(tx.Hash(), tx)
+		defer t.pool.Delete(tx.Hash())
 
 		backoff := retry.WithMaxDuration(time.Minute*1, retry.NewConstant(time.Second*1))
 		return retry.Do(ctx, backoff, func(ctx context.Context) error {
@@ -88,16 +140,237 @@ func (t *TxPool) Send(
 
 				t.logger.Error().Err(res.Error).
 					Str("flow-id", flowTx.ID().String()).
-					Str("evm-id", evmTx.Hash().Hex()).
+					Str("evm-id", tx.Hash().Hex()).
 					Msg("flow transaction error")
 
 				// hide specific cause since it's an implementation issue
-				return fmt.Errorf("failed to submit flow evm transaction %s", evmTx.Hash())
+				return fmt.Errorf("failed to submit flow evm transaction %s", tx.Hash())
 			}
 
 			return nil
 		})
 	}
+
+	return nil
+}
+
+// buildTransaction creates a Cadence transaction from the provided script,
+// with the given arguments and signs it with the configured COA account.
+func (t *SingleTxPool) buildTransaction(
+	ctx context.Context,
+	script []byte,
+	args ...cadence.Value,
+) (*flow.Transaction, error) {
+	// building and signing transactions should be blocking, so we don't have keys conflict
+	t.mux.Lock()
+	defer t.mux.Unlock()
+
+	defer func() {
+		t.collector.AvailableSigningKeys(t.keystore.AvailableKeys())
+	}()
+
+	var (
+		g           = errgroup.Group{}
+		err1, err2  error
+		latestBlock *flow.Block
+		account     *flow.Account
+	)
+	// execute concurrently so we can speed up all the information we need for tx
+	g.Go(func() error {
+		latestBlock, err1 = t.client.GetLatestBlock(ctx, true)
+		return err1
+	})
+	g.Go(func() error {
+		account, err2 = t.client.GetAccount(ctx, t.config.COAAddress)
+		return err2
+	})
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	flowTx := flow.NewTransaction().
+		SetScript(script).
+		SetReferenceBlockID(latestBlock.ID).
+		SetComputeLimit(flowGo.DefaultMaxTransactionGasLimit)
+
+	for _, arg := range args {
+		if err := flowTx.AddArgument(arg); err != nil {
+			return nil, fmt.Errorf("failed to add argument: %s, with %w", arg, err)
+		}
+	}
+
+	accKey, err := t.keystore.Take()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := accKey.SetProposerPayerAndSign(flowTx, account); err != nil {
+		accKey.Done()
+		return nil, err
+	}
+
+	// now that the transaction is prepared, store the transaction's metadata
+	accKey.SetLockMetadata(flowTx.ID(), latestBlock.Height)
+
+	t.collector.OperatorBalance(account)
+
+	return flowTx, nil
+}
+
+type pooledEvmTx struct {
+	txPayload cadence.String
+	nonce     uint64
+}
+
+// BatchTxPool is a `TxPool` implementation that collects and groups
+// transactions based on their EOA signer, and submits them for execution
+// using a batch.
+//
+// The underlying Cadence EVM API used, is `EVM.batchRun`, instead of the
+// `EVM.run` used in `SingleTxPool`.
+//
+// The main advantage of this implementation over the `SingleTxPool`, is the
+// guarantee that transactions originated from the same EOA address, which
+// arrive in a short time interval (about the same as Flow's block productionrate),
+// will be executed in the same order their arrived.
+// This helps to reduce the nonce mismatch errors which mainly occur from the
+// re-ordering of Cadence transactions that happens from Collection nodes.
+type BatchTxPool struct {
+	*SingleTxPool
+	logger      zerolog.Logger
+	client      *CrossSporkClient
+	txPublisher *models.Publisher[*gethTypes.Transaction]
+	config      config.Config
+	mux         sync.Mutex
+	keystore    *keystore.KeyStore
+	collector   metrics.Collector
+	pooledTxs   map[gethCommon.Address][]pooledEvmTx
+	txMux       sync.Mutex
+}
+
+var _ TxPool = &BatchTxPool{}
+
+func NewBatchTxPool(
+	client *CrossSporkClient,
+	transactionsPublisher *models.Publisher[*gethTypes.Transaction],
+	logger zerolog.Logger,
+	config config.Config,
+	collector metrics.Collector,
+	keystore *keystore.KeyStore,
+) *BatchTxPool {
+	// initialize the available keys metric since it is only updated when sending a tx
+	collector.AvailableSigningKeys(keystore.AvailableKeys())
+
+	singleTxPool := NewSingleTxPool(
+		client,
+		transactionsPublisher,
+		logger,
+		config,
+		collector,
+		keystore,
+	)
+	batchPool := &BatchTxPool{
+		SingleTxPool: singleTxPool,
+		logger:       logger,
+		client:       client,
+		txPublisher:  transactionsPublisher,
+		config:       config,
+		mux:          sync.Mutex{},
+		keystore:     keystore,
+		collector:    collector,
+		pooledTxs:    make(map[gethCommon.Address][]pooledEvmTx),
+		txMux:        sync.Mutex{},
+	}
+
+	go batchPool.processPooledTransactions()
+
+	return batchPool
+}
+
+// Add adds the EVM transaction to the tx pool, grouped with the rest of the
+// transactions from the same EOA signer.
+// After the configured `TxBatchInterval`, the collected transations
+// are batched and sent to the Flow network using `EVM.batchRun`, for execution.
+func (t *BatchTxPool) Add(
+	ctx context.Context,
+	tx *gethTypes.Transaction,
+) error {
+	// tx sending should be blocking, so we don't have races when
+	// pooled transactions are being processed in the background.
+	t.txMux.Lock()
+	defer t.txMux.Unlock()
+
+	t.txPublisher.Publish(tx) // publish pending transaction event
+
+	from, err := gethTypes.Sender(gethTypes.LatestSignerForChainID(tx.ChainId()), tx)
+	if err != nil {
+		return fmt.Errorf("failed to derive the sender: %w", err)
+	}
+	txData, err := tx.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	hexEncodedTx, err := cadence.NewString(hex.EncodeToString(txData))
+	if err != nil {
+		return err
+	}
+
+	userTx := pooledEvmTx{txPayload: hexEncodedTx, nonce: tx.Nonce()}
+	t.pooledTxs[from] = append(t.pooledTxs[from], userTx)
+
+	return nil
+}
+
+func (t *BatchTxPool) processPooledTransactions() {
+	for range time.Tick(t.config.TxBatchInterval) {
+		for address, pooledTxs := range t.pooledTxs {
+			if err := t.batchSubmitTransactions(address, pooledTxs); err != nil {
+				t.logger.Error().Err(err).Msg("failed to send Flow transaction from BatchPool")
+				continue
+			}
+		}
+	}
+}
+
+func (t *BatchTxPool) batchSubmitTransactions(
+	address gethCommon.Address,
+	pooledTxs []pooledEvmTx,
+) error {
+	t.txMux.Lock()
+	defer t.txMux.Unlock()
+
+	// Sort the transactions based on their nonce, to make sure
+	// that no re-ordering has happened due to races etc.
+	sort.Slice(pooledTxs, func(i, j int) bool {
+		return pooledTxs[i].nonce < pooledTxs[j].nonce
+	})
+
+	hexEncodedTxs := make([]cadence.Value, len(pooledTxs))
+	for i, txPayload := range pooledTxs {
+		hexEncodedTxs[i] = txPayload.txPayload
+	}
+
+	coinbaseAddress, err := cadence.NewString(t.config.Coinbase.Hex())
+	if err != nil {
+		return err
+	}
+
+	script := replaceAddresses(batchRunTxScript, t.config.FlowNetworkID)
+	ctx := context.Background()
+	flowTx, err := t.buildTransaction(
+		ctx,
+		script,
+		cadence.NewArray(hexEncodedTxs),
+		coinbaseAddress,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := t.client.SendTransaction(ctx, *flowTx); err != nil {
+		return err
+	}
+	delete(t.pooledTxs, address)
 
 	return nil
 }

--- a/services/requester/pool.go
+++ b/services/requester/pool.go
@@ -161,10 +161,6 @@ func (t *SingleTxPool) buildTransaction(
 	script []byte,
 	args ...cadence.Value,
 ) (*flow.Transaction, error) {
-	// building and signing transactions should be blocking, so we don't have keys conflict
-	t.mux.Lock()
-	defer t.mux.Unlock()
-
 	defer func() {
 		t.collector.AvailableSigningKeys(t.keystore.AvailableKeys())
 	}()
@@ -198,6 +194,11 @@ func (t *SingleTxPool) buildTransaction(
 			return nil, fmt.Errorf("failed to add argument: %s, with %w", arg, err)
 		}
 	}
+
+	// building and signing transactions should be blocking,
+	// so we don't have keys conflict
+	t.mux.Lock()
+	defer t.mux.Unlock()
 
 	accKey, err := t.keystore.Take()
 	if err != nil {

--- a/services/requester/pool.go
+++ b/services/requester/pool.go
@@ -281,12 +281,12 @@ func (t *BatchTxPool) Add(
 	ctx context.Context,
 	tx *gethTypes.Transaction,
 ) error {
+	t.txPublisher.Publish(tx) // publish pending transaction event
+
 	// tx sending should be blocking, so we don't have races when
 	// pooled transactions are being processed in the background.
 	t.txMux.Lock()
 	defer t.txMux.Unlock()
-
-	t.txPublisher.Publish(tx) // publish pending transaction event
 
 	from, err := gethTypes.Sender(gethTypes.LatestSignerForChainID(tx.ChainId()), tx)
 	if err != nil {

--- a/services/requester/pool.go
+++ b/services/requester/pool.go
@@ -237,15 +237,8 @@ type pooledEvmTx struct {
 // re-ordering of Cadence transactions that happens from Collection nodes.
 type BatchTxPool struct {
 	*SingleTxPool
-	logger      zerolog.Logger
-	client      *CrossSporkClient
-	txPublisher *models.Publisher[*gethTypes.Transaction]
-	config      config.Config
-	mux         sync.Mutex
-	keystore    *keystore.KeyStore
-	collector   metrics.Collector
-	pooledTxs   map[gethCommon.Address][]pooledEvmTx
-	txMux       sync.Mutex
+	pooledTxs map[gethCommon.Address][]pooledEvmTx
+	txMux     sync.Mutex
 }
 
 var _ TxPool = &BatchTxPool{}
@@ -271,13 +264,6 @@ func NewBatchTxPool(
 	)
 	batchPool := &BatchTxPool{
 		SingleTxPool: singleTxPool,
-		logger:       logger,
-		client:       client,
-		txPublisher:  transactionsPublisher,
-		config:       config,
-		mux:          sync.Mutex{},
-		keystore:     keystore,
-		collector:    collector,
 		pooledTxs:    make(map[gethCommon.Address][]pooledEvmTx),
 		txMux:        sync.Mutex{},
 	}

--- a/services/requester/pool.go
+++ b/services/requester/pool.go
@@ -459,7 +459,6 @@ func (t *BatchTxPool) fetchFlowLatestBlockAndCOA() (
 		return err2
 	})
 	if err := g.Wait(); err != nil {
-
 		return nil, nil, err
 	}
 

--- a/services/requester/pool.go
+++ b/services/requester/pool.go
@@ -352,7 +352,9 @@ func (t *BatchTxPool) batchSubmitTransactions(
 	}
 
 	script := replaceAddresses(batchRunTxScript, t.config.FlowNetworkID)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
 	flowTx, err := t.buildTransaction(
 		ctx,
 		script,

--- a/services/requester/single_tx_pool.go
+++ b/services/requester/single_tx_pool.go
@@ -1,0 +1,205 @@
+package requester
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/flow-go-sdk"
+	flowGo "github.com/onflow/flow-go/model/flow"
+	gethTypes "github.com/onflow/go-ethereum/core/types"
+	"github.com/rs/zerolog"
+	"github.com/sethvargo/go-retry"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/onflow/flow-evm-gateway/config"
+	"github.com/onflow/flow-evm-gateway/metrics"
+	"github.com/onflow/flow-evm-gateway/models"
+	"github.com/onflow/flow-evm-gateway/services/requester/keystore"
+)
+
+// SingleTxPool is a simple implementation of the `TxPool` interface that submits
+// transactions as soon as they arrive, without any delays or batching strategies.
+type SingleTxPool struct {
+	logger      zerolog.Logger
+	client      *CrossSporkClient
+	pool        *sync.Map
+	txPublisher *models.Publisher[*gethTypes.Transaction]
+	config      config.Config
+	mux         sync.Mutex
+	keystore    *keystore.KeyStore
+	collector   metrics.Collector
+	// todo add methods to inspect transaction pool state
+}
+
+var _ TxPool = &SingleTxPool{}
+
+func NewSingleTxPool(
+	client *CrossSporkClient,
+	transactionsPublisher *models.Publisher[*gethTypes.Transaction],
+	logger zerolog.Logger,
+	config config.Config,
+	collector metrics.Collector,
+	keystore *keystore.KeyStore,
+) *SingleTxPool {
+	// initialize the available keys metric since it is only updated when sending a tx
+	collector.AvailableSigningKeys(keystore.AvailableKeys())
+
+	return &SingleTxPool{
+		logger:      logger.With().Str("component", "tx-pool").Logger(),
+		client:      client,
+		txPublisher: transactionsPublisher,
+		pool:        &sync.Map{},
+		config:      config,
+		collector:   collector,
+		keystore:    keystore,
+	}
+}
+
+// Add creates a Cadence transaction that wraps the given EVM transaction in
+// an `EVM.run` function call for execution.
+//
+// The Cadence transaction is submitted to the Flow network right away.
+//
+// If the transaction state validation is configured to run with the
+// "tx-seal" strategy, the Cadence transaction status is awaited and an error
+// is returned in case of a failure in submission or an EVM validation error.
+// Until the Cadence transaction is sealed the transaction will stay in the
+// pool and marked as pending.
+//
+// If the transaction state validation is configured to run with the
+// "local-index" strategy, the Cadence transaction status is not awaited,
+// as the necessary EVM validation checks, such as nonce/balance checks,
+// have been checked against the EVM state of the local index.
+func (t *SingleTxPool) Add(
+	ctx context.Context,
+	tx *gethTypes.Transaction,
+) error {
+	t.txPublisher.Publish(tx) // publish pending transaction event
+
+	txData, err := tx.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	hexEncodedTx, err := cadence.NewString(hex.EncodeToString(txData))
+	if err != nil {
+		return err
+	}
+	coinbaseAddress, err := cadence.NewString(t.config.Coinbase.Hex())
+	if err != nil {
+		return err
+	}
+
+	script := replaceAddresses(runTxScript, t.config.FlowNetworkID)
+	flowTx, err := t.buildTransaction(ctx, script, hexEncodedTx, coinbaseAddress)
+	if err != nil {
+		return err
+	}
+
+	if err := t.client.SendTransaction(ctx, *flowTx); err != nil {
+		return err
+	}
+
+	if t.config.TxStateValidation == config.TxSealValidation {
+		// add to pool and delete after transaction is sealed or errored out
+		t.pool.Store(tx.Hash(), tx)
+		defer t.pool.Delete(tx.Hash())
+
+		backoff := retry.WithMaxDuration(time.Minute*1, retry.NewConstant(time.Second*1))
+		return retry.Do(ctx, backoff, func(ctx context.Context) error {
+			res, err := t.client.GetTransactionResult(ctx, flowTx.ID())
+			if err != nil {
+				return fmt.Errorf("failed to retrieve flow transaction result %s: %w", flowTx.ID(), err)
+			}
+			// retry until transaction is sealed
+			if res.Status < flow.TransactionStatusSealed {
+				return retry.RetryableError(fmt.Errorf("transaction %s not sealed", flowTx.ID()))
+			}
+
+			if res.Error != nil {
+				if err, ok := parseInvalidError(res.Error); ok {
+					return err
+				}
+
+				t.logger.Error().Err(res.Error).
+					Str("flow-id", flowTx.ID().String()).
+					Str("evm-id", tx.Hash().Hex()).
+					Msg("flow transaction error")
+
+				// hide specific cause since it's an implementation issue
+				return fmt.Errorf("failed to submit flow evm transaction %s", tx.Hash())
+			}
+
+			return nil
+		})
+	}
+
+	return nil
+}
+
+// buildTransaction creates a Cadence transaction from the provided script,
+// with the given arguments and signs it with the configured COA account.
+func (t *SingleTxPool) buildTransaction(
+	ctx context.Context,
+	script []byte,
+	args ...cadence.Value,
+) (*flow.Transaction, error) {
+	defer func() {
+		t.collector.AvailableSigningKeys(t.keystore.AvailableKeys())
+	}()
+
+	var (
+		g           = errgroup.Group{}
+		err1, err2  error
+		latestBlock *flow.Block
+		account     *flow.Account
+	)
+	// execute concurrently so we can speed up all the information we need for tx
+	g.Go(func() error {
+		latestBlock, err1 = t.client.GetLatestBlock(ctx, true)
+		return err1
+	})
+	g.Go(func() error {
+		account, err2 = t.client.GetAccount(ctx, t.config.COAAddress)
+		return err2
+	})
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	flowTx := flow.NewTransaction().
+		SetScript(script).
+		SetReferenceBlockID(latestBlock.ID).
+		SetComputeLimit(flowGo.DefaultMaxTransactionGasLimit)
+
+	for _, arg := range args {
+		if err := flowTx.AddArgument(arg); err != nil {
+			return nil, fmt.Errorf("failed to add argument: %s, with %w", arg, err)
+		}
+	}
+
+	// building and signing transactions should be blocking,
+	// so we don't have keys conflict
+	t.mux.Lock()
+	defer t.mux.Unlock()
+
+	accKey, err := t.keystore.Take()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := accKey.SetProposerPayerAndSign(flowTx, account); err != nil {
+		accKey.Done()
+		return nil, err
+	}
+
+	// now that the transaction is prepared, store the transaction's metadata
+	accKey.SetLockMetadata(flowTx.ID(), latestBlock.Height)
+
+	t.collector.OperatorBalance(account)
+
+	return flowTx, nil
+}

--- a/services/requester/tx_pool.go
+++ b/services/requester/tx_pool.go
@@ -1,0 +1,34 @@
+package requester
+
+import (
+	"context"
+	"regexp"
+
+	gethTypes "github.com/onflow/go-ethereum/core/types"
+
+	errs "github.com/onflow/flow-evm-gateway/models/errors"
+)
+
+const (
+	evmErrorRegex = `evm_error=(.*)\n`
+)
+
+// TxPool is the minimum interface that needs to be implemented by
+// the various transaction pool strategies.
+type TxPool interface {
+	Add(ctx context.Context, tx *gethTypes.Transaction) error
+}
+
+// this will extract the evm specific error from the Flow transaction error message
+// the run.cdc script panics with the evm specific error as the message which we
+// extract and return to the client. Any error returned that is evm specific
+// is a validation error due to assert statement in the run.cdc script.
+func parseInvalidError(err error) (error, bool) {
+	r := regexp.MustCompile(evmErrorRegex)
+	matches := r.FindStringSubmatch(err.Error())
+	if len(matches) != 2 {
+		return nil, false
+	}
+
+	return errs.NewFailedTransactionError(matches[1]), true
+}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/onflow/go-ethereum v1.15.10
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/sync v0.13.0
 )
 
 require (
@@ -231,7 +232,6 @@ require (
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/oauth2 v0.26.0 // indirect
-	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/term v0.31.0 // indirect
 	golang.org/x/text v0.24.0 // indirect

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -33,6 +33,7 @@ import (
 	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/go-ethereum/common"
+	"github.com/onflow/go-ethereum/common/hexutil"
 	"github.com/onflow/go-ethereum/core/types"
 	"github.com/rs/zerolog"
 
@@ -454,4 +455,19 @@ func (r *rpcTest) sendRawTx(signed []byte) (common.Hash, error) {
 	}
 
 	return h, nil
+}
+
+func (r *rpcTest) getBalance(address common.Address) (*big.Int, error) {
+	balanceRes, err := r.request("eth_getBalance", fmt.Sprintf(`["%s", "latest"]`, address))
+	if err != nil {
+		return nil, err
+	}
+
+	var balance hexutil.Big
+	err = json.Unmarshal(balanceRes, &balance)
+	if err != nil {
+		return nil, err
+	}
+
+	return balance.ToInt(), nil
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -555,11 +555,15 @@ func Test_ForceStartHeightIdempotency(t *testing.T) {
 
 	// Stop the EVM GW service
 	boot.Stop()
+
 	// Set `ForceStartHeight` to an earlier block, to verify that
 	// the ingestion process is idempotent
 	cfg.ForceStartCadenceHeight = 1
 
 	boot, err = bootstrap.New(cfg)
+	defer func() {
+		boot.Stop()
+	}()
 	require.NoError(t, err)
 
 	ready2 := make(chan struct{})

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -561,10 +561,12 @@ func Test_ForceStartHeightIdempotency(t *testing.T) {
 	cfg.ForceStartCadenceHeight = 1
 
 	boot, err = bootstrap.New(cfg)
-	defer func() {
-		boot.Stop()
-	}()
 	require.NoError(t, err)
+	defer func() {
+		if boot != nil {
+			boot.Stop()
+		}
+	}()
 
 	ready2 := make(chan struct{})
 	go func() {

--- a/tests/tx_batching_test.go
+++ b/tests/tx_batching_test.go
@@ -1,0 +1,249 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/onflow/flow-evm-gateway/bootstrap"
+	"github.com/onflow/flow-evm-gateway/config"
+	"github.com/onflow/flow-go-sdk/access/grpc"
+	"github.com/onflow/flow-go/fvm/evm/types"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/go-ethereum/common"
+	"github.com/onflow/go-ethereum/crypto"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TransactionBatchingMode(t *testing.T) {
+	srv, err := startEmulator(true)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		srv.Stop()
+	}()
+
+	grpcHost := "localhost:3569"
+	emu := srv.Emulator()
+	service := emu.ServiceKey()
+
+	client, err := grpc.NewClient(grpcHost)
+	require.NoError(t, err)
+
+	time.Sleep(500 * time.Millisecond) // some time to startup
+
+	// create new account with keys used for key-rotation
+	keyCount := 5
+	createdAddr, privateKey, err := bootstrap.CreateMultiKeyAccount(
+		client,
+		keyCount,
+		service.Address,
+		sc.FungibleToken.Address.HexWithPrefix(),
+		sc.FlowToken.Address.HexWithPrefix(),
+		service.PrivateKey,
+	)
+	require.NoError(t, err)
+
+	cfg := config.Config{
+		DatabaseDir:       t.TempDir(),
+		AccessNodeHost:    grpcHost,
+		RPCPort:           8545,
+		RPCHost:           "127.0.0.1",
+		FlowNetworkID:     "flow-emulator",
+		EVMNetworkID:      types.FlowEVMPreviewNetChainID,
+		Coinbase:          eoaTestAccount,
+		COAAddress:        *createdAddr,
+		COAKey:            privateKey,
+		GasPrice:          new(big.Int).SetUint64(0),
+		EnforceGasPrice:   true,
+		LogLevel:          zerolog.DebugLevel,
+		LogWriter:         testLogWriter(),
+		TxStateValidation: config.TxSealValidation,
+		TxBatchMode:       true,
+		TxBatchInterval:   time.Millisecond * 1200,
+	}
+
+	rpcTester := &rpcTest{
+		url: fmt.Sprintf("%s:%d", cfg.RPCHost, cfg.RPCPort),
+	}
+
+	ready := make(chan struct{})
+	go func() {
+		err = bootstrap.Run(ctx, cfg, func() {
+			close(ready)
+		})
+		require.NoError(t, err)
+	}()
+
+	<-ready
+
+	time.Sleep(3 * time.Second) // some time to startup
+
+	eoaKey, err := crypto.HexToECDSA(eoaTestPrivateKey)
+	require.NoError(t, err)
+
+	testAddr := common.HexToAddress("55253ed90B70b96C73092D8680915aaF50081194")
+	nonce := uint64(0)
+
+	// test scenario for multiple same-EOA transactions with increasing nonce
+	totalTxs := keyCount*5 + 3
+	hashes := make([]common.Hash, totalTxs)
+	for i := range totalTxs {
+		signed, _, err := evmSign(big.NewInt(10), 21000, eoaKey, nonce, &testAddr, nil)
+		require.NoError(t, err)
+
+		txHash, err := rpcTester.sendRawTx(signed)
+		require.NoError(t, err)
+		hashes[i] = txHash
+
+		// Add a bit of waiting time every 3 to 5 transactions, to give the
+		// `BatchTxPool` a chance to submit the pooled transactions.
+		// The waiting time is about the same as the mainnet block production
+		// rate.
+		if i%3 == 0 || i%5 == 0 {
+			time.Sleep(time.Millisecond * 800)
+		}
+		nonce += 1
+	}
+
+	assert.Eventually(t, func() bool {
+		for _, h := range hashes {
+			rcp, err := rpcTester.getReceipt(h.String())
+			if err != nil || rcp == nil || uint64(1) != rcp.Status {
+				return false
+			}
+		}
+
+		return true
+	}, time.Second*15, time.Second*1, "all transactions were not executed")
+
+	t.Run("same EOA transactions with mismatching nonces", func(t *testing.T) {
+		// the first nonce will cause a "nonce too low" validation error
+		// the second nonce will cause a "nonce too high" validation error
+		nonces := []uint64{nonce - 2, nonce + 2}
+		hashes := make([]common.Hash, len(nonces))
+
+		for i, nonce := range nonces {
+			signed, _, err := evmSign(big.NewInt(10), 21000, eoaKey, nonce, &testAddr, nil)
+			require.NoError(t, err)
+
+			txHash, err := rpcTester.sendRawTx(signed)
+			require.NoError(t, err)
+			hashes[i] = txHash
+		}
+
+		var latestBlock *flow.Block
+		require.Eventually(t, func() bool {
+			latestBlock, err = emu.GetLatestBlock()
+			require.NoError(t, err)
+
+			return latestBlock != nil
+		}, time.Second*15, time.Second*1, "latest block could not be fetched")
+
+		txResults, err := emu.GetTransactionResultsByBlockID(latestBlock.ID())
+		require.NoError(t, err)
+		require.Len(t, txResults, 1)
+
+		txResult := txResults[0]
+		// The `batch_run.cdc` Cadence transaction will fail with the error
+		// message of the first invalid EVM transaction.
+		expectedErrMessage := fmt.Sprintf(
+			"nonce too low: address 0xFACF71692421039876a5BB4F10EF7A439D8ef61E, tx: %d state: %d",
+			nonce-2,
+			nonce,
+		)
+		assert.Contains(t, txResult.ErrorMessage, expectedErrMessage)
+	})
+
+	t.Run("same EOA transactions with mismatching nonces and valid nonce", func(t *testing.T) {
+		// the first nonce will cause a "nonce too low" validation error
+		// the second nonce will cause a "nonce too high" validation error
+		// the third nonce, however, is valid and should execute
+		nonces := []uint64{nonce - 2, nonce + 2, nonce}
+		hashes := make([]common.Hash, len(nonces))
+
+		for i, nonce := range nonces {
+			signed, _, err := evmSign(big.NewInt(10), 21000, eoaKey, nonce, &testAddr, nil)
+			require.NoError(t, err)
+
+			txHash, err := rpcTester.sendRawTx(signed)
+			require.NoError(t, err)
+			hashes[i] = txHash
+		}
+
+		var latestBlock *flow.Block
+		require.Eventually(t, func() bool {
+			latestBlock, err = emu.GetLatestBlock()
+			require.NoError(t, err)
+
+			return latestBlock != nil
+		}, time.Second*15, time.Second*1, "latest block could not be fetched")
+
+		txResults, err := emu.GetTransactionResultsByBlockID(latestBlock.ID())
+		require.NoError(t, err)
+		require.Len(t, txResults, 1)
+
+		txResult := txResults[0]
+		// assert that the Cadence transaction did not revert
+		assert.Equal(t, "", txResult.ErrorMessage)
+
+		// assert that the EVM transaction that was signed with the
+		// third nonce, was successfully executed.
+		rcp, err := rpcTester.getReceipt(hashes[2].String())
+		require.NoError(t, err)
+		assert.Equal(t, uint64(1), rcp.Status)
+
+		nonce += 1
+	})
+
+	t.Run("same EOA transactions with valid nonce but non-sequential", func(t *testing.T) {
+		// the three nonces below are all valid, but they are
+		// non-sequential. Due to the thread nature of the EVM GW,
+		// we sort the grouped transactions of EOAs by their nonce.
+		nonces := []uint64{nonce + 2, nonce, nonce + 1}
+		hashes := make([]common.Hash, len(nonces))
+
+		for i, nonce := range nonces {
+			signed, _, err := evmSign(big.NewInt(10), 21000, eoaKey, nonce, &testAddr, nil)
+			require.NoError(t, err)
+
+			txHash, err := rpcTester.sendRawTx(signed)
+			require.NoError(t, err)
+			hashes[i] = txHash
+		}
+
+		var latestBlock *flow.Block
+		require.Eventually(t, func() bool {
+			latestBlock, err = emu.GetLatestBlock()
+			require.NoError(t, err)
+
+			return latestBlock != nil
+		}, time.Second*15, time.Second*1, "latest block could not be fetched")
+
+		txResults, err := emu.GetTransactionResultsByBlockID(latestBlock.ID())
+		require.NoError(t, err)
+		require.Len(t, txResults, 1)
+
+		txResult := txResults[0]
+		assert.Equal(t, "", txResult.ErrorMessage)
+
+		assert.Eventually(t, func() bool {
+			for _, h := range hashes {
+				rcp, err := rpcTester.getReceipt(h.String())
+				if err != nil || rcp == nil || uint64(1) != rcp.Status {
+					return false
+				}
+			}
+
+			return true
+		}, time.Second*15, time.Second*1, "all transactions were not executed")
+
+		nonce += 3
+	})
+}

--- a/tests/tx_batching_test.go
+++ b/tests/tx_batching_test.go
@@ -343,6 +343,7 @@ func Test_TransactionBatchingModeWithConcurrentTxSubmissions(t *testing.T) {
 	testEoaReceiver := common.HexToAddress("0x6F416dcC9BEFe43b7dDF53f2662F76dD34A9fc11")
 
 	totalTxs := 25
+	transferAmount := int64(50_000)
 	g := errgroup.Group{}
 	var err1 error
 
@@ -354,7 +355,14 @@ func Test_TransactionBatchingModeWithConcurrentTxSubmissions(t *testing.T) {
 			nonce := uint64(0)
 
 			for range totalTxs {
-				signed, _, err := evmSign(big.NewInt(50_000), 23_500, privateKey, nonce, &testEoaReceiver, nil)
+				signed, _, err := evmSign(
+					big.NewInt(transferAmount),
+					23_500,
+					privateKey,
+					nonce,
+					&testEoaReceiver,
+					nil,
+				)
 				if err != nil {
 					return err
 				}
@@ -378,7 +386,7 @@ func Test_TransactionBatchingModeWithConcurrentTxSubmissions(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, err1)
 
-	expectedBalance := int64(4 * totalTxs * 50_000)
+	expectedBalance := int64(len(testAddresses)) * int64(totalTxs) * transferAmount
 
 	assert.Eventually(t, func() bool {
 		balance, err := rpcTester.getBalance(testEoaReceiver)

--- a/tests/tx_batching_test.go
+++ b/tests/tx_batching_test.go
@@ -206,7 +206,7 @@ func Test_TransactionBatchingMode(t *testing.T) {
 
 	t.Run("same EOA transactions with valid nonce but non-sequential", func(t *testing.T) {
 		// the three nonces below are all valid, but they are
-		// non-sequential. Due to the thread nature of the EVM GW,
+		// non-sequential. Due to the threaded nature of the EVM GW,
 		// we sort the grouped transactions of EOAs by their nonce.
 		nonces := []uint64{nonce + 2, nonce, nonce + 1}
 		hashes := make([]common.Hash, len(nonces))
@@ -345,7 +345,6 @@ func Test_TransactionBatchingModeWithConcurrentTxSubmissions(t *testing.T) {
 	totalTxs := 25
 	transferAmount := int64(50_000)
 	g := errgroup.Group{}
-	var err1 error
 
 	for _, testPrivatekey := range testAddresses {
 		privateKey, err := crypto.HexToECDSA(testPrivatekey)
@@ -384,7 +383,6 @@ func Test_TransactionBatchingModeWithConcurrentTxSubmissions(t *testing.T) {
 
 	err = g.Wait()
 	require.NoError(t, err)
-	require.NoError(t, err1)
 
 	expectedBalance := int64(len(testAddresses)) * int64(totalTxs) * transferAmount
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/699
Closes: https://github.com/onflow/flow-evm-gateway/issues/477

## Description

Introduce a new implementation of the `TxPool` interface, namely `BatchTxPool`, to handle the nonce mismatch issues that certain EOAs face.

This issue manifests from the fact that certain EOAs send transactions quite frequently, with about the same rate as the block production rate. The Cadence transactions that wrap these EVM transactions with `EVM.run`, frequently end up on the same block, however, not in the proper order in which they were submitted, causing these nonce mismatch issues.

With the implementation of `BatchTxPool`, the EVM GW node operators can choose to run this pool strategy and configure a transaction batch interval that suits their needs. The way this strategy works is that it groups submitted transactions by the signed EOA address, and with a process that runs in the background after the transaction batch interval has passed, it will submit the transactions included the batch, up to that time. Under the hood, this uses the `EVM.batchRun` function from the `EVM` smart contract.

Some key points about the logic of the `batch_run.cdc` Cadence transaction:
- The EVM transactions that are passed as arguments in this Cadence transaction, strictly belong to the same EOA address
- The EVM transactions that are passed as arguments in this Cadence transaction, are properly sorted with their nonce
- If at least one of the EVM transactions in the batch was either `failed` or `successful`, in other words not `invalid`, we let the Cadence transaction succeed. Trading bots are not very meticulous about the nonce with which they sign the transactions, and they may repeatedly send transactions with low nonces. If at least one EVM transaction in the batch was valid, we don't abort the Cadence transaction.
- If the entire batch of EVM transactions had only `invalid` transactions, then we fail the Cadence transaction with the error message of the first `invalid` EVM transaction.

**NOTE:** The configured transaction batch interval means that even EOAs that send transactions in-frequently, will experience a small delay of up to the transaction batch interval. Because we can't know in advance if they are going to send more transactions in the coming seconds/milliseconds. That's why the transaction batch interval should be just enough to make sure that EOAs with high-throughput, will have their batch of transactions in the same block, but normal EOAs will not wait much for their transaction to be submitted.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced transaction batching mode for submitting multiple transactions together, reducing nonce mismatch issues for high-volume accounts.
  - Added configuration options to enable batching and set batch intervals.
  - Added a Cadence transaction script to support batch execution.
  - Enhanced transaction pool to support both single and batch submission modes.
  - Simplified transaction submission flow by removing Flow transaction construction and signing from the EVM component.

- **Bug Fixes**
  - Improved resource cleanup in integration tests to prevent resource leaks.

- **Tests**
  - Added comprehensive integration tests to verify transaction batching behavior, nonce handling, and transaction ordering.
  - Added helper method to retrieve account balances for test validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->