### PR TITLE
Update Dockerfile go version to `1.25`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # BUILD BIN
 
-FROM golang:1.23 as app-builder
+FROM golang:1.25 as app-builder
 
 # Build the app binary in /app
 WORKDIR /app


### PR DESCRIPTION
## Description

The go version was updated to `1.25` in the `go.mod` file, so we need to update the Dockerfile version as well.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the build environment to Go 1.25. Users may notice more consistent builds, compatibility with newer tooling, and potential performance improvements during build and CI processes. No functional changes to application behavior are expected. No action required; existing workflows and deployments should continue to operate as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->