### PR TITLE
Optimize performance of endpoints dealing with receipts

### DIFF
--- a/api/pull.go
+++ b/api/pull.go
@@ -456,12 +456,13 @@ func (api *PullAPI) getTransactions(latestHeight uint64, filter *transactionsFil
 			return nil, err
 		}
 
-		for _, h := range b.TransactionHashes {
-			tx, err := api.transactions.Get(h)
-			if err != nil {
-				return nil, err
-			}
-			receipt, err := api.receipts.GetByTransactionID(h)
+		receipts, err := api.receipts.GetByBlockHeight(b.Height)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, receipt := range receipts {
+			tx, err := api.transactions.Get(receipt.TxHash)
 			if err != nil {
 				return nil, err
 			}

--- a/services/evm/executor.go
+++ b/services/evm/executor.go
@@ -54,15 +54,11 @@ func NewBlockExecutor(
 
 func (s *BlockExecutor) Run(
 	tx models.Transaction,
+	receipt *models.Receipt,
 	tracer *tracers.Tracer,
 ) error {
 	l := s.logger.With().Str("tx-hash", tx.Hash().String()).Logger()
 	l.Info().Msg("executing new transaction")
-
-	receipt, err := s.receipts.GetByTransactionID(tx.Hash())
-	if err != nil {
-		return err
-	}
 
 	ctx, err := s.blockContext(receipt, tracer)
 	if err != nil {


### PR DESCRIPTION
## Description

For any block-related endpoints that are fetching receipts, use `GetByBlockHeight` instead of looping `GetByTransactionID`, avoid performing unnecessary DB calls.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 