### PR TITLE
Improve release frequency for signing keys

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -243,7 +243,7 @@ func (b *Bootstrap) StartAPIServer(ctx context.Context) error {
 		}
 	}
 
-	b.keystore = keystore.New(ctx, accountKeys, b.client, b.logger)
+	b.keystore = keystore.New(ctx, accountKeys, b.client, b.config, b.logger)
 
 	// create transaction pool
 	var txPool requester.TxPool

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -243,7 +243,7 @@ func (b *Bootstrap) StartAPIServer(ctx context.Context) error {
 		}
 	}
 
-	b.keystore = keystore.New(accountKeys)
+	b.keystore = keystore.New(ctx, accountKeys, b.client, b.logger)
 
 	// create transaction pool
 	var txPool requester.TxPool

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -282,6 +282,7 @@ func init() {
 	Cmd.Flags().StringVar(&cloudKMSLocationID, "coa-cloud-kms-location-id", "", "The location ID where the key ring is grouped into, e.g. 'global'")
 	Cmd.Flags().StringVar(&cloudKMSKeyRingID, "coa-cloud-kms-key-ring-id", "", "The key ring ID where the KMS keys exist, e.g. 'tx-signing'")
 	Cmd.Flags().StringVar(&cloudKMSKey, "coa-cloud-kms-key", "", `Name of the KMS key and its version, e.g. "gw-key-6@1"`)
+	Cmd.Flags().BoolVar(&cfg.COATxLookupEnabled, "coa-tx-lookup-enabled", false, "Release COA signing keys by looking up their tx result status. Increases capacity of the available COA signing keys.")
 	Cmd.Flags().StringVar(&walletKey, "wallet-api-key", "", "ECDSA private key used for wallet APIs. WARNING: This should only be used locally or for testing, never in production.")
 	Cmd.Flags().IntVar(&cfg.MetricsPort, "metrics-port", 9091, "Port for the metrics server")
 	Cmd.Flags().BoolVar(&cfg.IndexOnly, "index-only", false, "Run the gateway in index-only mode which only allows querying the state and indexing, but disallows sending transactions.")

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -282,7 +282,7 @@ func init() {
 	Cmd.Flags().StringVar(&cloudKMSLocationID, "coa-cloud-kms-location-id", "", "The location ID where the key ring is grouped into, e.g. 'global'")
 	Cmd.Flags().StringVar(&cloudKMSKeyRingID, "coa-cloud-kms-key-ring-id", "", "The key ring ID where the KMS keys exist, e.g. 'tx-signing'")
 	Cmd.Flags().StringVar(&cloudKMSKey, "coa-cloud-kms-key", "", `Name of the KMS key and its version, e.g. "gw-key-6@1"`)
-	Cmd.Flags().BoolVar(&cfg.COATxLookupEnabled, "coa-tx-lookup-enabled", false, "Release COA signing keys by looking up their tx result status. Increases capacity of the available COA signing keys.")
+	Cmd.Flags().BoolVar(&cfg.COATxLookupEnabled, "coa-tx-lookup-enabled", false, "Tracks cadence transactions to release COA signing keys more quickly. Use this on nodes with high tx volume that frequently run out of proposer keys.")
 	Cmd.Flags().StringVar(&walletKey, "wallet-api-key", "", "ECDSA private key used for wallet APIs. WARNING: This should only be used locally or for testing, never in production.")
 	Cmd.Flags().IntVar(&cfg.MetricsPort, "metrics-port", 9091, "Port for the metrics server")
 	Cmd.Flags().BoolVar(&cfg.IndexOnly, "index-only", false, "Run the gateway in index-only mode which only allows querying the state and indexing, but disallows sending transactions.")

--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,10 @@ type Config struct {
 	COAKey crypto.PrivateKey
 	// COACloudKMSKey is a Cloud KMS key that will be used for signing transactions.
 	COACloudKMSKey *flowGoKMS.Key
+	// COATxLookupEnabled sets whether COA signing keys are released by looking up
+	// their transaction result status from ANs. Increases capacity of the available
+	// COA signing keys.
+	COATxLookupEnabled bool
 	// GasPrice is a fixed gas price that will be used when submitting transactions.
 	GasPrice *big.Int
 	// EnforceGasPrice defines whether the minimum gas price should be enforced.

--- a/config/config.go
+++ b/config/config.go
@@ -56,9 +56,9 @@ type Config struct {
 	COAKey crypto.PrivateKey
 	// COACloudKMSKey is a Cloud KMS key that will be used for signing transactions.
 	COACloudKMSKey *flowGoKMS.Key
-	// COATxLookupEnabled sets whether COA signing keys are released by looking up
-	// their transaction result status from ANs. Increases capacity of the available
-	// COA signing keys.
+	// COATxLookupEnabled enables tracking of Cadence transactions to release COA signing
+	// keys much faster. Increases capacity of the available COA signing keys for nodes
+	// with high tx volume.
 	COATxLookupEnabled bool
 	// GasPrice is a fixed gas price that will be used when submitting transactions.
 	GasPrice *big.Int

--- a/services/ingestion/event_subscriber.go
+++ b/services/ingestion/event_subscriber.go
@@ -176,7 +176,12 @@ func (r *RPCEventSubscriber) subscribe(ctx context.Context, height uint64) <-cha
 				for _, evt := range blockEvents.Events {
 					r.keyLock.NotifyTransaction(evt.TransactionID)
 				}
-				r.keyLock.NotifyBlock(blockEvents.BlockID)
+				r.keyLock.NotifyBlock(
+					flow.BlockHeader{
+						ID:     blockEvents.BlockID,
+						Height: blockEvents.Height,
+					},
+				)
 
 				eventsChan <- evmEvents
 

--- a/services/ingestion/event_subscriber.go
+++ b/services/ingestion/event_subscriber.go
@@ -176,7 +176,7 @@ func (r *RPCEventSubscriber) subscribe(ctx context.Context, height uint64) <-cha
 				for _, evt := range blockEvents.Events {
 					r.keyLock.NotifyTransaction(evt.TransactionID)
 				}
-				r.keyLock.NotifyBlock(blockEvents.Height)
+				r.keyLock.NotifyBlock(blockEvents.BlockID)
 
 				eventsChan <- evmEvents
 

--- a/services/ingestion/event_subscriber_test.go
+++ b/services/ingestion/event_subscriber_test.go
@@ -44,9 +44,13 @@ func Test_Subscribing(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, keystore.New(nil), 1)
+	ctx := context.Background()
+	logger := zerolog.Nop()
+	ks := keystore.New(ctx, nil, client, logger)
 
-	events := subscriber.Subscribe(context.Background())
+	subscriber := NewRPCEventSubscriber(logger, client, flowGo.Previewnet, ks, 1)
+
+	events := subscriber.Subscribe(ctx)
 
 	var prevHeight uint64
 
@@ -84,9 +88,13 @@ func Test_MissingBlockEvent(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, keystore.New(nil), 1)
+	ctx := context.Background()
+	logger := zerolog.Nop()
+	ks := keystore.New(ctx, nil, client, logger)
 
-	events := subscriber.Subscribe(context.Background())
+	subscriber := NewRPCEventSubscriber(logger, client, flowGo.Previewnet, ks, 1)
+
+	events := subscriber.Subscribe(ctx)
 
 	missingHashes := make([]gethCommon.Hash, 0)
 
@@ -186,9 +194,13 @@ func Test_SubscribingWithRetryOnError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, keystore.New(nil), 1)
+	ctx := context.Background()
+	logger := zerolog.Nop()
+	ks := keystore.New(ctx, nil, client, logger)
 
-	events := subscriber.Subscribe(context.Background())
+	subscriber := NewRPCEventSubscriber(logger, client, flowGo.Previewnet, ks, 1)
+
+	events := subscriber.Subscribe(ctx)
 
 	var prevHeight uint64
 
@@ -249,9 +261,13 @@ func Test_SubscribingWithRetryOnErrorMultipleBlocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, keystore.New(nil), 1)
+	ctx := context.Background()
+	logger := zerolog.Nop()
+	ks := keystore.New(ctx, nil, client, logger)
 
-	events := subscriber.Subscribe(context.Background())
+	subscriber := NewRPCEventSubscriber(logger, client, flowGo.Previewnet, ks, 1)
+
+	events := subscriber.Subscribe(ctx)
 
 	var prevHeight uint64
 
@@ -311,9 +327,13 @@ func Test_SubscribingWithRetryOnErrorEmptyBlocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subscriber := NewRPCEventSubscriber(zerolog.Nop(), client, flowGo.Previewnet, keystore.New(nil), 1)
+	ctx := context.Background()
+	logger := zerolog.Nop()
+	ks := keystore.New(ctx, nil, client, logger)
 
-	events := subscriber.Subscribe(context.Background())
+	subscriber := NewRPCEventSubscriber(logger, client, flowGo.Previewnet, ks, 1)
+
+	events := subscriber.Subscribe(ctx)
 
 	var prevHeight uint64
 

--- a/services/ingestion/event_subscriber_test.go
+++ b/services/ingestion/event_subscriber_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onflow/flow-go-sdk/access"
 	gethCommon "github.com/onflow/go-ethereum/common"
 
+	"github.com/onflow/flow-evm-gateway/config"
 	"github.com/onflow/flow-evm-gateway/models"
 	errs "github.com/onflow/flow-evm-gateway/models/errors"
 	"github.com/onflow/flow-evm-gateway/services/requester"
@@ -46,7 +47,8 @@ func Test_Subscribing(t *testing.T) {
 
 	ctx := context.Background()
 	logger := zerolog.Nop()
-	ks := keystore.New(ctx, nil, client, logger)
+	cfg := config.Config{COATxLookupEnabled: true}
+	ks := keystore.New(ctx, nil, client, cfg, logger)
 
 	subscriber := NewRPCEventSubscriber(logger, client, flowGo.Previewnet, ks, 1)
 
@@ -90,7 +92,8 @@ func Test_MissingBlockEvent(t *testing.T) {
 
 	ctx := context.Background()
 	logger := zerolog.Nop()
-	ks := keystore.New(ctx, nil, client, logger)
+	cfg := config.Config{COATxLookupEnabled: true}
+	ks := keystore.New(ctx, nil, client, cfg, logger)
 
 	subscriber := NewRPCEventSubscriber(logger, client, flowGo.Previewnet, ks, 1)
 
@@ -196,7 +199,8 @@ func Test_SubscribingWithRetryOnError(t *testing.T) {
 
 	ctx := context.Background()
 	logger := zerolog.Nop()
-	ks := keystore.New(ctx, nil, client, logger)
+	cfg := config.Config{COATxLookupEnabled: true}
+	ks := keystore.New(ctx, nil, client, cfg, logger)
 
 	subscriber := NewRPCEventSubscriber(logger, client, flowGo.Previewnet, ks, 1)
 
@@ -263,7 +267,8 @@ func Test_SubscribingWithRetryOnErrorMultipleBlocks(t *testing.T) {
 
 	ctx := context.Background()
 	logger := zerolog.Nop()
-	ks := keystore.New(ctx, nil, client, logger)
+	cfg := config.Config{COATxLookupEnabled: true}
+	ks := keystore.New(ctx, nil, client, cfg, logger)
 
 	subscriber := NewRPCEventSubscriber(logger, client, flowGo.Previewnet, ks, 1)
 
@@ -329,7 +334,8 @@ func Test_SubscribingWithRetryOnErrorEmptyBlocks(t *testing.T) {
 
 	ctx := context.Background()
 	logger := zerolog.Nop()
-	ks := keystore.New(ctx, nil, client, logger)
+	cfg := config.Config{COATxLookupEnabled: true}
+	ks := keystore.New(ctx, nil, client, cfg, logger)
 
 	subscriber := NewRPCEventSubscriber(logger, client, flowGo.Previewnet, ks, 1)
 

--- a/services/requester/keystore/key_store.go
+++ b/services/requester/keystore/key_store.go
@@ -77,6 +77,11 @@ func (k *KeyStore) AvailableKeys() int {
 	return len(k.availableKeys)
 }
 
+// HasKeysInUse returns whether any of the keys are currently being used.
+func (k *KeyStore) HasKeysInUse() bool {
+	return k.AvailableKeys() != k.size
+}
+
 // Take reserves a key for use in a transaction.
 func (k *KeyStore) Take() (*AccountKey, error) {
 	select {
@@ -164,7 +169,7 @@ func (k *KeyStore) processLockedKeys(ctx context.Context) {
 			// Optimization to avoid AN calls when no signing keys have
 			// been used. For example, when back-filling the EVM GW state,
 			// we don't care about releasing signing keys.
-			if k.AvailableKeys() == k.size {
+			if !k.HasKeysInUse() {
 				continue
 			}
 

--- a/services/requester/keystore/key_store.go
+++ b/services/requester/keystore/key_store.go
@@ -172,19 +172,6 @@ func (k *KeyStore) processLockedKeys(ctx context.Context) {
 			close(k.done)
 			return
 		case blockHeader := <-k.blockChan:
-			// TODO: If calling `k.client.GetTransactionResultsByBlockID` for each
-			// new block, seems to be problematic for ANs, we can take an approach
-			// like the one below:
-			// If the available keys ratio is >= 60% of the total signing keys,
-			// then we can skip checking the transaction result statuses.
-			// The signing keys from invalid EVM transactions, will eventually
-			// come again into availability, after `accountKeyBlockExpiration`
-			// blocks have passed.
-			// availablekeysRatio := float64(k.AvailableKeys()) / float64(k.size)
-			// if availablekeysRatio >= 0.6 {
-			// 	continue
-			// }
-
 			// Optimization to avoid AN calls when no signing keys have
 			// been used. For example, when back-filling the EVM GW state,
 			// we don't care about releasing signing keys.

--- a/services/requester/keystore/key_store.go
+++ b/services/requester/keystore/key_store.go
@@ -116,9 +116,11 @@ func (k *KeyStore) NotifyBlock(blockHeader flowsdk.BlockHeader) {
 		k.logger.Warn().Msg(
 			"received `NotifyBlock` while the server is shutting down",
 		)
-		return
-	default:
-		k.blockChan <- blockHeader
+	case k.blockChan <- blockHeader:
+		k.logger.Info().Msgf(
+			"received `NotifyBlock` for block with ID: %s",
+			blockHeader.ID,
+		)
 	}
 }
 

--- a/services/requester/keystore/key_store_test.go
+++ b/services/requester/keystore/key_store_test.go
@@ -1,14 +1,18 @@
 package keystore
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/onflow/flow-evm-gateway/services/testutils"
 	sdk "github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go-sdk/access/mocks"
 	"github.com/onflow/flow-go-sdk/test"
 	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +29,7 @@ func TestTake(t *testing.T) {
 		keys = append(keys, NewAccountKey(*accountKey, addrGenerator.New(), signer))
 	}
 
-	ks := New(keys)
+	ks := New(context.Background(), keys, testutils.SetupClientForRange(1, 100), zerolog.Nop())
 
 	t.Run("Take with no metadata updates", func(t *testing.T) {
 		key, err := ks.Take()
@@ -67,10 +71,50 @@ func TestTake(t *testing.T) {
 	})
 
 	t.Run("Take with expiration", func(t *testing.T) {
+		blockHeight := uint64(10)
+		blockID10 := identifierFixture()
+		blockIDNonExpired := identifierFixture()
+		client := &testutils.MockClient{
+			Client: &mocks.Client{},
+			GetTransactionResultsByBlockIDFunc: func(ctx context.Context, blockID sdk.Identifier) ([]*sdk.TransactionResult, error) {
+				if blockID == blockID10 {
+					return []*sdk.TransactionResult{}, nil
+				}
+
+				if blockID == blockIDNonExpired {
+					return []*sdk.TransactionResult{
+						{
+							Status:           sdk.TransactionStatusFinalized,
+							Error:            nil,
+							Events:           []sdk.Event{},
+							BlockID:          blockID,
+							BlockHeight:      blockHeight + accountKeyBlockExpiration - 1,
+							TransactionID:    identifierFixture(),
+							CollectionID:     identifierFixture(),
+							ComputationUsage: 104_512,
+						},
+					}, nil
+				}
+
+				return []*sdk.TransactionResult{
+					{
+						Status:           sdk.TransactionStatusFinalized,
+						Error:            nil,
+						Events:           []sdk.Event{},
+						BlockID:          blockID,
+						BlockHeight:      blockHeight + accountKeyBlockExpiration,
+						TransactionID:    identifierFixture(),
+						CollectionID:     identifierFixture(),
+						ComputationUsage: 104_512,
+					},
+				}, nil
+			},
+		}
+		ks := New(context.Background(), keys, client, zerolog.Nop())
+
 		key, err := ks.Take()
 		require.NoError(t, err)
 
-		blockHeight := uint64(10)
 		txID := identifierFixture()
 		key.SetLockMetadata(txID, blockHeight)
 
@@ -82,13 +126,21 @@ func TestTake(t *testing.T) {
 		assert.Equal(t, key, ks.usedKeys[txID])
 
 		// notify for one block before the expiration block, key should still be reserved
-		ks.NotifyBlock(blockHeight + accountKeyBlockExpiration - 1)
+		ks.NotifyBlock(blockIDNonExpired)
+
+		// Give some time to allow the KeyStore to check for the
+		// transaction result statuses in the background.
+		time.Sleep(time.Second * 2)
 
 		assert.True(t, key.inUse.Load())
 		assert.Equal(t, key, ks.usedKeys[txID])
 
 		// notify for the expiration block
-		ks.NotifyBlock(blockHeight + accountKeyBlockExpiration)
+		ks.NotifyBlock(identifierFixture())
+
+		// Give some time to allow the KeyStore to check for the
+		// transaction result statuses in the background.
+		time.Sleep(time.Second * 2)
 
 		// keystore and key should be reset
 		assert.Equal(t, 2, ks.AvailableKeys())
@@ -106,9 +158,14 @@ func TestKeySigning(t *testing.T) {
 	accountKey.Index = 0 // the fixture starts from index 1
 	accountKey.SequenceNumber = 42
 
-	ks := New([]*AccountKey{
-		NewAccountKey(*accountKey, address, signer),
-	})
+	ks := New(
+		context.Background(),
+		[]*AccountKey{
+			NewAccountKey(*accountKey, address, signer),
+		},
+		testutils.SetupClientForRange(1, 100),
+		zerolog.Nop(),
+	)
 
 	key, err := ks.Take()
 	require.NoError(t, err)
@@ -154,7 +211,7 @@ func TestConcurrentUse(t *testing.T) {
 		keys = append(keys, key)
 	}
 
-	ks := New(keys)
+	ks := New(context.Background(), keys, testutils.SetupClientForRange(1, 100), zerolog.Nop())
 
 	g := errgroup.Group{}
 	g.SetLimit(concurrentTxCount)

--- a/services/testutils/mock_client.go
+++ b/services/testutils/mock_client.go
@@ -18,6 +18,7 @@ type MockClient struct {
 	GetEventsForHeightRangeFunc      func(
 		ctx context.Context, eventType string, startHeight uint64, endHeight uint64,
 	) ([]flow.BlockEvents, error)
+	GetTransactionResultsByBlockIDFunc func(ctx context.Context, blockID flow.Identifier) ([]*flow.TransactionResult, error)
 }
 
 func (c *MockClient) GetBlockHeaderByHeight(ctx context.Context, height uint64) (*flow.BlockHeader, error) {
@@ -48,6 +49,16 @@ func (c *MockClient) GetEventsForHeightRange(
 		return c.GetEventsForHeightRangeFunc(ctx, eventType, startHeight, endHeight)
 	}
 	return c.Client.GetEventsForHeightRange(ctx, eventType, startHeight, endHeight)
+}
+
+func (c *MockClient) GetTransactionResultsByBlockID(
+	ctx context.Context,
+	blockID flow.Identifier,
+) ([]*flow.TransactionResult, error) {
+	if c.GetTransactionResultsByBlockIDFunc != nil {
+		return c.GetTransactionResultsByBlockIDFunc(ctx, blockID)
+	}
+	return c.Client.GetTransactionResultsByBlockID(ctx, blockID)
 }
 
 func SetupClientForRange(startHeight uint64, endHeight uint64) *MockClient {

--- a/tests/key_store_release_test.go
+++ b/tests/key_store_release_test.go
@@ -55,20 +55,21 @@ func Test_KeyStoreSigningKeysRelease(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := config.Config{
-		DatabaseDir:       t.TempDir(),
-		AccessNodeHost:    grpcHost,
-		RPCPort:           8545,
-		RPCHost:           "127.0.0.1",
-		FlowNetworkID:     "flow-emulator",
-		EVMNetworkID:      types.FlowEVMPreviewNetChainID,
-		Coinbase:          eoaTestAccount,
-		COAAddress:        *createdAddr,
-		COAKey:            privateKey,
-		GasPrice:          new(big.Int).SetUint64(0),
-		EnforceGasPrice:   true,
-		LogLevel:          zerolog.DebugLevel,
-		LogWriter:         testLogWriter(),
-		TxStateValidation: config.LocalIndexValidation,
+		DatabaseDir:        t.TempDir(),
+		AccessNodeHost:     grpcHost,
+		RPCPort:            8545,
+		RPCHost:            "127.0.0.1",
+		FlowNetworkID:      "flow-emulator",
+		EVMNetworkID:       types.FlowEVMPreviewNetChainID,
+		Coinbase:           eoaTestAccount,
+		COAAddress:         *createdAddr,
+		COAKey:             privateKey,
+		COATxLookupEnabled: true,
+		GasPrice:           new(big.Int).SetUint64(0),
+		EnforceGasPrice:    true,
+		LogLevel:           zerolog.DebugLevel,
+		LogWriter:          testLogWriter(),
+		TxStateValidation:  config.LocalIndexValidation,
 	}
 
 	rpcTester := &rpcTest{

--- a/tests/key_store_release_test.go
+++ b/tests/key_store_release_test.go
@@ -1,0 +1,132 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/onflow/flow-go-sdk/access/grpc"
+	"github.com/onflow/flow-go/fvm/evm/types"
+	"github.com/onflow/go-ethereum/common"
+	"github.com/onflow/go-ethereum/crypto"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-evm-gateway/bootstrap"
+	"github.com/onflow/flow-evm-gateway/config"
+)
+
+func Test_KeyStoreSigningKeysRelease(t *testing.T) {
+	srv, err := startEmulator(true)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		srv.Stop()
+	}()
+
+	grpcHost := "localhost:3569"
+	emu := srv.Emulator()
+	service := emu.ServiceKey()
+
+	client, err := grpc.NewClient(grpcHost)
+	require.NoError(t, err)
+
+	// Poll for emulator readiness
+	require.Eventually(t, func() bool {
+		err := client.Ping(ctx)
+		return err == nil
+	}, 5*time.Second, 100*time.Millisecond, "emulator failed to start")
+
+	// create new account with keys used for key-rotation
+	keyCount := 5
+	createdAddr, privateKey, err := bootstrap.CreateMultiKeyAccount(
+		client,
+		keyCount,
+		service.Address,
+		sc.FungibleToken.Address.HexWithPrefix(),
+		sc.FlowToken.Address.HexWithPrefix(),
+		service.PrivateKey,
+	)
+	require.NoError(t, err)
+
+	cfg := config.Config{
+		DatabaseDir:       t.TempDir(),
+		AccessNodeHost:    grpcHost,
+		RPCPort:           8545,
+		RPCHost:           "127.0.0.1",
+		FlowNetworkID:     "flow-emulator",
+		EVMNetworkID:      types.FlowEVMPreviewNetChainID,
+		Coinbase:          eoaTestAccount,
+		COAAddress:        *createdAddr,
+		COAKey:            privateKey,
+		GasPrice:          new(big.Int).SetUint64(0),
+		EnforceGasPrice:   true,
+		LogLevel:          zerolog.DebugLevel,
+		LogWriter:         testLogWriter(),
+		TxStateValidation: config.LocalIndexValidation,
+	}
+
+	rpcTester := &rpcTest{
+		url: fmt.Sprintf("%s:%d", cfg.RPCHost, cfg.RPCPort),
+	}
+
+	ready := make(chan struct{})
+	go func() {
+		err = bootstrap.Run(ctx, cfg, func() {
+			close(ready)
+		})
+		require.NoError(t, err)
+	}()
+
+	<-ready
+
+	time.Sleep(3 * time.Second) // some time for EVM GW to startup
+
+	eoaKey, err := crypto.HexToECDSA(eoaTestPrivateKey)
+	require.NoError(t, err)
+
+	testAddr := common.HexToAddress("55253ed90B70b96C73092D8680915aaF50081194")
+
+	// The first 6 nonces: [5, 4, 3, 2, 1, 1], are all invalid EVM
+	// transactions that will fail with `nonce too high`, because
+	// fresh account starts at nonce 0.
+	// Given that we created our COA above with a `keyCount = 5`,
+	// we assert that transaction submission still functions properly
+	// and that signing keys get released frequently, with each new
+	// Flow block.
+	// The rest 8 nonces: [0, 1, 5, 2, 5, 3, 5, 4], contain 5 valid
+	// EVM transactions (nonces 0, 1, 2, 3, 4) and 3 invalid ones
+	// (the duplicate nonce 5 submissions).
+	// Finally, we assert that `testAddr` has the expected balance
+	// from the 5 valid EVM transactions, which are transfers of
+	// equal amounts.
+	nonces := []uint64{5, 4, 3, 2, 1, 1, 0, 1, 5, 2, 5, 3, 5, 4}
+	transferAmount := int64(50_000)
+	for _, nonce := range nonces {
+		signed, _, err := evmSign(big.NewInt(transferAmount), 23_000, eoaKey, nonce, &testAddr, nil)
+		require.NoError(t, err)
+
+		txHash, err := rpcTester.sendRawTx(signed)
+		// For nonces > 4 initially or out of sequence,
+		// we expect "nonce too high" errors but we still
+		// submit them to test key release.
+		if err != nil {
+			t.Logf("transaction with nonce %d returned error: %v", nonce, err)
+		} else {
+			t.Logf("transaction with nonce %d submitted: %s", nonce, txHash)
+		}
+	}
+
+	expectedBalance := int64(keyCount) * transferAmount
+	assert.Eventually(t, func() bool {
+		balance, err := rpcTester.getBalance(testAddr)
+		require.NoError(t, err)
+
+		return balance.Cmp(big.NewInt(expectedBalance)) == 0
+	}, time.Second*15, time.Second*1, "all transactions were not executed")
+}


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/841

## Description

Introduce a background process on keystore to improve release frequency for signing keys, by checking tx result status on each new block.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved key management by processing locked keys asynchronously using block headers, enhancing unlocking accuracy and reliability.
  * Added configuration option to enable releasing signing keys by transaction result lookup, increasing key capacity.
  * Added a new test verifying signing key release and reuse during EVM transaction submission with key rotation.
  * Introduced a command-line flag to toggle transaction result-based key release.

* **Bug Fixes**
  * Updated block notifications to include full block headers instead of just block heights, ensuring correct key release.

* **Tests**
  * Refactored tests for context-aware initialization and block header-based notifications.
  * Added mock client support for transaction result retrieval by block ID in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->