### PR TITLE
Include `errorCode` from EVM `txResult` in Cadence assert message

### DIFF
--- a/services/requester/cadence/batch_run.cdc
+++ b/services/requester/cadence/batch_run.cdc
@@ -28,7 +28,7 @@ transaction(hexEncodedTxs: [String], coinbase: String) {
         for txResult in txResults {
             assert(
                 txResult.status == EVM.Status.failed || txResult.status == EVM.Status.successful,
-                message: "evm_error=".concat(txResult.errorMessage).concat("\n")
+                message: "evm_error=\(txResult.errorMessage);evm_error_code=\(txResult.errorCode)"
             )
         }
     }

--- a/services/requester/cadence/run.cdc
+++ b/services/requester/cadence/run.cdc
@@ -8,7 +8,7 @@ transaction(hexEncodedTx: String, coinbase: String) {
         )
         assert(
             txResult.status == EVM.Status.failed || txResult.status == EVM.Status.successful,
-            message: "evm_error=".concat(txResult.errorMessage).concat("\n")
+            message: "evm_error=\(txResult.errorMessage);evm_error_code=\(txResult.errorCode)"
         )
     }
 }

--- a/services/requester/tx_pool.go
+++ b/services/requester/tx_pool.go
@@ -9,9 +9,7 @@ import (
 	errs "github.com/onflow/flow-evm-gateway/models/errors"
 )
 
-const (
-	evmErrorRegex = `evm_error=(.*)\n`
-)
+const evmErrorRegex = `evm_error=(.*);`
 
 // TxPool is the minimum interface that needs to be implemented by
 // the various transaction pool strategies.


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/868

## Description

The trace will now look something like:
```bash
* transaction execute failed: [Error Code: 1101] cadence runtime error: Execution failed:
error: assertion failed: evm_error=nonce too high: address 0x658Bdf435d810C91414eC09147DAA6DB62406379, tx: 1 state: 0;evm_error_code=202
  --> 7ab67265fa733e947f73791c7c5a916d025608f210a47bbb45cdb65c0401934f:9:8
   |
 9 |         assert(
10 |             txResult.status == EVM.Status.failed || txResult.status == EVM.Status.successful,
11 |             message: "evm_error_code=\(txResult.errorCode);evm_error=\(txResult.errorMessage)"
12 |         )
   |         ^
```

With the assertion error being:
```bash
evm_error=nonce too high: address 0x658Bdf435d810C91414eC09147DAA6DB62406379, tx: 1 state: 0;evm_error_code=202
```

The error code is included in `evm_error_code`, and the human-friendly representation of this type of error is included in `evm_error`

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error message format across single and batch executions for consistency.
  * Error outputs now include both an error code and message on a single line to improve troubleshooting and automated parsing.
  * Removed trailing newline from error messages to prevent extra blank lines and parsing mismatches in logs/tools.
  * No changes to transaction flow or status checks; only the observable error output format was updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->