### PR TITLE
Deprecate `--init-cadence-height` CLI flag

### DIFF
--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -170,21 +170,16 @@ func parseConfigFromFlags() error {
 	case "flow-testnet":
 		cfg.FlowNetworkID = flowGo.Testnet
 		cfg.EVMNetworkID = types.FlowEVMTestNetChainID
-		cfg.InitCadenceHeight = config.LiveNetworkInitCadenceHeight
+		cfg.InitCadenceHeight = config.TestnetInitCadenceHeight
 	case "flow-mainnet":
 		cfg.FlowNetworkID = flowGo.Mainnet
 		cfg.EVMNetworkID = types.FlowEVMMainNetChainID
-		cfg.InitCadenceHeight = config.LiveNetworkInitCadenceHeight
+		cfg.InitCadenceHeight = config.MainnetInitCadenceHeight
 	default:
 		return fmt.Errorf(
 			"flow network ID: %s not supported, valid values are ('flow-emulator', 'flow-previewnet', 'flow-testnet', 'flow-mainnet')",
 			flowNetwork,
 		)
-	}
-
-	// if a specific value was provided use it
-	if initHeight != 0 {
-		cfg.InitCadenceHeight = initHeight
 	}
 
 	// configure logging
@@ -296,4 +291,9 @@ func init() {
 	Cmd.Flags().BoolVar(&cfg.TxBatchMode, "tx-batch-mode", false, "Enable batch transaction submission, to avoid nonce mismatch issues for high-volume EOAs.")
 	Cmd.Flags().DurationVar(&cfg.TxBatchInterval, "tx-batch-interval", time.Millisecond*1200, "Time interval upon which to submit the transaction batches to the Flow network.")
 	Cmd.Flags().DurationVar(&cfg.EOAActivityCacheTTL, "eoa-activity-cache-ttl", time.Second*10, "Time interval used to track EOA activity. Tx send more frequently than this interval will be batched. Useful only when batch transaction submission is enabled.")
+
+	err := Cmd.Flags().MarkDeprecated("init-cadence-height", "This flag is no longer necessary and will be removed in future version. The initial Cadence height is known for testnet/mainnet and this was only required for fresh deployments of EVM Gateway. Once the DB has been initialized, the latest index Cadence height will be used upon start-up.")
+	if err != nil {
+		panic(err)
+	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -14,14 +14,24 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// Default InitCadenceHeight for initializing the database on a local emulator.
-// TODO: temporary fix until https://github.com/onflow/flow-go/issues/5481 is
-// fixed upstream and released.
-const EmulatorInitCadenceHeight = uint64(0)
+const (
+	// Default InitCadenceHeight for initializing the database on a local emulator.
+	// TODO: temporary fix until https://github.com/onflow/flow-go/issues/5481 is
+	// fixed upstream and released.
+	EmulatorInitCadenceHeight = uint64(0)
 
-// Default InitCadenceHeight for initializing the database on a live network.
-// We don't use 0 as it has a special meaning to represent latest block in the AN API context.
-const LiveNetworkInitCadenceHeight = uint64(1)
+	// Default InitCadenceHeight for initializing the database on a live network.
+	// We don't use 0 as it has a special meaning to represent latest block in the AN API context.
+	LiveNetworkInitCadenceHeight = uint64(1)
+
+	// Testnet height at which the `EVM` system contract was first deployed.
+	// This is the first height at which the EVM state starts.
+	TestnetInitCadenceHeight = uint64(211176670)
+
+	// Mainnet height at which the `EVM` system contract was first deployed.
+	// This is the first height at which the EVM state starts.
+	MainnetInitCadenceHeight = uint64(85981134)
+)
 
 type TxStateValidation string
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/885

## Description

This flag is unnecessary and it was causing confusion to EVM Gateway node operators.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Network-specific default initial Cadence heights for mainnet and testnet, improving out-of-the-box behavior; previewnet and emulator remain unchanged.

- Chores
  - Deprecated the init-cadence-height CLI flag; manual overrides are now ignored.
  - Added a startup deprecation notice with guidance; the flag will be removed in a future release.
  - No public API signature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->