### PR TITLE
Remove 'totalDifficulty' field from `Block` type

### DIFF
--- a/eth/types/types.go
+++ b/eth/types/types.go
@@ -470,7 +470,6 @@ type Block struct {
 	ReceiptsRoot     common.Hash      `json:"receiptsRoot"`
 	Miner            common.Address   `json:"miner"`
 	Difficulty       hexutil.Uint64   `json:"difficulty"`
-	TotalDifficulty  hexutil.Uint64   `json:"totalDifficulty"`
 	ExtraData        hexutil.Bytes    `json:"extraData"`
 	Size             hexutil.Uint64   `json:"size"`
 	GasLimit         hexutil.Uint64   `json:"gasLimit"`


### PR DESCRIPTION
Work Towards: https://github.com/onflow/flow-evm-gateway/issues/840

## Description

The `totalDifficulty` field was removed from the `Block` schema on Ethereum as well. See: https://github.com/ethereum/execution-apis/pull/570

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 