### PR TITLE
Back-port changes from `main` to soft-finality

### DIFF
--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -302,4 +302,5 @@ func init() {
 	Cmd.Flags().DurationVar(&cfg.TxBatchInterval, "tx-batch-interval", time.Millisecond*1200, "Time interval upon which to submit the transaction batches to the Flow network.")
 	Cmd.Flags().BoolVar(&experimentalSoftFinalityEnabled, "experimental-soft-finality-enabled", false, "Sets whether the gateway should use the experimental soft finality feature. WARNING: This may result in incorrect results being returned in certain circumstances. Use only if you know what you are doing.")
 	Cmd.Flags().BoolVar(&experimentalSealingVerificationEnabled, "experimental-sealing-verification-enabled", true, "Sets whether the gateway should use the experimental soft finality sealing verification feature. WARNING: This may result in indexing halts if events do not match. Use only if you know what you are doing.")
+	Cmd.Flags().DurationVar(&cfg.EOAActivityCacheTTL, "eoa-activity-cache-ttl", time.Second*10, "Time interval used to track EOA activity. Tx send more frequently than this interval will be batched. Useful only when batch transaction submission is enabled.")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -116,4 +116,8 @@ type Config struct {
 	// of the events from the sealed block in the Flow network.
 	// CAUTION: This feature is experimental and will cause the node to halt if the events don't match.
 	ExperimentalSealingVerificationEnabled bool
+	// EOAActivityCacheTTL is the time interval used to track EOA activity. Tx send more
+	// frequently than this interval will be batched.
+	// Useful only when batch transaction submission is enabled.
+	EOAActivityCacheTTL time.Duration
 }


### PR DESCRIPTION
## Description

Mainly changes from https://github.com/onflow/flow-evm-gateway/pull/852 .

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 