### PR TITLE
Add metric for the total number of dropped EVM transactions

### DIFF
--- a/metrics/nop.go
+++ b/metrics/nop.go
@@ -24,3 +24,4 @@ func (c *nopCollector) AvailableSigningKeys(count int)             {}
 func (c *nopCollector) GasEstimationIterations(count int)          {}
 func (c *nopCollector) BlockIngestionTime(blockCreation time.Time) {}
 func (c *nopCollector) RequestRateLimited(method string)           {}
+func (c *nopCollector) TransactionsDropped(count int)              {}

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -260,6 +260,9 @@ func (t *BatchTxPool) batchSubmitTransactionsForSameAddress(
 		coinbaseAddress,
 	)
 	if err != nil {
+		// If there was any error during the transaction build
+		// process, we record all transactions as dropped.
+		t.collector.TransactionsDropped(len(hexEncodedTxs))
 		return err
 	}
 
@@ -293,6 +296,9 @@ func (t *BatchTxPool) submitSingleTransaction(
 		coinbaseAddress,
 	)
 	if err != nil {
+		// If there was any error during the transaction build
+		// process, we record it as a dropped transaction.
+		t.collector.TransactionsDropped(1)
 		return err
 	}
 

--- a/services/requester/single_tx_pool.go
+++ b/services/requester/single_tx_pool.go
@@ -107,6 +107,9 @@ func (t *SingleTxPool) Add(
 		coinbaseAddress,
 	)
 	if err != nil {
+		// If there was any error during the transaction build
+		// process, we record it as a dropped transaction.
+		t.collector.TransactionsDropped(1)
 		return err
 	}
 


### PR DESCRIPTION
**Depends on:** https://github.com/onflow/flow-evm-gateway/pull/835
Closes: https://github.com/onflow/flow-evm-gateway/issues/836

## Description

For both tx pools (single & batch), we record the number of dropped EVM transactions.
The main reason that could cause an incoming EVM transaction, that has passed all applicable validation checks from EVM GW, to be dropped, is the absence of signing keys for the wrapping Cadence transaction.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new metric to track the number of EVM transactions dropped due to service errors.
  * Metrics are now collected and incremented whenever a transaction is dropped during batch or single transaction processing.

* **Bug Fixes**
  * Corrected the help text for the existing indexed transactions metric for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->