### PR TITLE
Check the returned error code on empty revert data

### DIFF
--- a/tests/web3js/eth_deploy_contract_and_interact_test.js
+++ b/tests/web3js/eth_deploy_contract_and_interact_test.js
@@ -221,6 +221,7 @@ it('deploy contract and interact', async () => {
             gas: 1_000_000,
             gasPrice: conf.minGasPrice
         })
+        assert.fail('expected eth_estimateGas to revert with empty revert data')
     } catch (error) {
         assert.equal(error.innerError.code, 3)
         assert.equal(error.innerError.data, '0x')
@@ -237,6 +238,7 @@ it('deploy contract and interact', async () => {
             gas: 1_000_000,
             gasPrice: conf.minGasPrice
         })
+        assert.fail('expected eth_call to revert with empty revert data')
     } catch (error) {
         assert.equal(error.innerError.code, 3)
         assert.equal(error.innerError.data, '0x')


### PR DESCRIPTION
Work towards: https://github.com/onflow/flow-evm-gateway/issues/840

## Description

Make sure that we return the proper error code for contract calls / gas estimations that revert without any explicit revert reason.

Ref: https://github.com/ethereum/go-ethereum/pull/31456

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded tests for gas estimation and eth_call across block heights (contract absent vs present), covering empty-revert handling, expected error codes/messages and gas values; preserves state-overrides and flow integration.
  * Added call-tracing scenarios validating trace outputs for empty and non-empty reverts, including gas, failure flags, return values, and trace log sizing to ensure deterministic traces.
* **Chores**
  * No changes to public APIs; improves test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->