### PR TITLE
Add cache for get blocks by number

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -352,6 +352,7 @@ func (b *Bootstrap) StartAPIServer(ctx context.Context) error {
 		rateLimiter,
 		b.collector,
 		indexingResumedHeight,
+		b.config.BlockByNumberCacheSize,
 	)
 
 	streamAPI := api.NewStreamAPI(

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -300,6 +300,7 @@ func init() {
 	Cmd.Flags().BoolVar(&experimentalSealingVerificationEnabled, "experimental-sealing-verification-enabled", true, "Sets whether the gateway should use the experimental soft finality sealing verification feature. WARNING: This may result in indexing halts if events do not match. Use only if you know what you are doing.")
 	Cmd.Flags().DurationVar(&cfg.EOAActivityCacheTTL, "eoa-activity-cache-ttl", time.Second*10, "Time interval used to track EOA activity. Tx send more frequently than this interval will be batched. Useful only when batch transaction submission is enabled.")
 	Cmd.Flags().DurationVar(&cfg.RpcRequestTimeout, "rpc-request-timeout", time.Second*120, "Sets the maximum duration at which JSON-RPC requests should generate a response, before they timeout. The default is 120 seconds.")
+	Cmd.Flags().IntVar(&cfg.BlockByNumberCacheSize, "block-by-number-cache-size", 1000, "Number of block cache for getBlockByNumber API.")
 
 	err := Cmd.Flags().MarkDeprecated("init-cadence-height", "This flag is no longer necessary and will be removed in future version. The initial Cadence height is known for testnet/mainnet and this was only required for fresh deployments of EVM Gateway. Once the DB has been initialized, the latest index Cadence height will be used upon start-up.")
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -136,4 +136,6 @@ type Config struct {
 	// RpcRequestTimeout is the maximum duration at which JSON-RPC requests should generate
 	// a response, before they timeout.
 	RpcRequestTimeout time.Duration
+	// BlockByNumberCacheSize is the size of the block by number cache.
+	BlockByNumberCacheSize int
 }


### PR DESCRIPTION
This PR adds a simple cache for the response from `GetBlockByNumber`, which can be heavy when there are a lot of tx in a block