### PR TITLE
Emit `ApiErrorOccurred` metric for request timed out error

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -435,7 +435,10 @@ type responseHandler struct {
 	metrics     metrics.Collector
 }
 
-const errCodePanic = -32603
+const (
+	errCodePanic   = -32603
+	errCodeTimeout = -32002
+)
 
 type jsonError struct {
 	Code    int    `json:"code"`
@@ -468,6 +471,11 @@ func (w *responseHandler) Write(data []byte) (int, error) {
 	// handle possible panics inside endpoints
 	if message.Error != nil && message.Error.Code == errCodePanic {
 		w.metrics.ServerPanicked(message.Error.Message)
+	}
+
+	// handle possible request timeouts
+	if message.Error != nil && message.Error.Code == errCodeTimeout {
+		w.metrics.ApiErrorOccurred()
 	}
 
 	// It's an error response and requires special treatment.


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/931

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and monitoring for timeout scenarios in the API server. Enhanced tracking of timeout-related errors provides better visibility into system performance and reliability issues. These changes enable faster identification and resolution of timeout-related problems, helping maintain optimal API availability and performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->