### PR TITLE
Allow timeout configuration for JSON-RPC requests

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -189,7 +189,9 @@ func (h *Server) Start() error {
 		CheckTimeouts(h.logger, &h.timeouts)
 		h.server.ReadTimeout = h.timeouts.ReadTimeout
 		h.server.ReadHeaderTimeout = h.timeouts.ReadHeaderTimeout
-		h.server.WriteTimeout = h.timeouts.WriteTimeout
+		// WriteTimeout is the maximum duration before timing out
+		// writes of the response, a.k.a JSON-RPC request timeout.
+		h.server.WriteTimeout = h.config.RpcRequestTimeout
 		h.server.IdleTimeout = h.timeouts.IdleTimeout
 	}
 

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -291,6 +291,7 @@ func init() {
 	Cmd.Flags().BoolVar(&cfg.TxBatchMode, "tx-batch-mode", false, "Enable batch transaction submission, to avoid nonce mismatch issues for high-volume EOAs.")
 	Cmd.Flags().DurationVar(&cfg.TxBatchInterval, "tx-batch-interval", time.Millisecond*1200, "Time interval upon which to submit the transaction batches to the Flow network.")
 	Cmd.Flags().DurationVar(&cfg.EOAActivityCacheTTL, "eoa-activity-cache-ttl", time.Second*10, "Time interval used to track EOA activity. Tx send more frequently than this interval will be batched. Useful only when batch transaction submission is enabled.")
+	Cmd.Flags().DurationVar(&cfg.RpcRequestTimeout, "rpc-request-timeout", time.Second*120, "Sets the maximum duration at which JSON-RPC requests should generate a response, before they timeout. The default is 120 seconds.")
 
 	err := Cmd.Flags().MarkDeprecated("init-cadence-height", "This flag is no longer necessary and will be removed in future version. The initial Cadence height is known for testnet/mainnet and this was only required for fresh deployments of EVM Gateway. Once the DB has been initialized, the latest index Cadence height will be used upon start-up.")
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -124,4 +124,7 @@ type Config struct {
 	// frequently than this interval will be batched.
 	// Useful only when batch transaction submission is enabled.
 	EOAActivityCacheTTL time.Duration
+	// RpcRequestTimeout is the maximum duration at which JSON-RPC requests should generate
+	// a response, before they timeout.
+	RpcRequestTimeout time.Duration
 }


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/723

## Description

Currently, the request timeout is hard-coded to `30` seconds, which is the default from Geth. However, for certain JSON-RPC calls, such as traces, we need a higher timeout. Setting the default to `120` seconds, and operators can tune this as they see fit.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable `--rpc-request-timeout` flag to control the maximum duration for RPC requests before timing out (default: 120 seconds), providing greater control over request handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->