### PR TITLE
Reject transactions that have already been submitted to the tx pool

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -29,9 +29,6 @@ func resolveBlockTag(
 	if number, ok := blockNumberOrHash.Number(); ok {
 		height, err := resolveBlockNumber(number, blocksDB)
 		if err != nil {
-			logger.Error().Err(err).
-				Stringer("block_number", number).
-				Msg("failed to resolve block by number")
 			return 0, err
 		}
 		return height, nil
@@ -40,9 +37,6 @@ func resolveBlockTag(
 	if hash, ok := blockNumberOrHash.Hash(); ok {
 		height, err := blocksDB.GetHeightByID(hash)
 		if err != nil {
-			logger.Error().Err(err).
-				Stringer("block_hash", hash).
-				Msg("failed to resolve block by hash")
 			return 0, err
 		}
 		return height, nil

--- a/models/errors/errors.go
+++ b/models/errors/errors.go
@@ -28,9 +28,8 @@ var (
 
 	// Transaction errors
 
-	ErrFailedTransaction    = errors.New("failed transaction")
-	ErrInvalidTransaction   = fmt.Errorf("%w: %w", ErrInvalid, ErrFailedTransaction)
-	ErrDuplicateTransaction = fmt.Errorf("%w: %s", ErrInvalid, "transaction already in pool")
+	ErrFailedTransaction  = errors.New("failed transaction")
+	ErrInvalidTransaction = fmt.Errorf("%w: %w", ErrInvalid, ErrFailedTransaction)
 
 	// Storage errors
 

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -287,9 +287,9 @@ func (t *BatchTxPool) submitSingleTransaction(
 	done := make(chan struct{})
 	var submitError error
 
-	// This method is called while holding the `t.txMux` lock,
-	// don't let it run for a long time, to avoid lock-contention
-	ctx, cancel := context.WithTimeout(ctx, time.Second*3)
+	// This method is called while holding the `t.txMux` lock.
+	// Do not let it run for a long time, to avoid lock-contention.
+	ctx, cancel := context.WithTimeout(ctx, time.Second*4)
 	defer cancel()
 
 	// build & submit transaction

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -194,11 +194,11 @@ func (t *BatchTxPool) Add(
 	}
 
 	if err != nil {
-		t.txMux.Lock()
 		// If there was an error during tx submission, remove the entry
 		// from the cache, to not block future requests with same nonce.
+		// Note: No need to acquire the `t.txMux` lock, `Remove` already
+		// has an internal lock.
 		t.eoaActivityCache.Remove(from)
-		t.txMux.Unlock()
 
 		t.logger.Error().Err(err).Msgf(
 			"failed to submit single Flow transaction for EOA: %s",

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -289,6 +289,8 @@ func (t *BatchTxPool) submitSingleTransaction(
 
 	// This method is called while holding the `t.txMux` lock.
 	// Do not let it run for a long time, to avoid lock-contention.
+	// The 4-second timeout provides a 1-second buffer on top of ANs
+	// 3-second timeout for LN requests.
 	ctx, cancel := context.WithTimeout(ctx, time.Second*4)
 	defer cancel()
 

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -191,7 +191,11 @@ func (t *BatchTxPool) Add(
 		return err
 	}
 
+	t.txMux.Lock()
+	defer t.txMux.Unlock()
+
 	// Update metadata for the last EOA activity only on successful add/submit.
+	eoaActivity, _ = t.eoaActivityCache.Get(from)
 	eoaActivity.lastSubmission = time.Now()
 	eoaActivity.txNonces = append(eoaActivity.txNonces, nonce)
 	// To avoid the slice of nonces from growing indefinitely,

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -192,9 +192,10 @@ func (t *BatchTxPool) Add(
 	eoaActivity.lastSubmission = time.Now()
 	eoaActivity.txNonces = append(eoaActivity.txNonces, nonce)
 	// To avoid the slice of nonces from growing indefinitely,
-	// maintain only a handful of the last tx nonces.
+	// keep only the last `maxTrackedTxNoncesPerEOA` nonces.
 	if len(eoaActivity.txNonces) > maxTrackedTxNoncesPerEOA {
-		eoaActivity.txNonces = eoaActivity.txNonces[1:]
+		firstKeep := len(eoaActivity.txNonces) - maxTrackedTxNoncesPerEOA
+		eoaActivity.txNonces = eoaActivity.txNonces[firstKeep:]
 	}
 
 	t.eoaActivityCache.Add(from, eoaActivity)

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -302,11 +302,9 @@ func (t *BatchTxPool) submitSingleTransaction(
 	done := make(chan struct{})
 	var submitError error
 
-	// This method is called while holding the `t.txMux` lock.
-	// Do not let it run for a long time, to avoid lock-contention.
-	// The 4-second timeout provides a 1-second buffer on top of ANs
+	// The 5-second timeout provides a 2-second buffer on top of ANs
 	// 3-second timeout for LN requests.
-	ctx, cancel := context.WithTimeout(ctx, time.Second*4)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 
 	// Build & submit the transaction, in a separate goroutine. The AN calls
@@ -314,8 +312,7 @@ func (t *BatchTxPool) submitSingleTransaction(
 	// long as is necessary for their completion.
 	// `context.WithTimeout` arranges for Done to be closed when the specified
 	// timeout elapses, and at that point we return an error to abort the
-	// transaction submission, and release the `t.txMux` lock for the next
-	// requests.
+	// transaction submission.
 	go func() {
 		defer close(done)
 

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -191,21 +191,7 @@ func (t *BatchTxPool) Add(
 		return err
 	}
 
-	t.txMux.Lock()
-	defer t.txMux.Unlock()
-
-	// Update metadata for the last EOA activity only on successful add/submit.
-	eoaActivity, _ = t.eoaActivityCache.Get(from)
-	eoaActivity.lastSubmission = time.Now()
-	eoaActivity.txNonces = append(eoaActivity.txNonces, nonce)
-	// To avoid the slice of nonces from growing indefinitely,
-	// keep only the last `maxTrackedTxNoncesPerEOA` nonces.
-	if len(eoaActivity.txNonces) > maxTrackedTxNoncesPerEOA {
-		firstKeep := len(eoaActivity.txNonces) - maxTrackedTxNoncesPerEOA
-		eoaActivity.txNonces = eoaActivity.txNonces[firstKeep:]
-	}
-
-	t.eoaActivityCache.Add(from, eoaActivity)
+	t.updateEOAActivityMetadata(from, nonce)
 
 	return nil
 }
@@ -327,4 +313,25 @@ func (t *BatchTxPool) submitSingleTransaction(
 	}
 
 	return nil
+}
+
+func (t *BatchTxPool) updateEOAActivityMetadata(
+	from gethCommon.Address,
+	nonce uint64,
+) {
+	t.txMux.Lock()
+	defer t.txMux.Unlock()
+
+	// Update metadata for the last EOA activity only on successful add/submit.
+	eoaActivity, _ := t.eoaActivityCache.Get(from)
+	eoaActivity.lastSubmission = time.Now()
+	eoaActivity.txNonces = append(eoaActivity.txNonces, nonce)
+	// To avoid the slice of nonces from growing indefinitely,
+	// keep only the last `maxTrackedTxNoncesPerEOA` nonces.
+	if len(eoaActivity.txNonces) > maxTrackedTxNoncesPerEOA {
+		firstKeep := len(eoaActivity.txNonces) - maxTrackedTxNoncesPerEOA
+		eoaActivity.txNonces = eoaActivity.txNonces[firstKeep:]
+	}
+
+	t.eoaActivityCache.Add(from, eoaActivity)
 }

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -238,7 +238,11 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 						"failed to submit batch Flow transaction for EOA: %s",
 						address.Hex(),
 					)
-					continue
+					// In case of any error, add the transactions back to the pool,
+					// as a retry mechanism.
+					t.txMux.Lock()
+					t.pooledTxs[address] = append(t.pooledTxs[address], pooledTxs...)
+					t.txMux.Unlock()
 				}
 			}
 		}

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -284,34 +284,56 @@ func (t *BatchTxPool) submitSingleTransaction(
 	ctx context.Context,
 	hexEncodedTx cadence.String,
 ) error {
-	coinbaseAddress, err := cadence.NewString(t.config.Coinbase.Hex())
-	if err != nil {
-		return err
+	done := make(chan struct{})
+	var submitError error
+
+	// This method is called while holding the `t.txMux` lock,
+	// don't let it run for a long time, to avoid lock-contention
+	ctx, cancel := context.WithTimeout(ctx, time.Second*3)
+	defer cancel()
+
+	// build & submit transaction
+	go func() {
+		defer close(done)
+
+		coinbaseAddress, err := cadence.NewString(t.config.Coinbase.Hex())
+		if err != nil {
+			submitError = err
+			return
+		}
+
+		script := replaceAddresses(runTxScript, t.config.FlowNetworkID)
+		flowTx, err := t.buildTransaction(
+			ctx,
+			t.getReferenceBlock(),
+			script,
+			cadence.NewArray([]cadence.Value{hexEncodedTx}),
+			coinbaseAddress,
+		)
+		if err != nil {
+			// If there was any error during the transaction build
+			// process, we record it as a dropped transaction.
+			t.collector.TransactionsDropped(1)
+			submitError = err
+			return
+		}
+
+		if err := t.client.SendTransaction(ctx, *flowTx); err != nil {
+			// If there was any error while sending the transaction,
+			// we record it as a dropped transaction.
+			t.collector.TransactionsDropped(1)
+			submitError = err
+			return
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-done:
 	}
 
-	script := replaceAddresses(runTxScript, t.config.FlowNetworkID)
-	flowTx, err := t.buildTransaction(
-		ctx,
-		t.getReferenceBlock(),
-		script,
-		cadence.NewArray([]cadence.Value{hexEncodedTx}),
-		coinbaseAddress,
-	)
-	if err != nil {
-		// If there was any error during the transaction build
-		// process, we record it as a dropped transaction.
-		t.collector.TransactionsDropped(1)
-		return err
-	}
-
-	if err := t.client.SendTransaction(ctx, *flowTx); err != nil {
-		// If there was any error while sending the transaction,
-		// we record it as a dropped transaction.
-		t.collector.TransactionsDropped(1)
-		return err
-	}
-
-	return nil
+	return submitError
 }
 
 func (t *BatchTxPool) updateEOAActivityMetadata(

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	eoaActivityCacheSize     = 10_000
-	maxTrackedTxNoncesPerEOA = 15
+	maxTrackedTxNoncesPerEOA = 30
 )
 
 type pooledEvmTx struct {

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -292,7 +292,13 @@ func (t *BatchTxPool) submitSingleTransaction(
 	ctx, cancel := context.WithTimeout(ctx, time.Second*4)
 	defer cancel()
 
-	// build & submit transaction
+	// Build & submit the transaction, in a separate goroutine. The AN calls
+	// do not respect the `context.WithTimeout` deadline, and can run for as
+	// long as is necessary for their completion.
+	// `context.WithTimeout` arranges for Done to be closed when the specified
+	// timeout elapses, and at that point we return an error to abort the
+	// transaction submission, and release the `t.txMux` lock for the next
+	// requests.
 	go func() {
 		defer close(done)
 

--- a/services/requester/requester.go
+++ b/services/requester/requester.go
@@ -238,7 +238,7 @@ func (e *EVM) SendRawTransaction(ctx context.Context, data []byte) (common.Hash,
 	}
 
 	e.logger.Info().
-		Str("evm-id", tx.Hash().Hex()).
+		Str("evm_tx", tx.Hash().Hex()).
 		Str("to", to).
 		Str("from", from.Hex()).
 		Str("value", tx.Value().String()).

--- a/services/requester/single_tx_pool.go
+++ b/services/requester/single_tx_pool.go
@@ -149,8 +149,8 @@ func (t *SingleTxPool) Add(
 				}
 
 				t.logger.Error().Err(res.Error).
-					Str("flow-id", flowTx.ID().String()).
-					Str("evm-id", tx.Hash().Hex()).
+					Str("flow_tx", flowTx.ID().String()).
+					Str("evm_tx", tx.Hash().Hex()).
 					Msg("flow transaction error")
 
 				// hide specific cause since it's an implementation issue

--- a/services/requester/single_tx_pool.go
+++ b/services/requester/single_tx_pool.go
@@ -95,6 +95,11 @@ func (t *SingleTxPool) Add(
 ) error {
 	t.txPublisher.Publish(tx) // publish pending transaction event
 
+	from, err := models.DeriveTxSender(tx)
+	if err != nil {
+		return err
+	}
+
 	txData, err := tx.MarshalBinary()
 	if err != nil {
 		return err
@@ -120,10 +125,21 @@ func (t *SingleTxPool) Add(
 		// If there was any error during the transaction build
 		// process, we record it as a dropped transaction.
 		t.collector.TransactionsDropped(1)
+		t.logger.Error().Err(err).Msgf(
+			"failed to build Flow transaction for EOA: %s",
+			from.Hex(),
+		)
 		return err
 	}
 
 	if err := t.client.SendTransaction(ctx, *flowTx); err != nil {
+		// If there was any error while sending the transaction,
+		// we record it as a dropped transaction.
+		t.collector.TransactionsDropped(1)
+		t.logger.Error().Err(err).Msgf(
+			"failed to submit Flow transaction for EOA: %s",
+			from.Hex(),
+		)
 		return err
 	}
 

--- a/tests/tx_batching_test.go
+++ b/tests/tx_batching_test.go
@@ -547,12 +547,12 @@ func Test_TransactionSubmissionWithPreviouslySubmittedTransactions(t *testing.T)
 	assert.ErrorContains(
 		t,
 		errors[0],
-		"a tx with hash 0x2bdf4aa4c3e273a624dddfdbde6614786b6a5329e246c531d3e0e9f92e79e04d has already been submitted",
+		"a tx with nonce 2 has already been submitted",
 	)
 	assert.ErrorContains(
 		t,
 		errors[1],
-		"a tx with hash 0xb72e1f83861a63b5ad4b927295af07fa9546b01aac5dfce046a5fb20f9be9f2f has already been submitted",
+		"a tx with nonce 3 has already been submitted",
 	)
 
 	assert.Eventually(t, func() bool {

--- a/tests/tx_batching_test.go
+++ b/tests/tx_batching_test.go
@@ -552,6 +552,9 @@ func Test_TransactionSubmissionWithPreviouslySubmittedTransactions(t *testing.T)
 		})
 	}
 
+	err = g.Wait()
+	require.NoError(t, err)
+
 	expectedBalance := big.NewInt(6 * transferAmount)
 
 	assert.Eventually(t, func() bool {


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/922

## Description

To avoid the noise from all the invalid transactions from trading bots, we keep track of the last 15 submitted transaction hashes, on a 10 second interval, with the aim to reject incoming transactions that match any of the tracked hashes.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switched duplicate detection to nonce-based per-account activity metadata for more reliable batching and deduplication.
  * Removed a previously exported duplicate-transaction error from the public surface.
  * Suppressed noisy logging when resolving block tags.

* **Refactor**
  * Simplified batching and single-submit flows and removed per-instance locking.
  * Standardized transaction log field names and adjusted batching submission behavior.

* **Tests**
  * Rewrote batching tests to submit multiple nonces in parallel, verify final balances, and updated timing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->