### PR TITLE
Track the latest finalized block header for tx submission

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -253,8 +253,9 @@ func (b *Bootstrap) StartAPIServer(ctx context.Context) error {
 
 	// create transaction pool
 	var txPool requester.TxPool
+	var err error
 	if b.config.TxBatchMode {
-		txPool = requester.NewBatchTxPool(
+		txPool, err = requester.NewBatchTxPool(
 			ctx,
 			b.client,
 			b.publishers.Transaction,
@@ -264,7 +265,8 @@ func (b *Bootstrap) StartAPIServer(ctx context.Context) error {
 			b.keystore,
 		)
 	} else {
-		txPool = requester.NewSingleTxPool(
+		txPool, err = requester.NewSingleTxPool(
+			ctx,
 			b.client,
 			b.publishers.Transaction,
 			b.logger,
@@ -272,6 +274,9 @@ func (b *Bootstrap) StartAPIServer(ctx context.Context) error {
 			b.collector,
 			b.keystore,
 		)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create transaction pool: %w", err)
 	}
 
 	evm, err := requester.NewEVM(

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -57,11 +57,12 @@ func NewBatchTxPool(
 	config config.Config,
 	collector metrics.Collector,
 	keystore *keystore.KeyStore,
-) *BatchTxPool {
+) (*BatchTxPool, error) {
 	// initialize the available keys metric since it is only updated when sending a tx
 	collector.AvailableSigningKeys(keystore.AvailableKeys())
 
-	singleTxPool := NewSingleTxPool(
+	singleTxPool, err := NewSingleTxPool(
+		ctx,
 		client,
 		transactionsPublisher,
 		logger,
@@ -69,6 +70,9 @@ func NewBatchTxPool(
 		collector,
 		keystore,
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	eoaActivity := expirable.NewLRU[gethCommon.Address, time.Time](
 		eoaActivityCacheSize,
@@ -84,7 +88,7 @@ func NewBatchTxPool(
 
 	go batchPool.processPooledTransactions(ctx)
 
-	return batchPool
+	return batchPool, nil
 }
 
 // Add adds the EVM transaction to the tx pool, grouped with the rest of the
@@ -161,14 +165,6 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			latestBlock, err := t.client.GetLatestBlock(ctx, true)
-			if err != nil {
-				t.logger.Error().Err(err).Msg(
-					"failed to get latest Flow block on batch tx submission",
-				)
-				continue
-			}
-
 			// Take a copy here to allow `Add()` to continue accept
 			// incoming EVM transactions, without blocking until the
 			// batch transactions are submitted.
@@ -180,7 +176,7 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 			for address, pooledTxs := range txsGroupedByAddress {
 				err := t.batchSubmitTransactionsForSameAddress(
 					ctx,
-					latestBlock,
+					t.getReferenceBlock(),
 					pooledTxs,
 				)
 				if err != nil {
@@ -197,7 +193,7 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 
 func (t *BatchTxPool) batchSubmitTransactionsForSameAddress(
 	ctx context.Context,
-	latestBlock *flow.Block,
+	referenceBlockHeader *flow.BlockHeader,
 	pooledTxs []pooledEvmTx,
 ) error {
 	// Sort the transactions based on their nonce, to make sure
@@ -219,7 +215,7 @@ func (t *BatchTxPool) batchSubmitTransactionsForSameAddress(
 	script := replaceAddresses(runTxScript, t.config.FlowNetworkID)
 	flowTx, err := t.buildTransaction(
 		ctx,
-		latestBlock,
+		referenceBlockHeader,
 		script,
 		cadence.NewArray(hexEncodedTxs),
 		coinbaseAddress,
@@ -242,11 +238,6 @@ func (t *BatchTxPool) submitSingleTransaction(
 	ctx context.Context,
 	hexEncodedTx cadence.String,
 ) error {
-	latestBlock, err := t.client.GetLatestBlock(ctx, true)
-	if err != nil {
-		return err
-	}
-
 	coinbaseAddress, err := cadence.NewString(t.config.Coinbase.Hex())
 	if err != nil {
 		return err
@@ -255,7 +246,7 @@ func (t *BatchTxPool) submitSingleTransaction(
 	script := replaceAddresses(runTxScript, t.config.FlowNetworkID)
 	flowTx, err := t.buildTransaction(
 		ctx,
-		latestBlock,
+		t.getReferenceBlock(),
 		script,
 		cadence.NewArray([]cadence.Value{hexEncodedTx}),
 		coinbaseAddress,

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -90,7 +90,7 @@ func startEmulator(createTestAccounts bool) (*server.EmulatorServer, error) {
 		GenesisTokenSupply:     genesisToken,
 		WithContracts:          true,
 		Host:                   "localhost",
-		TransactionExpiry:      10,
+		TransactionExpiry:      flow.DefaultTransactionExpiry,
 		TransactionMaxGasLimit: flow.DefaultMaxTransactionGasLimit,
 		SetupEVMEnabled:        true,
 		SetupVMBridgeEnabled:   true,


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/895

## Description

For every tx submission, we used to fetch the latest block, as well as the COA account.
This meant that we needed 2 AN calls for each tx submission.
Now we have a ticker which tracks the latest finalized block header, which is mainly used for setting the proper Reference Block ID, when preparing the Cadence tx for submission.
Later on, we plan to remove the COA account fetching as well.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - API server now halts and reports errors when transaction-pool creation fails.
  - Transaction submission error handling improved to avoid failures from stale or missing reference data.

- New Features
  - Background updater keeps an up-to-date Flow block header for transaction construction.

- Refactor
  - Initialization flow updated to consistently propagate transaction-pool creation errors.

- Tests
  - Emulator transaction expiry aligned to Flow’s default for more realistic testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->