### PR TITLE
Relax log-level on `processLockedKeys()` for tx results

### DIFF
--- a/services/requester/keystore/key_store.go
+++ b/services/requester/keystore/key_store.go
@@ -211,9 +211,9 @@ func (k *KeyStore) processLockedKeys(ctx context.Context) {
 			if k.config.COATxLookupEnabled {
 				txResults, err = k.client.GetTransactionResultsByBlockID(ctx, blockHeader.ID)
 				if err != nil && status.Code(err) != codes.Canceled {
-					k.logger.Error().Err(err).Msgf(
-						"failed to get transaction results for block ID: %s",
-						blockHeader.ID.Hex(),
+					k.logger.Warn().Msgf(
+						"failed to get transaction results: %v",
+						err,
 					)
 					continue
 				}


### PR DESCRIPTION
## Description

The previous `ERR` log-level, created unnecessary noise on Grafana panels, as this behavior is not really an error. It might happen because we requested the tx results on a given block, too fast, or the AN hasn't finished indexing them. In any case, this is not critical.
Changed the log-level to `WARN`.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Reduced log severity for certain transient lookup errors from Error to Warning to reduce operational noise.
  - Simplified log text to report the error value directly and removed redundant identifiers to make logs easier to scan.
  - No behavior change: processing continues unchanged when these transient errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->