### PR TITLE
Add metric to count the number of rate-limited transactions per EOA

### DIFF
--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -77,6 +77,11 @@ var requestRateLimitedCounters = prometheus.NewCounterVec(prometheus.CounterOpts
 	Help: "Total number of rate limits by JSON-RPC method",
 }, []string{"method"})
 
+var eoaRateLimitedTransactions = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Name: prefixedName("eoa_rate_limited_transactions"),
+	Help: "Total number of rate limited transactions by EOA",
+}, []string{"address"})
+
 var metrics = []prometheus.Collector{
 	apiErrors,
 	serverPanicsCounters,
@@ -91,6 +96,7 @@ var metrics = []prometheus.Collector{
 	gasEstimationIterations,
 	blockIngestionTime,
 	requestRateLimitedCounters,
+	eoaRateLimitedTransactions,
 }
 
 type Collector interface {
@@ -106,6 +112,7 @@ type Collector interface {
 	GasEstimationIterations(count int)
 	BlockIngestionTime(blockCreation time.Time)
 	RequestRateLimited(method string)
+	EOARateLimited(address string)
 }
 
 var _ Collector = &DefaultCollector{}
@@ -125,6 +132,7 @@ type DefaultCollector struct {
 	gasEstimationIterations    prometheus.Gauge
 	blockIngestionTime         prometheus.Histogram
 	requestRateLimitedCounters *prometheus.CounterVec
+	eoaRateLimitedTransactions *prometheus.CounterVec
 }
 
 func NewCollector(logger zerolog.Logger) Collector {
@@ -147,6 +155,7 @@ func NewCollector(logger zerolog.Logger) Collector {
 		gasEstimationIterations:    gasEstimationIterations,
 		blockIngestionTime:         blockIngestionTime,
 		requestRateLimitedCounters: requestRateLimitedCounters,
+		eoaRateLimitedTransactions: eoaRateLimitedTransactions,
 	}
 }
 
@@ -219,6 +228,12 @@ func (c *DefaultCollector) RequestRateLimited(method string) {
 			"method": method,
 		},
 	).Inc()
+}
+
+func (c *DefaultCollector) EOARateLimited(address string) {
+	c.eoaRateLimitedTransactions.
+		With(prometheus.Labels{"address": address}).
+		Inc()
 }
 
 func prefixedName(name string) string {

--- a/metrics/nop.go
+++ b/metrics/nop.go
@@ -24,3 +24,4 @@ func (c *nopCollector) AvailableSigningKeys(count int)             {}
 func (c *nopCollector) GasEstimationIterations(count int)          {}
 func (c *nopCollector) BlockIngestionTime(blockCreation time.Time) {}
 func (c *nopCollector) RequestRateLimited(method string)           {}
+func (c *nopCollector) EOARateLimited(address string)              {}

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -219,7 +219,7 @@ func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash,
 			return common.Hash{}, fmt.Errorf("failed to check rate limit: %w", err)
 		}
 		if !ok {
-			e.collector.RequestRateLimited("SendRawTransaction")
+			e.collector.EOARateLimited(from.Hex())
 			return common.Hash{}, errs.ErrRateLimit
 		}
 	}


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/838

## Description



______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 