### PR TITLE
Rework `BatchTxPool` functionality to a legitimate Ethereum tx mempool

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -287,6 +287,12 @@ func (b *Bootstrap) StartAPIServer(ctx context.Context) error {
 			nonceProvider,
 		)
 	} else if b.config.TxBatchMode {
+		nonceProvider := requester.NewLocalNonceProvider(
+			b.config.FlowNetworkID,
+			b.storages.Registers,
+			b.storages.Blocks,
+			b.collector,
+		)
 		txPool, err = requester.NewBatchTxPool(
 			ctx,
 			b.client,
@@ -295,6 +301,7 @@ func (b *Bootstrap) StartAPIServer(ctx context.Context) error {
 			b.config,
 			b.collector,
 			b.keystore,
+			nonceProvider,
 		)
 	} else {
 		txPool, err = requester.NewSingleTxPool(

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -281,6 +281,7 @@ var (
 	txStateValidation string
 	initHeight,
 	forceStartHeight uint64
+	eoaActivityCacheTTL time.Duration
 )
 
 func init() {
@@ -321,7 +322,7 @@ func init() {
 	Cmd.Flags().DurationVar(&cfg.TxRequestLimitDuration, "tx-request-limit-duration", time.Second*3, "Time interval upon which to enforce transaction submission rate limiting.")
 	Cmd.Flags().BoolVar(&cfg.TxBatchMode, "tx-batch-mode", false, "Enable batch transaction submission, to avoid nonce mismatch issues for high-volume EOAs.")
 	Cmd.Flags().DurationVar(&cfg.TxBatchInterval, "tx-batch-interval", time.Millisecond*1200, "Time interval upon which to submit the transaction batches to the Flow network.")
-	Cmd.Flags().DurationVar(&cfg.EOAActivityCacheTTL, "eoa-activity-cache-ttl", time.Second*10, "Time interval used to track EOA activity. Tx send more frequently than this interval will be batched. Useful only when batch transaction submission is enabled.")
+	Cmd.Flags().DurationVar(&eoaActivityCacheTTL, "eoa-activity-cache-ttl", time.Second*10, "Time interval used to track EOA activity. Tx send more frequently than this interval will be batched. Useful only when batch transaction submission is enabled.")
 	Cmd.Flags().BoolVar(&cfg.ExperimentalSoftFinalityEnabled, "experimental-soft-finality-enabled", false, "Sets whether the gateway should use the experimental soft finality feature. This results in faster indexing time, because EVM state is fetched from finalized, instead of sealed Flow blocks.")
 	Cmd.Flags().BoolVar(&cfg.ExperimentalSealingVerificationEnabled, "experimental-sealing-verification-enabled", false, "Sets whether the gateway should use the experimental soft finality sealing verification feature. This is an extra safety check for --experimental-soft-finality-enabled=true, which verifies that all finalized Flow blocks that were indexed, have eventually been sealed. The ingestion will halt, even if a single Flow block was not found to be sealed.")
 	Cmd.Flags().BoolVar(&cfg.TxMemPoolMode, "tx-mempool-mode", false, "Enable the transaction mempool: expected-nonce transactions are submitted immediately, out-of-order transactions are held until their nonce gap fills. Mutually exclusive with --tx-batch-mode and requires --tx-state-validation=local-index.")
@@ -333,6 +334,11 @@ func init() {
 	Cmd.Flags().DurationVar(&cfg.RpcRequestTimeout, "rpc-request-timeout", time.Second*120, "Sets the maximum duration at which JSON-RPC requests should generate a response, before they timeout. The default is 120 seconds.")
 
 	err := Cmd.Flags().MarkDeprecated("init-cadence-height", "This flag is no longer necessary and will be removed in future version. The initial Cadence height is known for testnet/mainnet and this was only required for fresh deployments of EVM Gateway. Once the DB has been initialized, the latest index Cadence height will be used upon start-up.")
+	if err != nil {
+		panic(err)
+	}
+
+	err = Cmd.Flags().MarkDeprecated("eoa-activity-cache-ttl", "This flag is no longer applicable and will be removed in future version. EOA activity is now preserved in a dedicated per-EOA queue, and not in a cache.")
 	if err != nil {
 		panic(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -120,10 +120,6 @@ type Config struct {
 	// TxBatchInterval is the time interval upon which to submit the transaction batches to the
 	// Flow network.
 	TxBatchInterval time.Duration
-	// EOAActivityCacheTTL is the time interval used to track EOA activity. Tx send more
-	// frequently than this interval will be batched.
-	// Useful only when batch transaction submission is enabled.
-	EOAActivityCacheTTL time.Duration
 	// ExperimentalSoftFinalityEnabled enables the experimental soft finality feature which syncs
 	// EVM block and transaction data from the upstream Access node before the block is sealed.
 	// CAUTION: This feature is experimental and may return incorrect data in certain circumstances.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/ethereum/go-ethereum v1.17.4
 	github.com/goccy/go-json v0.10.4
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/holiman/uint256 v1.3.2
 	github.com/onflow/atree v0.16.1
 	github.com/onflow/cadence v1.10.5
@@ -98,6 +97,7 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/huandu/go-clone v1.6.0 // indirect

--- a/models/errors/errors.go
+++ b/models/errors/errors.go
@@ -43,6 +43,9 @@ var (
 	// configured maximum gap ahead of the EOA's on-chain nonce. Such a tx cannot
 	// execute until the gap fills, so it is rejected up front for fast feedback.
 	ErrNonceTooHigh = fmt.Errorf("%w: %s", ErrInvalid, "nonce too high")
+	// ErrTxPoolFull is returned when the per-EOA pool has reached its size cap
+	// and cannot accept another transaction until existing ones drain.
+	ErrTxPoolFull = fmt.Errorf("%w: %s", ErrInvalid, "transaction pool is full for this account")
 
 	// Storage errors
 

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -523,6 +523,8 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 					}
 					t.collector.TxPoolSubmission(flushReasonPrefix)
 					t.logSubmission(address, batch.txs, flushReasonPrefix, flowTxID)
+					// reset submission failure retries on success
+					batch.eoaQueue.retries = 0
 				}
 				t.txQueuesMux.Unlock()
 			}

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -257,9 +257,15 @@ type pooledEvmTx struct {
 // batchSubmission is a batch selected for submission, detached from the queue so
 // the network call happens outside queueMux.
 type batchSubmission struct {
-	txs                []pooledEvmTx
-	eoaQueue           *txQueue
-	lastSubmittedAt    time.Time
+	txs      []pooledEvmTx
+	eoaQueue *txQueue
+	// lastSubmittedAt holds the value of `eoaQueue.lastSubmittedAt` at the time
+	// of batch selection. Used for reverting the queue's last submitted state
+	// for submission retries
+	lastSubmittedAt time.Time
+	// lastSubmittedNonce holds the value of `eoaQueue.lastSubmittedNonce` at the
+	// time of batch selection. Used for reverting the queue's last submitted state
+	// for submission retries
 	lastSubmittedNonce uint64
 }
 

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -48,6 +48,9 @@ const (
 	// How long the EOA queue holds an out-of-order transaction
 	// waiting for its nonce gap to fill, before dropping it.
 	maxQueueTTL = 30 * time.Second
+	// Max number of retries to perform on submission errors, such as
+	// networking issues etc.
+	maxSubmissionRetries = 5
 )
 
 // BatchTxPool is a TxPool implementation that collects and groups transactions
@@ -107,6 +110,9 @@ type txQueue struct {
 	// lastSubmittedNonce is the last EOA nonce that was submitted with a
 	// Cadence tx (used for classifying whether to queue or submit right away).
 	lastSubmittedNonce uint64
+	// retries is the total number of retries performed after submission errors,
+	// such as transient networking issues etc.
+	retries uint64
 }
 
 // size returns the total number of pooled transactions.
@@ -476,7 +482,17 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 					// Rollback the nonce range reservation from before — but only
 					// if a concurrent Add() has not already advanced past it via
 					// the fast path, otherwise we'd erase legitimate activity.
-					eoaQueue := t.eoaEnqueueTxs(address, batch.txs)
+					eoaQueue, ok := t.eoaEnqueueTxs(address, batch.txs)
+					if !ok {
+						t.logger.Warn().Err(err).Msgf(
+							"max number of retries reached for EOA: %s, batch count: %d, nonce: %d, tx hash: %s",
+							address.Hex(),
+							len(batch.txs),
+							batch.txs[0].nonce,
+							batch.txs[0].txHash.Hex(),
+						)
+						t.collector.TransactionsDropped(len(batch.txs))
+					}
 					if eoaQueue.lastSubmittedNonce == batch.txs[len(batch.txs)-1].nonce {
 						eoaQueue.lastSubmittedNonce = batch.lastSubmittedNonce
 						eoaQueue.lastSubmittedAt = batch.lastSubmittedAt
@@ -598,15 +614,24 @@ func (t *BatchTxPool) eoaQueueEntry(address gethCommon.Address) *txQueue {
 // nonce entry already in the queue is preserved: a concurrent Add() may have
 // dropped a fresher payload there while we were off-lock, and last-write-wins
 // for the client means the fresh payload must win over the failed batch.
-func (t *BatchTxPool) eoaEnqueueTxs(address gethCommon.Address, txs []pooledEvmTx) *txQueue {
+// Up to `maxSubmissionRetries` are allowed and a boolean value is returned to
+// denote enqueue failure.
+func (t *BatchTxPool) eoaEnqueueTxs(
+	address gethCommon.Address,
+	txs []pooledEvmTx,
+) (*txQueue, bool) {
 	queue := t.eoaQueueEntry(address)
+	if queue.retries >= maxSubmissionRetries {
+		return nil, false
+	}
 	for _, tx := range txs {
 		if _, exists := queue.txs[tx.nonce]; exists {
 			continue
 		}
 		queue.txs[tx.nonce] = tx
 	}
-	return queue
+	queue.retries += 1
+	return queue, true
 }
 
 // logSubmission records the fate of a submitted batch so a transaction is

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -119,14 +119,9 @@ func (t *txQueue) spacingElapsed(now time.Time, spacing time.Duration) bool {
 // is stale and could be removed from the mempool queue, to avoid memory
 // growth. If there are no pooled transactions and the last submission was
 // 2 times more than the given spacing interval, we can safely remove this
-// entry. A zero-value lastSubmittedAt (no submission has happened yet) is
-// treated as not-stale so a freshly-created queue is never harvested before
-// it has a chance to submit.
+// entry.
 func (t *txQueue) staleEntry(now time.Time, spacing time.Duration) bool {
-	if len(t.txs) != 0 || t.lastSubmittedAt.IsZero() {
-		return false
-	}
-	return now.Sub(t.lastSubmittedAt) >= (spacing * stalenessFactor)
+	return len(t.txs) == 0 && now.Sub(t.lastSubmittedAt) >= (spacing*stalenessFactor)
 }
 
 // validNonce compares the transaction nonce with the nonce from the local

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -45,6 +45,9 @@ const (
 	// gives an indication that an EOA queue is stale and could be
 	// removed, to avoid unconstrained memory growth.
 	stalenessFactor = 2
+	// How long the EOA queue holds an out-of-order transaction
+	// waiting for its nonce gap to fill, before dropping it.
+	maxQueueTTL = 30 * time.Second
 )
 
 // BatchTxPool is a TxPool implementation that collects and groups transactions
@@ -148,10 +151,11 @@ func (t *txQueue) validNonce(
 }
 
 // pruneTxs drops pooled transactions that can never be submitted from this
-// queue: nonces below the on-chain frontier (already used), and nonces further
+// queue: nonces below the on-chain frontier (already used), nonces further
 // than `maxNonceLookahead` beyond the frontier (unreachable within any
-// realistic gap-fill window). The absolute queue-length cap is enforced at
-// admission time in Add() — this pass only prunes; it does not size-cap.
+// realistic gap-fill window) and transactions that have exceeded the queue
+// TTL. The absolute queue-length cap is enforced at admission time in Add(),
+// this pass only prunes; it does not size-cap.
 func (t *txQueue) pruneTxs(
 	address gethCommon.Address,
 	stateNonce uint64,
@@ -167,6 +171,17 @@ func (t *txQueue) pruneTxs(
 				tx.nonce,
 				address,
 				stateNonce,
+			)
+			staleNonces = append(staleNonces, nonce)
+			continue
+		}
+
+		// drop any pooled transactions that have exceeded the pool TTL
+		if time.Since(tx.enqueuedAt) >= maxQueueTTL {
+			logger.Warn().Msgf(
+				"dropped tx with nonce: %d for EOA: %s, exceeds pool TTL",
+				tx.nonce,
+				address,
 			)
 			staleNonces = append(staleNonces, nonce)
 			continue
@@ -217,9 +232,10 @@ func (t *txQueue) selectSequentialNonces(stateNonce uint64) []pooledEvmTx {
 // pooledEvmTx is a transaction queued in the mempool, waiting for the
 // batch interval to elapse or its nonce gap to be filled.
 type pooledEvmTx struct {
-	txPayload cadence.String
-	txHash    gethCommon.Hash
-	nonce     uint64
+	txPayload  cadence.String
+	txHash     gethCommon.Hash
+	nonce      uint64
+	enqueuedAt time.Time
 }
 
 // batchSubmission is a batch selected for submission, detached from the queue so
@@ -312,7 +328,12 @@ func (t *BatchTxPool) Add(
 		return errs.ErrInFlightNonce
 	}
 
-	userTx := pooledEvmTx{txPayload: hexEncodedTx, txHash: tx.Hash(), nonce: tx.Nonce()}
+	userTx := pooledEvmTx{
+		txPayload:  hexEncodedTx,
+		txHash:     tx.Hash(),
+		nonce:      tx.Nonce(),
+		enqueuedAt: time.Now(),
+	}
 	// get the latest nonce from the local state index
 	nonce, err := t.nonceProvider.GetNextNonce(from)
 	if err != nil {

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -577,20 +577,13 @@ func (t *BatchTxPool) eoaQueueEntry(address gethCommon.Address) *txQueue {
 // dropped a fresher payload there while we were off-lock, and last-write-wins
 // for the client means the fresh payload must win over the failed batch.
 func (t *BatchTxPool) eoaEnqueueTxs(address gethCommon.Address, txs []pooledEvmTx) *txQueue {
-	queue, ok := t.txQueues[address]
-	if !ok {
-		queue = &txQueue{
-			txs: make(map[uint64]pooledEvmTx),
-		}
-		t.txQueues[address] = queue
-	}
+	queue := t.eoaQueueEntry(address)
 	for _, tx := range txs {
 		if _, exists := queue.txs[tx.nonce]; exists {
 			continue
 		}
 		queue.txs[tx.nonce] = tx
 	}
-
 	return queue
 }
 

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -96,6 +96,16 @@ type BatchTxPool struct {
 	nonceProvider NonceProvider
 	txQueues      map[gethCommon.Address]*txQueue
 	txQueuesMux   sync.Mutex
+
+	// submitBatch exists as a field so tests can inject a fake. It returns the
+	// ID of the wrapping Cadence transaction (zero on early build failure
+	// before a Flow tx is signed) so logSubmission can record it, letting an
+	// operator correlate a wedged EVM nonce to the specific Cadence tx.
+	submitBatch func(
+		ctx context.Context,
+		block *flow.BlockHeader,
+		txs []pooledEvmTx,
+	) (flow.Identifier, error)
 }
 
 // txQueue tracks the pooled transactions and submission state for one EOA.
@@ -287,6 +297,7 @@ func NewBatchTxPool(
 		txQueues:      make(map[gethCommon.Address]*txQueue),
 		txQueuesMux:   sync.Mutex{},
 	}
+	batchPool.submitBatch = batchPool.batchSubmitTransactionsForSameAddress
 
 	go batchPool.processPooledTransactions(ctx)
 
@@ -462,7 +473,7 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 			t.txQueuesMux.Unlock()
 
 			for address, batch := range txBatchByAddress {
-				flowTxID, err := t.batchSubmitTransactionsForSameAddress(
+				flowTxID, err := t.submitBatch(
 					ctx,
 					t.getReferenceBlock(),
 					batch.txs,
@@ -622,7 +633,7 @@ func (t *BatchTxPool) eoaEnqueueTxs(
 ) (*txQueue, bool) {
 	queue := t.eoaQueueEntry(address)
 	if queue.retries >= maxSubmissionRetries {
-		return nil, false
+		return queue, false
 	}
 	for _, tx := range txs {
 		if _, exists := queue.txs[tx.nonce]; exists {

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -51,6 +51,12 @@ const (
 	// Max number of retries to perform on submission errors, such as
 	// networking issues etc.
 	maxSubmissionRetries = 5
+
+	// The possible reasons returned by `fastPathAvailable()`
+	fastPathNoAvailability = "fast-path: conditions not satisfied"
+	fastPathNoSpacing      = "fast-path: not enough spacing elapsed"
+	fastPathStateNonce     = "fast-path: next unindexed nonce"
+	fastPathInFlightNonce  = "fast-path: next unsubmitted nonce"
 )
 
 // BatchTxPool is a TxPool implementation that collects and groups transactions
@@ -145,25 +151,37 @@ func (t *txQueue) staleEntry(now time.Time, spacing time.Duration) bool {
 	return len(t.txs) == 0 && now.Sub(t.lastSubmittedAt) >= (spacing*stalenessFactor)
 }
 
-// validNonce compares the transaction nonce with the nonce from the local
-// state index and the last submission activity (if any), and returns whether
-// the transaction nonce is valid for submission.
-func (t *txQueue) validNonce(
+// fastPathAvailable checks whether there is a fast-path strategy, based on
+// the EOA's last activity and the given transaction nonce. If enough spacing
+// has elapsed since the EOA's last activity, for the given current time and
+// spacing duration, and the transaction nonce matches the nonce from the
+// local staate index or the last submission activity (if any), fast-path is
+// available.
+//
+// Returns the matching fast-path strategy, if any, and a boolean value which
+// denotes its availability.
+func (t *txQueue) fastPathAvailable(
+	now time.Time,
+	spacing time.Duration,
 	txNonce uint64,
 	stateNonce uint64,
-) bool {
+) (string, bool) {
+	if !t.spacingElapsed(now, spacing) {
+		return fastPathNoSpacing, false
+	}
+
 	if txNonce == stateNonce {
-		return true
+		return fastPathStateNonce, true
 	}
 
 	// a value of 0 for `lastSubmittedNonce` is legit, if this is the EOA's
 	// first transaction ever, so we use `lastSubmittedAt` to differentiate
 	// between Go's zero-value.
 	if txNonce == t.lastSubmittedNonce+1 && !t.lastSubmittedAt.IsZero() {
-		return true
+		return fastPathInFlightNonce, true
 	}
 
-	return false
+	return fastPathNoAvailability, false
 }
 
 // pruneTxs drops pooled transactions that can never be submitted from this
@@ -370,7 +388,8 @@ func (t *BatchTxPool) Add(
 	// has elapsed and the tx nonce is the next expected, we submit right
 	// away and update the `lastSubmittedAt` & `lastSubmittedNonce` fields,
 	// for classifying future submissions, that might arrive shortly.
-	if eoaQueue.spacingElapsed(time.Now(), t.config.TxBatchInterval) && eoaQueue.validNonce(tx.Nonce(), nonce) {
+	reason, ok := eoaQueue.fastPathAvailable(time.Now(), t.config.TxBatchInterval, tx.Nonce(), nonce)
+	if ok {
 		// Bound the submit so a hung call cannot pin `txQueuesMux`
 		// indefinitely (see `fastPathSubmitTimeout`).
 		submitCtx, cancel := context.WithTimeout(ctx, fastPathSubmitTimeout)
@@ -387,7 +406,7 @@ func (t *BatchTxPool) Add(
 			)
 			return err
 		}
-		t.logSubmission(from, []pooledEvmTx{userTx}, flushReasonFastPath, flowTxID)
+		t.logSubmission(from, []pooledEvmTx{userTx}, reason, flowTxID)
 
 		eoaQueue.lastSubmittedAt = time.Now()
 		eoaQueue.lastSubmittedNonce = tx.Nonce()

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -490,11 +490,7 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 					// In case of any submission errors, add the transactions back
 					// to the pool as a retry mechanism. This is an important part
 					// to avoid gaps, which would require users to resubmit.
-					// Rollback the nonce range reservation from before — but only
-					// if a concurrent Add() has not already advanced past it via
-					// the fast path, otherwise we'd erase legitimate activity.
-					eoaQueue, ok := t.eoaEnqueueTxs(address, batch.txs)
-					if !ok {
+					if !t.eoaEnqueueTxs(address, batch) {
 						t.logger.Warn().Err(err).Msgf(
 							"max number of retries reached for EOA: %s, batch count: %d, nonce: %d, tx hash: %s",
 							address.Hex(),
@@ -503,10 +499,6 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 							batch.txs[0].txHash.Hex(),
 						)
 						t.collector.TransactionsDropped(len(batch.txs))
-					}
-					if eoaQueue.lastSubmittedNonce == batch.txs[len(batch.txs)-1].nonce {
-						eoaQueue.lastSubmittedNonce = batch.lastSubmittedNonce
-						eoaQueue.lastSubmittedAt = batch.lastSubmittedAt
 					}
 				} else {
 					// Merge the ack with any concurrent Add() fast-path that
@@ -622,29 +614,41 @@ func (t *BatchTxPool) eoaQueueEntry(address gethCommon.Address) *txQueue {
 }
 
 // eoaEnqueueTxs re-adds the given transactions to the corresponding txQueue
-// for the given address (used as a rollback path on submission failure), and
-// returns the txQueue. One will be created if it doesn't yet exist. A same-
-// nonce entry already in the queue is preserved: a concurrent Add() may have
-// dropped a fresher payload there while we were off-lock, and last-write-wins
-// for the client means the fresh payload must win over the failed batch.
+// for the given address (used as a rollback path on submission failure).
+// One will be created if it doesn't yet exist. A same-nonce entry already
+// in the queue is preserved: a concurrent Add() may have dropped a fresher
+// payload there while we were off-lock, and last-write-wins for the client
+// means the fresh payload must win over the failed batch.
 // Up to `maxSubmissionRetries` are allowed and a boolean value is returned to
 // denote enqueue success.
 func (t *BatchTxPool) eoaEnqueueTxs(
 	address gethCommon.Address,
-	txs []pooledEvmTx,
-) (*txQueue, bool) {
+	batch batchSubmission,
+) bool {
 	queue := t.eoaQueueEntry(address)
-	if queue.retries >= maxSubmissionRetries {
-		return queue, false
+	// Rollback the nonce range reservation from before — but only
+	// if a concurrent Add() has not already advanced past it via
+	// the fast path, otherwise we'd erase legitimate activity.
+	if queue.lastSubmittedNonce == batch.txs[len(batch.txs)-1].nonce {
+		queue.lastSubmittedNonce = batch.lastSubmittedNonce
+		queue.lastSubmittedAt = batch.lastSubmittedAt
 	}
-	for _, tx := range txs {
+
+	if queue.retries >= maxSubmissionRetries {
+		return false
+	}
+
+	// re-add the transactions from the batch, in the per-EOA pool
+	for _, tx := range batch.txs {
 		if _, exists := queue.txs[tx.nonce]; exists {
 			continue
 		}
 		queue.txs[tx.nonce] = tx
 	}
+
+	// increment the counter of submission retries
 	queue.retries += 1
-	return queue, true
+	return true
 }
 
 // logSubmission records the fate of a submitted batch so a transaction is

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -429,7 +429,7 @@ func (t *BatchTxPool) Add(
 }
 
 func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
-	ticker := time.NewTicker(t.config.TxBatchInterval)
+	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
 	for {
@@ -453,6 +453,11 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 			queues := len(t.txQueues)
 			queuedTxs := 0
 			for address, eoaQueue := range t.txQueues {
+				// skip processing for this EOA, if there was any recent activity
+				// from concurrent `Add()`
+				if !eoaQueue.spacingElapsed(time.Now(), t.config.TxBatchInterval) {
+					continue
+				}
 				if eoaQueue.staleEntry(time.Now(), t.config.TxBatchInterval) {
 					staleEntries = append(staleEntries, address)
 					continue

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -44,7 +44,7 @@ const (
 	// Multiplication factor for the submission spacing interval, which
 	// gives an indication that an EOA queue is stale and could be
 	// removed, to avoid unconstrained memory growth.
-	stalenessFactor = 2
+	stalenessFactor = 4
 	// How long the EOA queue holds an out-of-order transaction
 	// waiting for its nonce gap to fill, before dropping it.
 	maxQueueTTL = 30 * time.Second
@@ -139,8 +139,8 @@ func (t *txQueue) spacingElapsed(now time.Time, spacing time.Duration) bool {
 // staleEntry checks whether the recorded submission activity for the EOA
 // is stale and could be removed from the mempool queue, to avoid memory
 // growth. If there are no pooled transactions and the last submission was
-// 2 times more than the given spacing interval, we can safely remove this
-// entry.
+// `stalenessFactor` times more than the given spacing interval, we can
+// safely remove this entry.
 func (t *txQueue) staleEntry(now time.Time, spacing time.Duration) bool {
 	return len(t.txs) == 0 && now.Sub(t.lastSubmittedAt) >= (spacing*stalenessFactor)
 }

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -221,9 +221,11 @@ type pooledEvmTx struct {
 // batchSubmission is a batch selected for submission, detached from the queue so
 // the network call happens outside queueMux.
 type batchSubmission struct {
-	from     gethCommon.Address
-	txs      []pooledEvmTx
-	eoaQueue *txQueue
+	from               gethCommon.Address
+	txs                []pooledEvmTx
+	eoaQueue           *txQueue
+	lastSubmittedAt    time.Time
+	lastSubmittedNonce uint64
 }
 
 var _ TxPool = (*BatchTxPool)(nil)
@@ -401,10 +403,16 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 					continue
 				}
 				txBatchByAddress[address] = batchSubmission{
-					from:     address,
-					txs:      txSequence,
-					eoaQueue: eoaQueue,
+					from:               address,
+					txs:                txSequence,
+					eoaQueue:           eoaQueue,
+					lastSubmittedAt:    eoaQueue.lastSubmittedAt,
+					lastSubmittedNonce: eoaQueue.lastSubmittedNonce,
 				}
+				// reserve the nonce range before releasing the lock, so a
+				// concurrent `Add()` cannot fast-path the same nonces.
+				eoaQueue.lastSubmittedAt = time.Now()
+				eoaQueue.lastSubmittedNonce = txSequence[len(txSequence)-1].nonce
 			}
 
 			// cleanup any stale entries, to avoid unconstrained memory growth
@@ -431,7 +439,10 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 					// In case of any submission errors, add the transactions back
 					// to the pool as a retry mechanism. This is an important part
 					// to avoid gaps, which would require users to resubmit.
-					batch.eoaQueue = t.eoaEnqueueTxs(address, batch.txs)
+					// Rollback the nonce range reservation from before.
+					eoaQueue := t.eoaEnqueueTxs(address, batch.txs)
+					eoaQueue.lastSubmittedAt = batch.lastSubmittedAt
+					eoaQueue.lastSubmittedNonce = batch.lastSubmittedNonce
 				} else {
 					batch.eoaQueue.lastSubmittedAt = time.Now()
 					batch.eoaQueue.lastSubmittedNonce = batch.txs[len(batch.txs)-1].nonce

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -306,11 +306,15 @@ func (t *BatchTxPool) Add(
 		return err
 	}
 
-	// Reject an exact duplicate of a transaction already in the queue (cheapest
-	// check; needs no index read).
+	// Reject an exact duplicate of a transaction already in the queue
+	// (cheapest check; needs no index read).
 	eoaQueue := t.eoaQueueEntry(from)
 	if existing, ok := eoaQueue.txs[tx.Nonce()]; ok && existing.txHash == tx.Hash() {
 		return errs.ErrDuplicateTransaction
+	}
+	// Reject any transaction with a nonce that has already been submitted.
+	if !eoaQueue.lastSubmittedAt.IsZero() && tx.Nonce() <= eoaQueue.lastSubmittedNonce {
+		return errs.ErrInFlightNonce
 	}
 	userTx := pooledEvmTx{txPayload: hexEncodedTx, txHash: tx.Hash(), nonce: tx.Nonce()}
 

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -628,7 +628,7 @@ func (t *BatchTxPool) eoaQueueEntry(address gethCommon.Address) *txQueue {
 // dropped a fresher payload there while we were off-lock, and last-write-wins
 // for the client means the fresh payload must win over the failed batch.
 // Up to `maxSubmissionRetries` are allowed and a boolean value is returned to
-// denote enqueue failure.
+// denote enqueue success.
 func (t *BatchTxPool) eoaEnqueueTxs(
 	address gethCommon.Address,
 	txs []pooledEvmTx,

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -225,7 +225,6 @@ type pooledEvmTx struct {
 // batchSubmission is a batch selected for submission, detached from the queue so
 // the network call happens outside queueMux.
 type batchSubmission struct {
-	from               gethCommon.Address
 	txs                []pooledEvmTx
 	eoaQueue           *txQueue
 	lastSubmittedAt    time.Time
@@ -417,7 +416,6 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 					continue
 				}
 				txBatchByAddress[address] = batchSubmission{
-					from:               address,
 					txs:                txSequence,
 					eoaQueue:           eoaQueue,
 					lastSubmittedAt:    eoaQueue.lastSubmittedAt,

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -310,6 +310,7 @@ func (t *BatchTxPool) Add(
 	if existing, ok := eoaQueue.txs[tx.Nonce()]; ok && existing.txHash == tx.Hash() {
 		return errs.ErrDuplicateTransaction
 	}
+	userTx := pooledEvmTx{txPayload: hexEncodedTx, txHash: tx.Hash(), nonce: tx.Nonce()}
 
 	// Check the `txQueue` for an entry with the given EOA. If enough spacing
 	// has elapsed and the tx nonce is the next expected, we submit right
@@ -319,7 +320,7 @@ func (t *BatchTxPool) Add(
 		// Bound the submit so a hung call cannot pin `txQueuesMux`
 		// indefinitely (see `fastPathSubmitTimeout`).
 		submitCtx, cancel := context.WithTimeout(ctx, fastPathSubmitTimeout)
-		err = t.submitSingleTransaction(submitCtx, hexEncodedTx)
+		flowTxID, err := t.submitSingleTransaction(submitCtx, hexEncodedTx)
 		cancel()
 		if err != nil {
 			// If there was any error during transaction submission,
@@ -332,6 +333,7 @@ func (t *BatchTxPool) Add(
 			)
 			return err
 		}
+		t.logSubmission(from, []pooledEvmTx{userTx}, flushReasonFastPath, flowTxID)
 
 		eoaQueue.lastSubmittedAt = time.Now()
 		eoaQueue.lastSubmittedNonce = tx.Nonce()
@@ -342,11 +344,7 @@ func (t *BatchTxPool) Add(
 		return nil
 	}
 
-	eoaQueue.txs[tx.Nonce()] = pooledEvmTx{
-		txPayload: hexEncodedTx,
-		txHash:    tx.Hash(),
-		nonce:     tx.Nonce(),
-	}
+	eoaQueue.txs[tx.Nonce()] = userTx
 
 	return nil
 }
@@ -416,7 +414,7 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 			t.txQueuesMux.Unlock()
 
 			for address, batch := range txBatchByAddress {
-				err = t.batchSubmitTransactionsForSameAddress(
+				flowTxID, err := t.batchSubmitTransactionsForSameAddress(
 					ctx,
 					t.getReferenceBlock(),
 					batch.txs,
@@ -438,6 +436,7 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 					batch.eoaQueue.lastSubmittedAt = time.Now()
 					batch.eoaQueue.lastSubmittedNonce = batch.txs[len(batch.txs)-1].nonce
 					t.collector.TxPoolSubmission(flushReasonPrefix)
+					t.logSubmission(address, batch.txs, flushReasonFastPath, flowTxID)
 				}
 				t.txQueuesMux.Unlock()
 			}
@@ -451,7 +450,7 @@ func (t *BatchTxPool) batchSubmitTransactionsForSameAddress(
 	ctx context.Context,
 	referenceBlockHeader *flow.BlockHeader,
 	pooledTxs []pooledEvmTx,
-) error {
+) (flow.Identifier, error) {
 	// the `pooledTxs` slice is already sorted by nonce, in ascending order
 	// inside the `processPooledTransactions()` function.
 	hexEncodedTxs := make([]cadence.Value, len(pooledTxs))
@@ -461,7 +460,7 @@ func (t *BatchTxPool) batchSubmitTransactionsForSameAddress(
 
 	coinbaseAddress, err := cadence.NewString(t.config.Coinbase.Hex())
 	if err != nil {
-		return err
+		return flow.Identifier{}, err
 	}
 
 	script := replaceAddresses(runTxScript, t.config.FlowNetworkID)
@@ -478,7 +477,7 @@ func (t *BatchTxPool) batchSubmitTransactionsForSameAddress(
 			txHashes[i] = tx.txHash.Hex()
 		}
 		t.logger.Error().Err(err).Strs("tx_hashes", txHashes).Msg("failed to build Flow transaction, EVM transactions re-queued")
-		return err
+		return flow.Identifier{}, err
 	}
 
 	if err := t.client.SendTransaction(ctx, *flowTx); err != nil {
@@ -487,19 +486,19 @@ func (t *BatchTxPool) batchSubmitTransactionsForSameAddress(
 			txHashes[i] = tx.txHash.Hex()
 		}
 		t.logger.Error().Err(err).Strs("tx_hashes", txHashes).Msg("failed to send Flow transaction, EVM transactions re-queued")
-		return err
+		return flow.Identifier{}, err
 	}
 
-	return nil
+	return flowTx.ID(), nil
 }
 
 func (t *BatchTxPool) submitSingleTransaction(
 	ctx context.Context,
 	hexEncodedTx cadence.String,
-) error {
+) (flow.Identifier, error) {
 	coinbaseAddress, err := cadence.NewString(t.config.Coinbase.Hex())
 	if err != nil {
-		return err
+		return flow.Identifier{}, err
 	}
 
 	script := replaceAddresses(runTxScript, t.config.FlowNetworkID)
@@ -511,14 +510,14 @@ func (t *BatchTxPool) submitSingleTransaction(
 		coinbaseAddress,
 	)
 	if err != nil {
-		return err
+		return flow.Identifier{}, err
 	}
 
 	if err := t.client.SendTransaction(ctx, *flowTx); err != nil {
-		return err
+		return flow.Identifier{}, err
 	}
 
-	return nil
+	return flowTx.ID(), nil
 }
 
 // eoaQueueEntry returns the corresponding txQueue for the given address.
@@ -550,4 +549,29 @@ func (t *BatchTxPool) eoaEnqueueTxs(address gethCommon.Address, txs []pooledEvmT
 	}
 
 	return queue
+}
+
+// logSubmission records the fate of a submitted batch so a transaction is
+// never silently lost.
+func (t *BatchTxPool) logSubmission(
+	from gethCommon.Address,
+	txs []pooledEvmTx,
+	reason string,
+	flowTxID flow.Identifier,
+) {
+	if len(txs) == 0 {
+		return
+	}
+
+	event := t.logger.Info().
+		Str("eoa", from.Hex()).
+		Uint64("low-nonce", txs[0].nonce).
+		Uint64("high-nonce", txs[len(txs)-1].nonce).
+		Int("batch-size", len(txs)).
+		Str("reason", reason)
+
+	if flowTxID != (flow.Identifier{}) {
+		event = event.Str("flow_tx_id", flowTxID.Hex())
+	}
+	event.Msg("submitted EVM transactions to Flow")
 }

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -290,15 +290,6 @@ func (t *BatchTxPool) Add(
 		return err
 	}
 
-	// get the latest nonce from the local state index
-	nonce, err := t.nonceProvider.GetNextNonce(from)
-	if err != nil {
-		t.logger.Error().Err(err).Msgf(
-			"failed to get nonce for EOA: %s", from,
-		)
-		return err
-	}
-
 	txData, err := tx.MarshalBinary()
 	if err != nil {
 		return err
@@ -325,6 +316,15 @@ func (t *BatchTxPool) Add(
 		return errs.ErrTxPoolFull
 	}
 	userTx := pooledEvmTx{txPayload: hexEncodedTx, txHash: tx.Hash(), nonce: tx.Nonce()}
+
+	// get the latest nonce from the local state index
+	nonce, err := t.nonceProvider.GetNextNonce(from)
+	if err != nil {
+		t.logger.Error().Err(err).Msgf(
+			"failed to get nonce for EOA: %s", from,
+		)
+		return err
+	}
 
 	// Check the `txQueue` for an entry with the given EOA. If enough spacing
 	// has elapsed and the tx nonce is the next expected, we submit right

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -1,9 +1,14 @@
 package requester
 
+// BatchTxPool shares several building blocks with the newer TxMemPool
+// (see tx_mempool.go): the NonceProvider / NonceView interfaces used to
+// consult the local state index, the fastPathSubmitTimeout bound on
+// synchronous submits, and the flushReason* labels used for metrics and
+// logs. Those symbols are intentionally single-sourced there.
+
 import (
 	"context"
 	"encoding/hex"
-	"sort"
 	"sync"
 	"time"
 
@@ -28,9 +33,14 @@ const (
 	// running out of computation limit, which will revert all wrapped
 	// EVM transactions.
 	maxTxBatch = 5
-	// Max number of pooled transactions per EOA, to avoid unconstrained
-	// memory growth.
-	maxEOAPoolSize = 50
+	// Max nonce lookahead per EOA relative to the on-chain frontier: any
+	// pooled tx whose nonce exceeds `stateNonce + maxNonceLookahead` is
+	// dropped during flush pruning. Independent of queue length.
+	maxNonceLookahead = 50
+	// Absolute cap on the number of transactions queued per EOA, enforced
+	// at admission (Add) time to bound memory even when the client uses
+	// contiguous nonces within `maxNonceLookahead`.
+	maxEOAQueueSize = 50
 	// Multiplication factor for the submission spacing interval, which
 	// gives an indication that an EOA queue is stale and could be
 	// removed, to avoid unconstrained memory growth.
@@ -109,9 +119,14 @@ func (t *txQueue) spacingElapsed(now time.Time, spacing time.Duration) bool {
 // is stale and could be removed from the mempool queue, to avoid memory
 // growth. If there are no pooled transactions and the last submission was
 // 2 times more than the given spacing interval, we can safely remove this
-// entry.
+// entry. A zero-value lastSubmittedAt (no submission has happened yet) is
+// treated as not-stale so a freshly-created queue is never harvested before
+// it has a chance to submit.
 func (t *txQueue) staleEntry(now time.Time, spacing time.Duration) bool {
-	return len(t.txs) == 0 && now.Sub(t.lastSubmittedAt) >= (spacing*stalenessFactor)
+	if len(t.txs) != 0 || t.lastSubmittedAt.IsZero() {
+		return false
+	}
+	return now.Sub(t.lastSubmittedAt) >= (spacing * stalenessFactor)
 }
 
 // validNonce compares the transaction nonce with the nonce from the local
@@ -135,10 +150,11 @@ func (t *txQueue) validNonce(
 	return false
 }
 
-// pruneTxs filters out any pooled transactions with nonce lower than the
-// given state nonce, as they are stale and should not be submitted. It
-// will also filter any transactions past the size of `maxEOAPoolSize`,
-// to avoid unconstrained memory growth
+// pruneTxs drops pooled transactions that can never be submitted from this
+// queue: nonces below the on-chain frontier (already used), and nonces further
+// than `maxNonceLookahead` beyond the frontier (unreachable within any
+// realistic gap-fill window). The absolute queue-length cap is enforced at
+// admission time in Add() — this pass only prunes; it does not size-cap.
 func (t *txQueue) pruneTxs(
 	address gethCommon.Address,
 	stateNonce uint64,
@@ -156,15 +172,17 @@ func (t *txQueue) pruneTxs(
 				stateNonce,
 			)
 			staleNonces = append(staleNonces, nonce)
+			continue
 		}
 
-		// keep up to `maxEOAPoolSize` txs per EOA in the pool,
-		// to avoid unconstrained memory growth
-		if tx.nonce > maxEOAPoolSize+stateNonce {
+		// drop txs whose nonce is further ahead than we're willing
+		// to hold (nonce lookahead cap).
+		if tx.nonce > maxNonceLookahead+stateNonce {
 			logger.Warn().Msgf(
-				"dropped tx with nonce: %d for EOA: %s, due to max pool size limit",
+				"dropped tx with nonce: %d for EOA: %s, exceeds nonce lookahead of %d",
 				tx.nonce,
 				address,
+				maxNonceLookahead,
 			)
 			staleNonces = append(staleNonces, nonce)
 		}
@@ -178,33 +196,22 @@ func (t *txQueue) pruneTxs(
 
 // selectSequentialNonces returns up to `maxTxBatch` pooled transactions
 // forming a sequential nonce run starting exactly at `stateNonce`, sorted
-// ascending.
-// Returns an empty slice when the transaction with stateNonce is absent.
+// ascending. Returns an empty slice when the transaction with stateNonce
+// is absent.
+//
+// Since the queue is keyed by nonce, we walk forward from stateNonce with
+// direct map lookups — O(k) where k = returned batch length. No sort, no
+// full-map scan.
 func (t *txQueue) selectSequentialNonces(stateNonce uint64) []pooledEvmTx {
-	txs := make([]pooledEvmTx, 0)
-	for _, tx := range t.txs {
-		txs = append(txs, tx)
-	}
-
-	// pick the txs with the valid nonce sequence.
-	// txs should be first sorted by nonce, in ascending order.
-	sort.Slice(txs, func(i, j int) bool {
-		return txs[i].nonce < txs[j].nonce
-	})
-	txSequence := make([]pooledEvmTx, 0)
-	for _, tx := range txs {
-		if len(txSequence) >= maxTxBatch {
+	txSequence := make([]pooledEvmTx, 0, maxTxBatch)
+	for i := 0; i < maxTxBatch; i++ {
+		tx, ok := t.txs[stateNonce]
+		if !ok {
 			break
 		}
-		if tx.nonce == stateNonce {
-			txSequence = append(txSequence, tx)
-			stateNonce += 1
-		}
-	}
-
-	// remove the transactions with sequential nonces from the pooled transactions.
-	for _, tx := range txSequence {
-		delete(t.txs, tx.nonce)
+		txSequence = append(txSequence, tx)
+		delete(t.txs, stateNonce)
+		stateNonce++
 	}
 
 	return txSequence
@@ -309,12 +316,18 @@ func (t *BatchTxPool) Add(
 	// Reject an exact duplicate of a transaction already in the queue
 	// (cheapest check; needs no index read).
 	eoaQueue := t.eoaQueueEntry(from)
-	if existing, ok := eoaQueue.txs[tx.Nonce()]; ok && existing.txHash == tx.Hash() {
+	existing, existsAtNonce := eoaQueue.txs[tx.Nonce()]
+	if existsAtNonce && existing.txHash == tx.Hash() {
 		return errs.ErrDuplicateTransaction
 	}
 	// Reject any transaction with a nonce that has already been submitted.
 	if !eoaQueue.lastSubmittedAt.IsZero() && tx.Nonce() <= eoaQueue.lastSubmittedNonce {
 		return errs.ErrInFlightNonce
+	}
+	// Bound per-EOA memory. A same-nonce replacement (last-write-wins) does
+	// not grow the queue and is allowed even at the cap.
+	if !existsAtNonce && eoaQueue.size() >= maxEOAQueueSize {
+		return errs.ErrTxPoolFull
 	}
 	userTx := pooledEvmTx{txPayload: hexEncodedTx, txHash: tx.Hash(), nonce: tx.Nonce()}
 
@@ -443,15 +456,29 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 					// In case of any submission errors, add the transactions back
 					// to the pool as a retry mechanism. This is an important part
 					// to avoid gaps, which would require users to resubmit.
-					// Rollback the nonce range reservation from before.
+					// Rollback the nonce range reservation from before — but only
+					// if a concurrent Add() has not already advanced past it via
+					// the fast path, otherwise we'd erase legitimate activity.
 					eoaQueue := t.eoaEnqueueTxs(address, batch.txs)
-					eoaQueue.lastSubmittedAt = batch.lastSubmittedAt
-					eoaQueue.lastSubmittedNonce = batch.lastSubmittedNonce
+					if eoaQueue.lastSubmittedNonce == batch.txs[len(batch.txs)-1].nonce {
+						eoaQueue.lastSubmittedNonce = batch.lastSubmittedNonce
+						eoaQueue.lastSubmittedAt = batch.lastSubmittedAt
+					}
 				} else {
-					batch.eoaQueue.lastSubmittedAt = time.Now()
-					batch.eoaQueue.lastSubmittedNonce = batch.txs[len(batch.txs)-1].nonce
+					// Merge the ack with any concurrent Add() fast-path that
+					// advanced the queue while we were off-lock: never regress
+					// lastSubmittedNonce, and use the LATER of the two timestamps
+					// for spacing accounting.
+					batchTail := batch.txs[len(batch.txs)-1].nonce
+					if batchTail > batch.eoaQueue.lastSubmittedNonce {
+						batch.eoaQueue.lastSubmittedNonce = batchTail
+					}
+					now := time.Now()
+					if now.After(batch.eoaQueue.lastSubmittedAt) {
+						batch.eoaQueue.lastSubmittedAt = now
+					}
 					t.collector.TxPoolSubmission(flushReasonPrefix)
-					t.logSubmission(address, batch.txs, flushReasonFastPath, flowTxID)
+					t.logSubmission(address, batch.txs, flushReasonPrefix, flowTxID)
 				}
 				t.txQueuesMux.Unlock()
 			}
@@ -548,9 +575,12 @@ func (t *BatchTxPool) eoaQueueEntry(address gethCommon.Address) *txQueue {
 	return queue
 }
 
-// eoaEnqueueTxs enqueues the given transactions to the corresponding txQueue
-// for the given address, and returns the txQueue. One will be created if it
-// doesn't yet exist.
+// eoaEnqueueTxs re-adds the given transactions to the corresponding txQueue
+// for the given address (used as a rollback path on submission failure), and
+// returns the txQueue. One will be created if it doesn't yet exist. A same-
+// nonce entry already in the queue is preserved: a concurrent Add() may have
+// dropped a fresher payload there while we were off-lock, and last-write-wins
+// for the client means the fresh payload must win over the failed batch.
 func (t *BatchTxPool) eoaEnqueueTxs(address gethCommon.Address, txs []pooledEvmTx) *txQueue {
 	queue, ok := t.txQueues[address]
 	if !ok {
@@ -560,6 +590,9 @@ func (t *BatchTxPool) eoaEnqueueTxs(address gethCommon.Address, txs []pooledEvmT
 		t.txQueues[address] = queue
 	}
 	for _, tx := range txs {
+		if _, exists := queue.txs[tx.nonce]; exists {
+			continue
+		}
 		queue.txs[tx.nonce] = tx
 	}
 

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -70,14 +70,16 @@ const (
 // # Fix
 //
 // For all incoming transactions, we are now inspecting the EOA's current nonce
-// in the local state index:
-// 1. If it matches the transaction nonce, we submit it right away, and record
-// this activity in the EOA's dedicated queue, for use in future submissions.
-// 2. If the transaction nonce is higher, we check for any recent submissions
-// to see if we can form a valid sequence. This could happen from in-flight
-// transaction submission, that have not yet been index by the local state
-// index. In this case we optimistically submit right away. and record this
-// activity in the EOA's dedicated queue, for use in future submissions.
+// in the local state index, as well as the elapsed spacing from any recent
+// submission:
+// 1. If enough spacing has elapsed and the current nonce matches the transaction
+// nonce, we submit it right away, and record this activity in the EOA's dedicated
+// queue, for use in future submissions.
+// 2. If enough spacing has elapsed and the transaction nonce is higher, we check
+// for any recent submissions to see if we can form a valid sequence. This could
+// happen from in-flight transaction submission, that have not yet been indexed
+// by the local state index. In this case we optimistically submit right away and
+// record this activity in the EOA's dedicated queue, for use in future submissions.
 // 3. If none of the above 2 conditions are met, we enqueue the transaction
 // in the pool. The flush timer (TxBatchInterval) is the sole submission trigger.
 // This guarantees that parallel transactions from the same wallet accumulate

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -311,13 +311,8 @@ func (t *BatchTxPool) Add(
 	if !eoaQueue.lastSubmittedAt.IsZero() && tx.Nonce() <= eoaQueue.lastSubmittedNonce {
 		return errs.ErrInFlightNonce
 	}
-	// Bound per-EOA memory. A same-nonce replacement (last-write-wins) does
-	// not grow the queue and is allowed even at the cap.
-	if !existsAtNonce && eoaQueue.size() >= maxEOAQueueSize {
-		return errs.ErrTxPoolFull
-	}
-	userTx := pooledEvmTx{txPayload: hexEncodedTx, txHash: tx.Hash(), nonce: tx.Nonce()}
 
+	userTx := pooledEvmTx{txPayload: hexEncodedTx, txHash: tx.Hash(), nonce: tx.Nonce()}
 	// get the latest nonce from the local state index
 	nonce, err := t.nonceProvider.GetNextNonce(from)
 	if err != nil {
@@ -357,6 +352,12 @@ func (t *BatchTxPool) Add(
 		delete(eoaQueue.txs, tx.Nonce())
 		t.collector.TxPoolSubmission(flushReasonFastPath)
 		return nil
+	}
+
+	// Bound per-EOA memory. A same-nonce replacement (last-write-wins) does
+	// not grow the queue and is allowed even at the cap.
+	if !existsAtNonce && eoaQueue.size() >= maxEOAQueueSize {
+		return errs.ErrTxPoolFull
 	}
 
 	eoaQueue.txs[tx.Nonce()] = userTx

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -3,14 +3,12 @@ package requester
 import (
 	"context"
 	"encoding/hex"
-	"slices"
 	"sort"
 	"sync"
 	"time"
 
 	gethCommon "github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/rs/zerolog"
@@ -22,32 +20,210 @@ import (
 	"github.com/onflow/flow-evm-gateway/services/requester/keystore"
 )
 
-const eoaActivityCacheSize = 10_000
+const (
+	// Max number of transactions per EOA batch submission. The Cadence
+	// transaction that wraps and executes EVM transactions with
+	// `EVM.batchRun`, is submitted with a computation limit of `9,999`.
+	// Adding more EVM transactions per batch, increases the risk of
+	// running out of computation limit, which will revert all wrapped
+	// EVM transactions.
+	maxTxBatch = 5
+	// Max number of pooled transactions per EOA, to avoid unconstrained
+	// memory growth.
+	maxEOAPoolSize = 50
+	// Multiplication factor for the submission spacing interval, which
+	// gives an indication that an EOA queue is stale and could be
+	// removed, to avoid unconstrained memory growth.
+	stalenessFactor = 2
+)
 
+// BatchTxPool is a TxPool implementation that collects and groups transactions
+// by EOA signer, sorts them by nonce, and submits them as a batch via
+// EVM.batchRun on each flush interval.
+//
+// # Problem
+//
+// Flow did not have a traditional EVM mempool. On standard EVM chains, when a
+// wallet sends transactions out-of-nonce-sequence (e.g., nonces 5, 7, 6 in
+// parallel), the mempool holds future-nonce transactions until the gap is
+// filled. Flow EVM had no such pooling mechanism — a transaction whose nonce
+// does not match the current account nonce is simply dropped.
+//
+// The original BatchTxPool implementation partially addressed this by batching
+// transactions that arrived from an EOA with "recent activity" (i.e., a prior
+// transaction within TxBatchInterval). However, it still submitted the FIRST
+// transaction from any burst immediately — before the rest of the burst had
+// a chance to arrive. If that first transaction happened to carry a future
+// nonce (due to parallel dispatch), it failed, and the gap it left caused all
+// subsequent nonces in the batch to fail as well.
+//
+// # Fix
+//
+// For all incoming transactions, we are now inspecting the EOA's current nonce
+// in the local state index:
+// 1. If it matches the transaction nonce, we submit it right away, and record
+// this activity in the EOA's dedicated queue, for use in future submissions.
+// 2. If the transaction nonce is higher, we check for any recent submissions
+// to see if we can form a valid sequence. This could happen from in-flight
+// transaction submission, that have not yet been index by the local state
+// index. In this case we optimistically submit right away. and record this
+// activity in the EOA's dedicated queue, for use in future submissions.
+// 3. If none of the above 2 conditions are met, we enqueue the transaction
+// in the pool. The flush timer (TxBatchInterval) is the sole submission trigger.
+// This guarantees that parallel transactions from the same wallet accumulate
+// in the pool before being sorted by nonce and submitted atomically.
+type BatchTxPool struct {
+	*SingleTxPool
+
+	nonceProvider NonceProvider
+	txQueues      map[gethCommon.Address]*txQueue
+	txQueuesMux   sync.Mutex
+}
+
+// txQueue tracks the pooled transactions and submission state for one EOA.
+type txQueue struct {
+	// txs holds pooled transactions keyed by nonce. Keying by nonce gives
+	// last-write-wins semantics when a client resubmits a not-yet-sent
+	// transaction with the same nonce (e.g. to change its payload).
+	txs map[uint64]pooledEvmTx
+	// lastSubmittedAt is when the last Cadence tx for this EOA was submitted
+	// (used for submission spacing).
+	lastSubmittedAt time.Time
+	// lastSubmittedNonce is the last EOA nonce that was submitted with a
+	// Cadence tx (used for classifying whether to queue or submit right away).
+	lastSubmittedNonce uint64
+}
+
+// size returns the total number of pooled transactions.
+func (t *txQueue) size() int {
+	return len(t.txs)
+}
+
+// spacingElapsed checks whether enough spacing has elapsed since the EOA's
+// last activity, for the given current time and spacing duration.
+func (t *txQueue) spacingElapsed(now time.Time, spacing time.Duration) bool {
+	return t.lastSubmittedAt.IsZero() || now.Sub(t.lastSubmittedAt) >= spacing
+}
+
+// staleEntry checks whether the recorded submission activity for the EOA
+// is stale and could be removed from the mempool queue, to avoid memory
+// growth. If there are no pooled transactions and the last submission was
+// 2 times more than the given spacing interval, we can safely remove this
+// entry.
+func (t *txQueue) staleEntry(now time.Time, spacing time.Duration) bool {
+	return len(t.txs) == 0 && now.Sub(t.lastSubmittedAt) >= (spacing*stalenessFactor)
+}
+
+// validNonce compares the transaction nonce with the nonce from the local
+// state index and the last submission activity (if any), and returns whether
+// the transaction nonce is valid for submission.
+func (t *txQueue) validNonce(
+	txNonce uint64,
+	stateNonce uint64,
+) bool {
+	if txNonce == stateNonce {
+		return true
+	}
+
+	// a value of 0 for `lastSubmittedNonce` is legit, if this is the EOA's
+	// first transaction ever, so we use `lastSubmittedAt` to differentiate
+	// between Go's zero-value.
+	if txNonce == t.lastSubmittedNonce+1 && !t.lastSubmittedAt.IsZero() {
+		return true
+	}
+
+	return false
+}
+
+// pruneTxs filters out any pooled transactions with nonce lower than the
+// given state nonce, as they are stale and should not be submitted. It
+// will also filter any transactions past the size of `maxEOAPoolSize`,
+// to avoid unconstrained memory growth
+func (t *txQueue) pruneTxs(
+	address gethCommon.Address,
+	stateNonce uint64,
+	logger zerolog.Logger,
+) {
+	staleNonces := make([]uint64, 0)
+	for nonce, tx := range t.txs {
+		// drop any pooled transactions with nonce lower than
+		// the nonce in local state index
+		if tx.nonce < stateNonce {
+			logger.Warn().Msgf(
+				"dropped tx with nonce: %d for EOA: %s, expected state nonce: %d",
+				tx.nonce,
+				address,
+				stateNonce,
+			)
+			staleNonces = append(staleNonces, nonce)
+		}
+
+		// keep up to `maxEOAPoolSize` txs per EOA in the pool,
+		// to avoid unconstrained memory growth
+		if tx.nonce > maxEOAPoolSize+stateNonce {
+			logger.Warn().Msgf(
+				"dropped tx with nonce: %d for EOA: %s, due to max pool size limit",
+				tx.nonce,
+				address,
+			)
+			staleNonces = append(staleNonces, nonce)
+		}
+	}
+
+	// remove the transactions with stale nonces from the pooled transactions.
+	for _, nonce := range staleNonces {
+		delete(t.txs, nonce)
+	}
+}
+
+// selectSequentialNonces returns up to `maxTxBatch` pooled transactions
+// forming a sequential nonce run starting exactly at `stateNonce`, sorted
+// ascending.
+// Returns an empty slice when the transaction with stateNonce is absent.
+func (t *txQueue) selectSequentialNonces(stateNonce uint64) []pooledEvmTx {
+	txs := make([]pooledEvmTx, 0)
+	for _, tx := range t.txs {
+		txs = append(txs, tx)
+	}
+
+	// pick the txs with the valid nonce sequence.
+	// txs should be first sorted by nonce, in ascending order.
+	sort.Slice(txs, func(i, j int) bool {
+		return txs[i].nonce < txs[j].nonce
+	})
+	txSequence := make([]pooledEvmTx, 0)
+	for _, tx := range txs {
+		if len(txSequence) >= maxTxBatch {
+			break
+		}
+		if tx.nonce == stateNonce {
+			txSequence = append(txSequence, tx)
+			stateNonce += 1
+		}
+	}
+
+	// remove the transactions with sequential nonces from the pooled transactions.
+	for _, tx := range txSequence {
+		delete(t.txs, tx.nonce)
+	}
+
+	return txSequence
+}
+
+// pooledEvmTx is a transaction queued in the mempool, waiting for the
+// batch interval to elapse or its nonce gap to be filled.
 type pooledEvmTx struct {
 	txPayload cadence.String
 	txHash    gethCommon.Hash
 	nonce     uint64
 }
 
-// BatchTxPool is a `TxPool` implementation that collects and groups
-// transactions based on their EOA signer, and submits them for execution
-// using a batch.
-//
-// The underlying Cadence EVM API used, is `EVM.batchRun`, instead of the
-// `EVM.run` used in `SingleTxPool`.
-//
-// The main advantage of this implementation over the `SingleTxPool`, is the
-// guarantee that transactions originated from the same EOA address, which
-// arrive in a short time interval (about the same as Flow's block production rate),
-// will be executed in the same order their arrived.
-// This helps to reduce the nonce mismatch errors which mainly occur from the
-// re-ordering of Cadence transactions that happens from Collection nodes.
-type BatchTxPool struct {
-	*SingleTxPool
-	pooledTxs   map[gethCommon.Address][]pooledEvmTx
-	txMux       sync.Mutex
-	eoaActivity *expirable.LRU[gethCommon.Address, time.Time]
+// batchSubmission is a batch selected for submission, detached from the queue so
+// the network call happens outside queueMux.
+type batchSubmission struct {
+	from     gethCommon.Address
+	txs      []pooledEvmTx
+	eoaQueue *txQueue
 }
 
 var _ TxPool = (*BatchTxPool)(nil)
@@ -60,6 +236,7 @@ func NewBatchTxPool(
 	config config.Config,
 	collector metrics.Collector,
 	keystore *keystore.KeyStore,
+	nonceProvider NonceProvider,
 ) (*BatchTxPool, error) {
 	// initialize the available keys metric since it is only updated when sending a tx
 	collector.AvailableSigningKeys(keystore.AvailableKeys())
@@ -77,16 +254,11 @@ func NewBatchTxPool(
 		return nil, err
 	}
 
-	eoaActivity := expirable.NewLRU[gethCommon.Address, time.Time](
-		eoaActivityCacheSize,
-		nil,
-		config.EOAActivityCacheTTL,
-	)
 	batchPool := &BatchTxPool{
-		SingleTxPool: singleTxPool,
-		pooledTxs:    make(map[gethCommon.Address][]pooledEvmTx),
-		txMux:        sync.Mutex{},
-		eoaActivity:  eoaActivity,
+		SingleTxPool:  singleTxPool,
+		nonceProvider: nonceProvider,
+		txQueues:      make(map[gethCommon.Address]*txQueue),
+		txQueuesMux:   sync.Mutex{},
 	}
 
 	go batchPool.processPooledTransactions(ctx)
@@ -94,10 +266,10 @@ func NewBatchTxPool(
 	return batchPool, nil
 }
 
-// Add adds the EVM transaction to the tx pool, grouped with the rest of the
-// transactions from the same EOA signer.
-// After the configured `TxBatchInterval`, the collected transations
-// are batched and sent to the Flow network using `EVM.batchRun`, for execution.
+// Add inspects the nonce of the incoming transaction, and either submits it
+// right away or enqueues the transaction in the per-EOA pool, in which case
+// it will be processed and submitted by the flush goroutine
+// (processPooledTransactions) on every `TxBatchInterval` tick.
 func (t *BatchTxPool) Add(
 	ctx context.Context,
 	tx *gethTypes.Transaction,
@@ -106,11 +278,20 @@ func (t *BatchTxPool) Add(
 
 	// tx adding should be blocking, so we don't have races when
 	// pooled transactions are being processed in the background.
-	t.txMux.Lock()
-	defer t.txMux.Unlock()
+	t.txQueuesMux.Lock()
+	defer t.txQueuesMux.Unlock()
 
 	from, err := models.DeriveTxSender(tx)
 	if err != nil {
+		return err
+	}
+
+	// get the latest nonce from the local state index
+	nonce, err := t.nonceProvider.GetNextNonce(from)
+	if err != nil {
+		t.logger.Error().Err(err).Msgf(
+			"failed to get nonce for EOA: %s", from,
+		)
 		return err
 	}
 
@@ -123,48 +304,40 @@ func (t *BatchTxPool) Add(
 		return err
 	}
 
-	// Scenarios
-	// 1. EOA activity not found:
-	// => We send the transaction individually, without adding it
-	// to the batch pool.
-	//
-	// 2. EOA activity found AND it was more than [X] seconds ago:
-	// => We send the transaction individually, without adding it
-	// to the batch pool.
-	//
-	// 3. EOA activity found AND it was less than [X] seconds ago:
-	// => We add the transaction to the batch pool, so that it gets
-	// processed and submitted according to the configured
-	// `TxBatchInterval`.
-	//
-	// For all 3 cases, we record the activity time for the next
-	// transactions that might come from the same EOA.
-	// [X] is equal to the configured `TxBatchInterval` duration.
-	lastActivityTime, found := t.eoaActivity.Get(from)
+	// Reject an exact duplicate of a transaction already in the queue (cheapest
+	// check; needs no index read).
+	eoaQueue := t.eoaQueueEntry(from)
+	if existing, ok := eoaQueue.txs[tx.Nonce()]; ok && existing.txHash == tx.Hash() {
+		return errs.ErrDuplicateTransaction
+	}
 
-	if !found {
-		// Case 1. EOA activity not found:
-		err = t.submitSingleTransaction(ctx, hexEncodedTx)
-	} else if time.Since(lastActivityTime) > t.config.TxBatchInterval {
-		// Case 2. EOA activity found AND it was more than [X] seconds ago:
-		err = t.submitSingleTransaction(ctx, hexEncodedTx)
-	} else {
-		// Case 3. EOA activity found AND it was less than [X] seconds ago:
-		userTx := pooledEvmTx{txPayload: hexEncodedTx, txHash: tx.Hash(), nonce: tx.Nonce()}
-		// Prevent submission of duplicate transactions, based on their tx hash
-		if slices.Contains(t.pooledTxs[from], userTx) {
-			return errs.ErrDuplicateTransaction
+	// Check the `txQueue` for an entry with the given EOA. If enough spacing
+	// has elapsed and the tx nonce is the next expected, we submit right
+	// away and update the `lastSubmittedAt` & `lastSubmittedNonce` fields,
+	// for classifying future submissions, that might arrive shortly.
+	if eoaQueue.spacingElapsed(time.Now(), t.config.TxBatchInterval) && eoaQueue.validNonce(tx.Nonce(), nonce) {
+		// Bound the submit so a hung call cannot pin `txQueuesMux`
+		// indefinitely (see `fastPathSubmitTimeout`).
+		submitCtx, cancel := context.WithTimeout(ctx, fastPathSubmitTimeout)
+		err = t.submitSingleTransaction(submitCtx, hexEncodedTx)
+		cancel()
+		if err != nil {
+			return err
 		}
-		t.pooledTxs[from] = append(t.pooledTxs[from], userTx)
+
+		eoaQueue.lastSubmittedAt = time.Now()
+		eoaQueue.lastSubmittedNonce = tx.Nonce()
+		t.collector.TxPoolSubmission(flushReasonFastPath)
+		return nil
 	}
 
-	t.eoaActivity.Add(from, time.Now())
-
-	if err != nil {
-		t.collector.TransactionsDropped(1)
-		t.logger.Error().Err(err).Str("tx_hash", tx.Hash().Hex()).Msg("failed to build Flow transaction, EVM transaction dropped")
+	eoaQueue.txs[tx.Nonce()] = pooledEvmTx{
+		txPayload: hexEncodedTx,
+		txHash:    tx.Hash(),
+		nonce:     tx.Nonce(),
 	}
-	return err
+
+	return nil
 }
 
 func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
@@ -176,28 +349,89 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			// Take a copy here to allow `Add()` to continue accept
-			// incoming EVM transactions, without blocking until the
-			// batch transactions are submitted.
-			t.txMux.Lock()
-			txsGroupedByAddress := t.pooledTxs
-			t.pooledTxs = make(map[gethCommon.Address][]pooledEvmTx)
-			t.txMux.Unlock()
-
-			for address, pooledTxs := range txsGroupedByAddress {
-				err := t.batchSubmitTransactionsForSameAddress(
-					ctx,
-					t.getReferenceBlock(),
-					pooledTxs,
+			// construct a block view here, to read the nonce for each
+			// EOA below, without recreating the block view each time.
+			blockView, err := t.nonceProvider.GetBlockView()
+			if err != nil {
+				t.logger.Fatal().Err(err).Msgf(
+					"failed to construct BlockView for nonce reading",
 				)
+				return
+			}
+
+			t.txQueuesMux.Lock()
+			txBatchByAddress := make(map[gethCommon.Address]batchSubmission)
+			staleEntries := make([]gethCommon.Address, 0)
+			queues := len(t.txQueues)
+			queuedTxs := 0
+			for address, eoaQueue := range t.txQueues {
+				if eoaQueue.staleEntry(time.Now(), t.config.TxBatchInterval) {
+					staleEntries = append(staleEntries, address)
+					continue
+				}
+				queuedTxs += eoaQueue.size()
+
+				// get the latest nonce from the local state index.
+				nonce, err := blockView.GetNonce(address)
 				if err != nil {
 					t.logger.Error().Err(err).Msgf(
-						"failed to submit Flow transaction from BatchTxPool for EOA: %s",
-						address.Hex(),
+						"failed to get nonce for EOA: %s", address,
 					)
 					continue
 				}
+
+				// drop any pooled transactions with nonce lower than
+				// the local state index nonce.
+				eoaQueue.pruneTxs(address, nonce, t.logger)
+
+				// pick the txs with the valid nonce sequence
+				txSequence := eoaQueue.selectSequentialNonces(nonce)
+				// if there is no valid nonce sequence, according to the local state
+				// index, continue with the next EOA.
+				if len(txSequence) == 0 {
+					continue
+				}
+				txBatchByAddress[address] = batchSubmission{
+					from:     address,
+					txs:      txSequence,
+					eoaQueue: eoaQueue,
+				}
 			}
+
+			// cleanup any stale entries, to avoid unconstrained memory growth
+			for _, address := range staleEntries {
+				delete(t.txQueues, address)
+			}
+			t.txQueuesMux.Unlock()
+
+			for address, batch := range txBatchByAddress {
+				err = t.batchSubmitTransactionsForSameAddress(
+					ctx,
+					t.getReferenceBlock(),
+					batch.txs,
+				)
+				t.txQueuesMux.Lock()
+				if err != nil {
+					t.logger.Error().Err(err).Msgf(
+						"failed to submit batch Flow transaction for EOA: %s, batch count: %d, nonce: %d, tx hash: %s",
+						address.Hex(),
+						len(batch.txs),
+						batch.txs[0].nonce,
+						batch.txs[0].txHash.Hex(),
+					)
+					// In case of any submission errors, add the transactions back
+					// to the pool as a retry mechanism. This is an important part
+					// to avoid gaps, which would require users to resubmit.
+					batch.eoaQueue = t.eoaEnqueueTxs(address, batch.txs)
+				} else {
+					batch.eoaQueue.lastSubmittedAt = time.Now()
+					batch.eoaQueue.lastSubmittedNonce = batch.txs[len(batch.txs)-1].nonce
+				}
+				t.txQueuesMux.Unlock()
+				t.collector.TxPoolSubmission(flushReasonPrefix)
+			}
+
+			t.collector.TxPoolSize(queues, queuedTxs)
 		}
 	}
 }
@@ -207,12 +441,8 @@ func (t *BatchTxPool) batchSubmitTransactionsForSameAddress(
 	referenceBlockHeader *flow.BlockHeader,
 	pooledTxs []pooledEvmTx,
 ) error {
-	// Sort the transactions based on their nonce, to make sure
-	// that no re-ordering has happened due to races etc.
-	sort.Slice(pooledTxs, func(i, j int) bool {
-		return pooledTxs[i].nonce < pooledTxs[j].nonce
-	})
-
+	// the `pooledTxs` slice is already sorted by nonce, in ascending order
+	// inside the `processPooledTransactions()` function.
 	hexEncodedTxs := make([]cadence.Value, len(pooledTxs))
 	for i, txPayload := range pooledTxs {
 		hexEncodedTxs[i] = txPayload.txPayload
@@ -234,7 +464,7 @@ func (t *BatchTxPool) batchSubmitTransactionsForSameAddress(
 	if err != nil {
 		// If there was any error during the transaction build
 		// process, we record all transactions as dropped.
-		t.collector.TransactionsDropped(len(hexEncodedTxs))
+		t.collector.TransactionsDropped(len(pooledTxs))
 		txHashes := make([]string, len(pooledTxs))
 		for i, tx := range pooledTxs {
 			txHashes[i] = tx.txHash.Hex()
@@ -244,6 +474,8 @@ func (t *BatchTxPool) batchSubmitTransactionsForSameAddress(
 	}
 
 	if err := t.client.SendTransaction(ctx, *flowTx); err != nil {
+		// If there was any error while sending the transaction,
+		// we record all transactions as dropped.
 		t.collector.TransactionsDropped(len(pooledTxs))
 		txHashes := make([]string, len(pooledTxs))
 		for i, tx := range pooledTxs {
@@ -285,4 +517,35 @@ func (t *BatchTxPool) submitSingleTransaction(
 	}
 
 	return nil
+}
+
+// eoaQueueEntry returns the corresponding txQueue for the given address.
+// One will be created if it doesn't yet exist.
+func (t *BatchTxPool) eoaQueueEntry(address gethCommon.Address) *txQueue {
+	queue, ok := t.txQueues[address]
+	if !ok {
+		queue = &txQueue{
+			txs: make(map[uint64]pooledEvmTx),
+		}
+		t.txQueues[address] = queue
+	}
+	return queue
+}
+
+// eoaEnqueueTxs enqueues the given transactions to the corresponding txQueue
+// for the given address, and returns the txQueue. One will be created if it
+// doesn't yet exist.
+func (t *BatchTxPool) eoaEnqueueTxs(address gethCommon.Address, txs []pooledEvmTx) *txQueue {
+	queue, ok := t.txQueues[address]
+	if !ok {
+		queue = &txQueue{
+			txs: make(map[uint64]pooledEvmTx),
+		}
+		t.txQueues[address] = queue
+	}
+	for _, tx := range txs {
+		queue.txs[tx.nonce] = tx
+	}
+
+	return queue
 }

--- a/services/requester/batch_tx_pool.go
+++ b/services/requester/batch_tx_pool.go
@@ -322,11 +322,22 @@ func (t *BatchTxPool) Add(
 		err = t.submitSingleTransaction(submitCtx, hexEncodedTx)
 		cancel()
 		if err != nil {
+			// If there was any error during transaction submission,
+			// we record it as a dropped transaction.
+			t.collector.TransactionsDropped(1)
+			t.logger.Error().Err(err).Str("tx_hash", tx.Hash().Hex()).Msgf(
+				"failed to submit Flow transaction for EOA: %s, with nonce: %d",
+				from.Hex(),
+				tx.Nonce(),
+			)
 			return err
 		}
 
 		eoaQueue.lastSubmittedAt = time.Now()
 		eoaQueue.lastSubmittedNonce = tx.Nonce()
+		// the submitted nonce must not stay queued, otherwise the flush
+		// loop can resubmit a superseded payload for the same nonce.
+		delete(eoaQueue.txs, tx.Nonce())
 		t.collector.TxPoolSubmission(flushReasonFastPath)
 		return nil
 	}
@@ -353,10 +364,10 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 			// EOA below, without recreating the block view each time.
 			blockView, err := t.nonceProvider.GetBlockView()
 			if err != nil {
-				t.logger.Fatal().Err(err).Msgf(
+				t.logger.Error().Err(err).Msg(
 					"failed to construct BlockView for nonce reading",
 				)
-				return
+				continue
 			}
 
 			t.txQueuesMux.Lock()
@@ -426,9 +437,9 @@ func (t *BatchTxPool) processPooledTransactions(ctx context.Context) {
 				} else {
 					batch.eoaQueue.lastSubmittedAt = time.Now()
 					batch.eoaQueue.lastSubmittedNonce = batch.txs[len(batch.txs)-1].nonce
+					t.collector.TxPoolSubmission(flushReasonPrefix)
 				}
 				t.txQueuesMux.Unlock()
-				t.collector.TxPoolSubmission(flushReasonPrefix)
 			}
 
 			t.collector.TxPoolSize(queues, queuedTxs)
@@ -462,26 +473,20 @@ func (t *BatchTxPool) batchSubmitTransactionsForSameAddress(
 		coinbaseAddress,
 	)
 	if err != nil {
-		// If there was any error during the transaction build
-		// process, we record all transactions as dropped.
-		t.collector.TransactionsDropped(len(pooledTxs))
 		txHashes := make([]string, len(pooledTxs))
 		for i, tx := range pooledTxs {
 			txHashes[i] = tx.txHash.Hex()
 		}
-		t.logger.Error().Err(err).Strs("tx_hashes", txHashes).Msg("failed to build Flow transaction, EVM transactions dropped")
+		t.logger.Error().Err(err).Strs("tx_hashes", txHashes).Msg("failed to build Flow transaction, EVM transactions re-queued")
 		return err
 	}
 
 	if err := t.client.SendTransaction(ctx, *flowTx); err != nil {
-		// If there was any error while sending the transaction,
-		// we record all transactions as dropped.
-		t.collector.TransactionsDropped(len(pooledTxs))
 		txHashes := make([]string, len(pooledTxs))
 		for i, tx := range pooledTxs {
 			txHashes[i] = tx.txHash.Hex()
 		}
-		t.logger.Error().Err(err).Strs("tx_hashes", txHashes).Msg("failed to send Flow transaction, EVM transactions dropped")
+		t.logger.Error().Err(err).Strs("tx_hashes", txHashes).Msg("failed to send Flow transaction, EVM transactions re-queued")
 		return err
 	}
 
@@ -506,9 +511,6 @@ func (t *BatchTxPool) submitSingleTransaction(
 		coinbaseAddress,
 	)
 	if err != nil {
-		// If there was any error during the transaction build
-		// process, we record it as a dropped transaction.
-		t.collector.TransactionsDropped(1)
 		return err
 	}
 

--- a/services/requester/batch_tx_pool_test.go
+++ b/services/requester/batch_tx_pool_test.go
@@ -1,12 +1,24 @@
 package requester
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	gethCommon "github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/onflow/flow-evm-gateway/config"
+	"github.com/onflow/flow-evm-gateway/metrics"
+	"github.com/onflow/flow-evm-gateway/models"
+	errs "github.com/onflow/flow-evm-gateway/models/errors"
+	"github.com/onflow/flow-go-sdk"
+	flowGo "github.com/onflow/flow-go/model/flow"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 func makePooledTx(nonce uint64) pooledEvmTx {
@@ -251,4 +263,185 @@ func Test_BatchTxPool_EnqueueFillsMissingNonces(t *testing.T) {
 	assert.Equal(t, uint64(1), q.txs[1].nonce)
 	assert.Equal(t, uint64(2), q.txs[2].nonce)
 	assert.Equal(t, uint64(3), q.txs[3].nonce)
+}
+
+// Test_BatchTxPool_ErrTxPoolFull asserts that `Add()` bounds the per-EOA
+// queue to a configured max number of entries.
+func Test_BatchTxPool_ErrTxPoolFull(t *testing.T) {
+	pool := &BatchTxPool{
+		SingleTxPool: &SingleTxPool{
+			logger:      zerolog.Nop(),
+			txPublisher: models.NewPublisher[*gethTypes.Transaction](),
+			collector:   metrics.NopCollector,
+		},
+		nonceProvider: &fakeNonceProvider{nonce: 0},
+		txQueues:      map[gethCommon.Address]*txQueue{},
+	}
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	for i := range maxEOAQueueSize {
+		tx := signedTestTx(t, key, uint64(i+1), 1)
+		require.NoError(t, pool.Add(context.Background(), tx))
+	}
+
+	tx := signedTestTx(t, key, uint64(maxEOAQueueSize+1), 1)
+	err = pool.Add(context.Background(), tx)
+	require.Error(t, err)
+	require.ErrorContains(t, err, errs.ErrTxPoolFull.Error())
+}
+
+// Test_BatchTxPool_SubmissionFailureNonceReservationRollback asserts that
+// a submission failure on a batch will rollback any nonce reservation, while
+// guarding any advances made by a concurrent `Add()`.
+func Test_BatchTxPool_SubmissionFailureNonceReservationRollback(t *testing.T) {
+	pool := &BatchTxPool{
+		SingleTxPool: &SingleTxPool{
+			logger:      zerolog.Nop(),
+			txPublisher: models.NewPublisher[*gethTypes.Transaction](),
+			collector:   metrics.NopCollector,
+			config: config.Config{
+				TxBatchMode:     true,
+				TxBatchInterval: time.Second,
+				FlowNetworkID:   flowGo.Emulator,
+			},
+		},
+		nonceProvider: &fakeNonceProvider{nonce: 2},
+		txQueues:      map[gethCommon.Address]*txQueue{},
+	}
+	pool.submitBatch = func(
+		ctx context.Context,
+		block *flow.BlockHeader,
+		txs []pooledEvmTx,
+	) (flow.Identifier, error) {
+		return flow.Identifier{}, fmt.Errorf("failed to submit batch Flow transaction")
+	}
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	pool.eoaEnqueueTxs(addr, []pooledEvmTx{
+		makePooledTx(2),
+		makePooledTx(3),
+		makePooledTx(4),
+	})
+
+	q := pool.eoaQueueEntry(addr)
+	assert.Len(t, q.txs, 3)
+	lastSubmittedAt := time.Now()
+	lastSubmittedNonce := uint64(1)
+	q.lastSubmittedAt = lastSubmittedAt
+	q.lastSubmittedNonce = lastSubmittedNonce
+	assert.Equal(t, uint64(2), q.txs[2].nonce)
+	assert.Equal(t, uint64(3), q.txs[3].nonce)
+	assert.Equal(t, uint64(4), q.txs[4].nonce)
+	assert.Equal(t, lastSubmittedNonce, q.lastSubmittedNonce)
+
+	ctx := context.Background()
+	submitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+
+	g := errgroup.Group{}
+	nonce := uint64(5)
+	g.Go(func() error {
+		for {
+			select {
+			case <-submitCtx.Done():
+				return nil
+			default:
+				tx := signedTestTx(t, key, nonce, 1)
+				require.NoError(t, pool.Add(context.Background(), tx))
+				nonce += 1
+				time.Sleep(time.Millisecond * 500)
+			}
+		}
+	})
+
+	pool.processPooledTransactions(submitCtx)
+
+	cancel()
+	err = g.Wait()
+	require.NoError(t, err)
+
+	assert.Equal(t, lastSubmittedAt, q.lastSubmittedAt)
+	assert.Equal(t, lastSubmittedNonce, q.lastSubmittedNonce)
+}
+
+// Test_BatchTxPool_SubmissionSuccessNonRegressionMerge asserts that on successful
+// batch submission, we perform non-regression merge, to account for any advances
+// by concurrent `Add()`.
+func Test_BatchTxPool_SubmissionSuccessNonRegressionMerge(t *testing.T) {
+	pool := &BatchTxPool{
+		SingleTxPool: &SingleTxPool{
+			logger:      zerolog.Nop(),
+			txPublisher: models.NewPublisher[*gethTypes.Transaction](),
+			collector:   metrics.NopCollector,
+			config: config.Config{
+				TxBatchMode:     true,
+				TxBatchInterval: time.Second,
+				FlowNetworkID:   flowGo.Emulator,
+			},
+		},
+		nonceProvider: &fakeNonceProvider{nonce: 2},
+		txQueues:      map[gethCommon.Address]*txQueue{},
+	}
+	pool.submitBatch = func(
+		ctx context.Context,
+		block *flow.BlockHeader,
+		txs []pooledEvmTx,
+	) (flow.Identifier, error) {
+		return flow.HexToID(
+			"2222222222222222222222222222222222222222222222222222222222222222",
+		), nil
+	}
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	pool.eoaEnqueueTxs(addr, []pooledEvmTx{
+		makePooledTx(2),
+		makePooledTx(3),
+		makePooledTx(4),
+	})
+
+	q := pool.eoaQueueEntry(addr)
+	assert.Len(t, q.txs, 3)
+	lastSubmittedAt := time.Now()
+	lastSubmittedNonce := uint64(1)
+	q.lastSubmittedAt = lastSubmittedAt
+	q.lastSubmittedNonce = lastSubmittedNonce
+	assert.Equal(t, uint64(2), q.txs[2].nonce)
+	assert.Equal(t, uint64(3), q.txs[3].nonce)
+	assert.Equal(t, uint64(4), q.txs[4].nonce)
+	assert.Equal(t, lastSubmittedNonce, q.lastSubmittedNonce)
+
+	ctx := context.Background()
+	submitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+
+	g := errgroup.Group{}
+	nonce := uint64(5)
+	g.Go(func() error {
+		for {
+			select {
+			case <-submitCtx.Done():
+				return nil
+			default:
+				tx := signedTestTx(t, key, nonce, 1)
+				require.NoError(t, pool.Add(context.Background(), tx))
+				nonce += 1
+				time.Sleep(time.Millisecond * 500)
+			}
+		}
+	})
+
+	pool.processPooledTransactions(submitCtx)
+
+	cancel()
+	err = g.Wait()
+	require.NoError(t, err)
+
+	assert.Greater(t, q.lastSubmittedAt, lastSubmittedAt)
+	assert.Greater(t, q.lastSubmittedNonce, lastSubmittedNonce)
 }

--- a/services/requester/batch_tx_pool_test.go
+++ b/services/requester/batch_tx_pool_test.go
@@ -63,23 +63,42 @@ func Test_TxQueue_StaleEntry(t *testing.T) {
 	})
 }
 
-func Test_TxQueue_ValidNonce(t *testing.T) {
+func Test_TxQueue_FastPathAvailable(t *testing.T) {
+	now := time.Now()
+	spacing := 2 * time.Second
+
 	t.Run("matches state nonce", func(t *testing.T) {
 		q := &txQueue{}
-		assert.True(t, q.validNonce(5, 5))
+		reason, available := q.fastPathAvailable(now, spacing, 5, 5)
+		assert.True(t, available)
+		assert.Equal(t, fastPathStateNonce, reason)
 	})
 
-	t.Run("matches lastSubmittedNonce+1 when there is prior activity", func(t *testing.T) {
+	t.Run("matches lastSubmittedNonce+1 when there is prior activity with elapsed spacing", func(t *testing.T) {
+		q := &txQueue{
+			lastSubmittedNonce: 5,
+			lastSubmittedAt:    now.Add(-2 * spacing),
+		}
+		reason, available := q.fastPathAvailable(now, spacing, 6, 4)
+		assert.True(t, available)
+		assert.Equal(t, fastPathInFlightNonce, reason)
+	})
+
+	t.Run("does not match lastSubmittedNonce+1 without elapsed spacing", func(t *testing.T) {
 		q := &txQueue{
 			lastSubmittedNonce: 5,
 			lastSubmittedAt:    time.Now(),
 		}
-		assert.True(t, q.validNonce(6, 4))
+		reason, available := q.fastPathAvailable(now, spacing, 6, 4)
+		assert.False(t, available)
+		assert.Equal(t, fastPathNoSpacing, reason)
 	})
 
 	t.Run("lastSubmittedNonce+1 without prior activity is rejected", func(t *testing.T) {
 		q := &txQueue{lastSubmittedNonce: 0}
-		assert.False(t, q.validNonce(1, 4))
+		reason, available := q.fastPathAvailable(now, spacing, 1, 4)
+		assert.False(t, available)
+		assert.Equal(t, fastPathNoAvailability, reason)
 	})
 
 	t.Run("arbitrary future nonce is rejected", func(t *testing.T) {
@@ -87,7 +106,9 @@ func Test_TxQueue_ValidNonce(t *testing.T) {
 			lastSubmittedNonce: 5,
 			lastSubmittedAt:    time.Now(),
 		}
-		assert.False(t, q.validNonce(9, 5))
+		reason, available := q.fastPathAvailable(now, spacing, 9, 5)
+		assert.False(t, available)
+		assert.Equal(t, fastPathNoSpacing, reason)
 	})
 }
 

--- a/services/requester/batch_tx_pool_test.go
+++ b/services/requester/batch_tx_pool_test.go
@@ -11,8 +11,9 @@ import (
 
 func makePooledTx(nonce uint64) pooledEvmTx {
 	return pooledEvmTx{
-		txHash: gethCommon.BytesToHash([]byte{byte(nonce)}),
-		nonce:  nonce,
+		txHash:     gethCommon.BytesToHash([]byte{byte(nonce)}),
+		nonce:      nonce,
+		enqueuedAt: time.Now(),
 	}
 }
 
@@ -167,6 +168,23 @@ func Test_TxQueue_PruneTxs(t *testing.T) {
 		assert.True(t, hasEdge, "nonce exactly at the cap boundary must be retained")
 		assert.False(t, hasOver)
 		assert.False(t, hasFar)
+	})
+
+	t.Run("drops nonces exceeding queue TTL", func(t *testing.T) {
+		q := &txQueue{txs: map[uint64]pooledEvmTx{
+			2: makePooledTx(2),
+			3: makePooledTx(3),
+		}}
+		tx4 := makePooledTx(4)
+		tx4.enqueuedAt = time.Now().Add(-(maxQueueTTL * 2))
+		q.txs[4] = tx4
+		q.pruneTxs(addr, 1, zerolog.Nop())
+		_, has2 := q.txs[2]
+		_, has3 := q.txs[3]
+		_, has4 := q.txs[4]
+		assert.True(t, has2)
+		assert.True(t, has3)
+		assert.False(t, has4)
 	})
 }
 

--- a/services/requester/batch_tx_pool_test.go
+++ b/services/requester/batch_tx_pool_test.go
@@ -1,0 +1,236 @@
+package requester
+
+import (
+	"testing"
+	"time"
+
+	gethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func makePooledTx(nonce uint64) pooledEvmTx {
+	return pooledEvmTx{
+		txHash: gethCommon.BytesToHash([]byte{byte(nonce)}),
+		nonce:  nonce,
+	}
+}
+
+func Test_TxQueue_StaleEntry(t *testing.T) {
+	now := time.Now()
+	spacing := time.Second
+
+	t.Run("zero-value lastSubmittedAt is not stale", func(t *testing.T) {
+		q := &txQueue{txs: map[uint64]pooledEvmTx{}}
+		assert.False(t, q.staleEntry(now, spacing))
+	})
+
+	t.Run("non-empty queue is not stale", func(t *testing.T) {
+		q := &txQueue{
+			txs:             map[uint64]pooledEvmTx{5: makePooledTx(5)},
+			lastSubmittedAt: now.Add(-time.Hour),
+		}
+		assert.False(t, q.staleEntry(now, spacing))
+	})
+
+	t.Run("empty and recently submitted is not stale", func(t *testing.T) {
+		q := &txQueue{
+			txs:             map[uint64]pooledEvmTx{},
+			lastSubmittedAt: now.Add(-spacing),
+		}
+		assert.False(t, q.staleEntry(now, spacing))
+	})
+
+	t.Run("empty and past 2x spacing is stale", func(t *testing.T) {
+		q := &txQueue{
+			txs:             map[uint64]pooledEvmTx{},
+			lastSubmittedAt: now.Add(-2 * spacing),
+		}
+		assert.True(t, q.staleEntry(now, spacing))
+	})
+}
+
+func Test_TxQueue_ValidNonce(t *testing.T) {
+	t.Run("matches state nonce", func(t *testing.T) {
+		q := &txQueue{}
+		assert.True(t, q.validNonce(5, 5))
+	})
+
+	t.Run("matches lastSubmittedNonce+1 when there is prior activity", func(t *testing.T) {
+		q := &txQueue{
+			lastSubmittedNonce: 5,
+			lastSubmittedAt:    time.Now(),
+		}
+		assert.True(t, q.validNonce(6, 4))
+	})
+
+	t.Run("lastSubmittedNonce+1 without prior activity is rejected", func(t *testing.T) {
+		q := &txQueue{lastSubmittedNonce: 0}
+		assert.False(t, q.validNonce(1, 4))
+	})
+
+	t.Run("arbitrary future nonce is rejected", func(t *testing.T) {
+		q := &txQueue{
+			lastSubmittedNonce: 5,
+			lastSubmittedAt:    time.Now(),
+		}
+		assert.False(t, q.validNonce(9, 5))
+	})
+}
+
+func Test_TxQueue_SelectSequentialNonces(t *testing.T) {
+	t.Run("empty queue returns empty batch", func(t *testing.T) {
+		q := &txQueue{txs: map[uint64]pooledEvmTx{}}
+		assert.Empty(t, q.selectSequentialNonces(0))
+	})
+
+	t.Run("gap at head returns empty batch and preserves queue", func(t *testing.T) {
+		q := &txQueue{txs: map[uint64]pooledEvmTx{
+			5: makePooledTx(5),
+			6: makePooledTx(6),
+		}}
+		assert.Empty(t, q.selectSequentialNonces(3))
+		assert.Len(t, q.txs, 2, "queue must be untouched when head gap blocks selection")
+	})
+
+	t.Run("full consecutive run from stateNonce", func(t *testing.T) {
+		q := &txQueue{txs: map[uint64]pooledEvmTx{
+			3: makePooledTx(3),
+			4: makePooledTx(4),
+			5: makePooledTx(5),
+		}}
+		batch := q.selectSequentialNonces(3)
+		assert.Len(t, batch, 3)
+		assert.Equal(t, uint64(3), batch[0].nonce)
+		assert.Equal(t, uint64(5), batch[2].nonce)
+		assert.Empty(t, q.txs, "selected txs must be removed from the queue")
+	})
+
+	t.Run("stops at first gap and leaves post-gap txs in queue", func(t *testing.T) {
+		q := &txQueue{txs: map[uint64]pooledEvmTx{
+			1: makePooledTx(1),
+			2: makePooledTx(2),
+			4: makePooledTx(4),
+			5: makePooledTx(5),
+		}}
+		batch := q.selectSequentialNonces(1)
+		assert.Len(t, batch, 2)
+		assert.Equal(t, uint64(1), batch[0].nonce)
+		assert.Equal(t, uint64(2), batch[1].nonce)
+		_, has4 := q.txs[4]
+		_, has5 := q.txs[5]
+		assert.True(t, has4)
+		assert.True(t, has5)
+	})
+
+	t.Run("caps at maxTxBatch", func(t *testing.T) {
+		q := &txQueue{txs: map[uint64]pooledEvmTx{}}
+		for n := uint64(0); n < 10; n++ {
+			q.txs[n] = makePooledTx(n)
+		}
+		batch := q.selectSequentialNonces(0)
+		assert.Len(t, batch, maxTxBatch)
+		assert.Equal(t, uint64(maxTxBatch-1), batch[maxTxBatch-1].nonce)
+		assert.Len(t, q.txs, 10-maxTxBatch, "unselected txs remain in queue")
+	})
+}
+
+func Test_TxQueue_PruneTxs(t *testing.T) {
+	addr := gethCommon.HexToAddress("0x1")
+
+	t.Run("drops nonces below state nonce", func(t *testing.T) {
+		q := &txQueue{txs: map[uint64]pooledEvmTx{
+			2: makePooledTx(2),
+			3: makePooledTx(3),
+			5: makePooledTx(5),
+		}}
+		q.pruneTxs(addr, 4, zerolog.Nop())
+		_, has2 := q.txs[2]
+		_, has3 := q.txs[3]
+		_, has5 := q.txs[5]
+		assert.False(t, has2)
+		assert.False(t, has3)
+		assert.True(t, has5)
+	})
+
+	t.Run("drops nonces past the lookahead cap", func(t *testing.T) {
+		q := &txQueue{txs: map[uint64]pooledEvmTx{
+			10:                            makePooledTx(10),
+			10 + maxNonceLookahead:        makePooledTx(10 + maxNonceLookahead),
+			10 + maxNonceLookahead + 1:    makePooledTx(10 + maxNonceLookahead + 1),
+			10 + maxNonceLookahead + 1000: makePooledTx(10 + maxNonceLookahead + 1000),
+		}}
+		q.pruneTxs(addr, 10, zerolog.Nop())
+		_, hasEdge := q.txs[10+maxNonceLookahead]
+		_, hasOver := q.txs[10+maxNonceLookahead+1]
+		_, hasFar := q.txs[10+maxNonceLookahead+1000]
+		assert.True(t, hasEdge, "nonce exactly at the cap boundary must be retained")
+		assert.False(t, hasOver)
+		assert.False(t, hasFar)
+	})
+}
+
+func Test_TxQueue_SpacingElapsed(t *testing.T) {
+	now := time.Now()
+	spacing := 2 * time.Second
+
+	t.Run("zero-value lastSubmittedAt always elapsed", func(t *testing.T) {
+		q := &txQueue{}
+		assert.True(t, q.spacingElapsed(now, spacing))
+	})
+
+	t.Run("within spacing not elapsed", func(t *testing.T) {
+		q := &txQueue{lastSubmittedAt: now.Add(-time.Second)}
+		assert.False(t, q.spacingElapsed(now, spacing))
+	})
+
+	t.Run("at exact spacing is elapsed", func(t *testing.T) {
+		q := &txQueue{lastSubmittedAt: now.Add(-spacing)}
+		assert.True(t, q.spacingElapsed(now, spacing))
+	})
+}
+
+// Test_BatchTxPool_EnqueuePreservesFresh asserts the rollback path never
+// clobbers a same-nonce entry that a concurrent Add() may have parked while
+// the flush loop was off-lock: last-write-wins must remain intact.
+func Test_BatchTxPool_EnqueuePreservesFresh(t *testing.T) {
+	pool := &BatchTxPool{
+		txQueues: map[gethCommon.Address]*txQueue{},
+	}
+	addr := gethCommon.HexToAddress("0xabc")
+
+	fresh := makePooledTx(3)
+	fresh.txHash = gethCommon.BytesToHash([]byte("fresh"))
+
+	q := pool.eoaQueueEntry(addr)
+	q.txs[3] = fresh
+
+	stale := makePooledTx(3)
+	stale.txHash = gethCommon.BytesToHash([]byte("stale"))
+	pool.eoaEnqueueTxs(addr, []pooledEvmTx{stale})
+
+	assert.Equal(t, fresh.txHash, q.txs[3].txHash,
+		"eoaEnqueueTxs must not overwrite a fresh same-nonce entry")
+}
+
+// Test_BatchTxPool_EnqueueFillsMissingNonces asserts that on rollback we do
+// re-queue nonces the queue no longer holds — the retry path exists precisely
+// so a failed batch is picked up on the next tick.
+func Test_BatchTxPool_EnqueueFillsMissingNonces(t *testing.T) {
+	pool := &BatchTxPool{
+		txQueues: map[gethCommon.Address]*txQueue{},
+	}
+	addr := gethCommon.HexToAddress("0xabc")
+
+	pool.eoaEnqueueTxs(addr, []pooledEvmTx{
+		makePooledTx(1),
+		makePooledTx(2),
+		makePooledTx(3),
+	})
+
+	q := pool.eoaQueueEntry(addr)
+	assert.Len(t, q.txs, 3)
+	assert.Equal(t, uint64(1), q.txs[1].nonce)
+	assert.Equal(t, uint64(2), q.txs[2].nonce)
+	assert.Equal(t, uint64(3), q.txs[3].nonce)
+}

--- a/services/requester/batch_tx_pool_test.go
+++ b/services/requester/batch_tx_pool_test.go
@@ -237,7 +237,12 @@ func Test_BatchTxPool_EnqueuePreservesFresh(t *testing.T) {
 
 	stale := makePooledTx(3)
 	stale.txHash = gethCommon.BytesToHash([]byte("stale"))
-	pool.eoaEnqueueTxs(addr, []pooledEvmTx{stale})
+	pool.eoaEnqueueTxs(
+		addr,
+		batchSubmission{
+			txs: []pooledEvmTx{stale},
+		},
+	)
 
 	assert.Equal(t, fresh.txHash, q.txs[3].txHash,
 		"eoaEnqueueTxs must not overwrite a fresh same-nonce entry")
@@ -252,11 +257,15 @@ func Test_BatchTxPool_EnqueueFillsMissingNonces(t *testing.T) {
 	}
 	addr := gethCommon.HexToAddress("0xabc")
 
-	pool.eoaEnqueueTxs(addr, []pooledEvmTx{
-		makePooledTx(1),
-		makePooledTx(2),
-		makePooledTx(3),
-	})
+	pool.eoaEnqueueTxs(addr,
+		batchSubmission{
+			txs: []pooledEvmTx{
+				makePooledTx(1),
+				makePooledTx(2),
+				makePooledTx(3),
+			},
+		},
+	)
 
 	q := pool.eoaQueueEntry(addr)
 	assert.Len(t, q.txs, 3)
@@ -322,11 +331,15 @@ func Test_BatchTxPool_SubmissionFailureNonceReservationRollback(t *testing.T) {
 	require.NoError(t, err)
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 
-	pool.eoaEnqueueTxs(addr, []pooledEvmTx{
-		makePooledTx(2),
-		makePooledTx(3),
-		makePooledTx(4),
-	})
+	pool.eoaEnqueueTxs(addr,
+		batchSubmission{
+			txs: []pooledEvmTx{
+				makePooledTx(2),
+				makePooledTx(3),
+				makePooledTx(4),
+			},
+		},
+	)
 
 	q := pool.eoaQueueEntry(addr)
 	assert.Len(t, q.txs, 3)
@@ -400,11 +413,15 @@ func Test_BatchTxPool_SubmissionSuccessNonRegressionMerge(t *testing.T) {
 	require.NoError(t, err)
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 
-	pool.eoaEnqueueTxs(addr, []pooledEvmTx{
-		makePooledTx(2),
-		makePooledTx(3),
-		makePooledTx(4),
-	})
+	pool.eoaEnqueueTxs(addr,
+		batchSubmission{
+			txs: []pooledEvmTx{
+				makePooledTx(2),
+				makePooledTx(3),
+				makePooledTx(4),
+			},
+		},
+	)
 
 	q := pool.eoaQueueEntry(addr)
 	assert.Len(t, q.txs, 3)

--- a/services/requester/batch_tx_pool_test.go
+++ b/services/requester/batch_tx_pool_test.go
@@ -54,10 +54,10 @@ func Test_TxQueue_StaleEntry(t *testing.T) {
 		assert.False(t, q.staleEntry(now, spacing))
 	})
 
-	t.Run("empty and past 2x spacing is stale", func(t *testing.T) {
+	t.Run("empty and past spacing*stalenessFactor is stale", func(t *testing.T) {
 		q := &txQueue{
 			txs:             map[uint64]pooledEvmTx{},
-			lastSubmittedAt: now.Add(-2 * spacing),
+			lastSubmittedAt: now.Add(spacing * -stalenessFactor),
 		}
 		assert.True(t, q.staleEntry(now, spacing))
 	})

--- a/services/requester/batch_tx_pool_test.go
+++ b/services/requester/batch_tx_pool_test.go
@@ -20,9 +20,9 @@ func Test_TxQueue_StaleEntry(t *testing.T) {
 	now := time.Now()
 	spacing := time.Second
 
-	t.Run("zero-value lastSubmittedAt is not stale", func(t *testing.T) {
+	t.Run("zero-value lastSubmittedAt is stale", func(t *testing.T) {
 		q := &txQueue{txs: map[uint64]pooledEvmTx{}}
-		assert.False(t, q.staleEntry(now, spacing))
+		assert.True(t, q.staleEntry(now, spacing))
 	})
 
 	t.Run("non-empty queue is not stale", func(t *testing.T) {

--- a/tests/tx_batching_test.go
+++ b/tests/tx_batching_test.go
@@ -245,10 +245,9 @@ func Test_BatchTxPool_GapHoldAndFill(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Sleep past the collection window (300ms) and the submission spacing
-	// (1200ms), but well within the pool TTL (5s): the held transactions
-	// must NOT have been submitted.
-	time.Sleep(2500 * time.Millisecond)
+	// Sleep past two flush ticks: the held transactions must NOT have
+	// been submitted, because nonce 2 is missing.
+	time.Sleep(2 * cfg.TxBatchInterval)
 
 	balance, err := rpcTester.getBalance(testEoaReceiver)
 	require.NoError(t, err)
@@ -962,10 +961,10 @@ func setupGatewayNode(t *testing.T) (emulator.Emulator, config.Config, func()) {
 		require.NoError(t, err)
 	}()
 
+	<-bootstrapDone
+
 	// Allow the Gateway to catch up on indexing
 	time.Sleep(time.Second * 2)
-
-	<-bootstrapDone
 
 	return emu, cfg, func() {
 		cancel()

--- a/tests/tx_batching_test.go
+++ b/tests/tx_batching_test.go
@@ -572,6 +572,68 @@ func Test_BatchTxPool_InFlightNonceRejection(t *testing.T) {
 	}, time.Second*15, time.Second*1, "first transaction was not executed")
 }
 
+// Test_BatchTxPool_WedgeRecovery reproduces the wedge state described in
+// https://github.com/onflow/flow-evm-gateway/issues/983#issuecomment-5112498568
+// (a Cadence wrapper reverts before advancing on-chain state, leaving the
+// pool's in-flight marker ahead of state) and asserts that the pool's
+// staleEntry eviction clears the wedge within TxBatchInterval*stalenessFactor.
+//
+// Auto-mine is disabled so on-chain state stays at nonce 0 for the whole
+// test. Without that, validateTransactionWithState (requester.go) would
+// preempt the pool's in-flight check with ErrNonceTooLow as soon as tx1
+// mined, masking the pool's eviction timing entirely. This is the reason
+// the equivalent scenario cannot be reproduced on testnet — state
+// validation catches up in ~1–3s regardless of pool behavior.
+func Test_BatchTxPool_WedgeRecovery(t *testing.T) {
+	emu, cfg, stop := setupGatewayNode(t)
+	defer stop()
+
+	rpcTester := &rpcTest{
+		url: fmt.Sprintf("%s:%d", cfg.RPCHost, cfg.RPCPort),
+	}
+
+	testAddr := common.HexToAddress("0x061B63D29332e4de81bD9F51A48609824CD113a8")
+	privateKey, err := crypto.HexToECDSA("ddcb1e965557474fd13de3a66a40e4bc9b759a306e5db1046bac5ca47aafd584")
+	require.NoError(t, err)
+
+	fundEOA(t, rpcTester, testAddr)
+
+	testEoaReceiver := common.HexToAddress("0x6F416dcC9BEFe43b7dDF53f2662F76dD34A9fc11")
+
+	// Three DIFFERENT transfers (distinct values → distinct hashes) all
+	// carrying the same nonce 0.
+	signedFirst, _, err := evmSign(big.NewInt(50_000), 205_000, privateKey, 0, &testEoaReceiver, nil)
+	require.NoError(t, err)
+	signedSecond, _, err := evmSign(big.NewInt(60_000), 23_500, privateKey, 0, &testEoaReceiver, nil)
+	require.NoError(t, err)
+	signedThird, _, err := evmSign(big.NewInt(70_000), 23_500, privateKey, 0, &testEoaReceiver, nil)
+	require.NoError(t, err)
+
+	// Freeze on-chain state so the pool's in-flight marker is the only gate.
+	emu.DisableAutoMine()
+
+	// tx1 fast-paths: pool sets lastSubmittedNonce = 0.
+	_, err = rpcTester.sendRawTx(signedFirst)
+	require.NoError(t, err)
+
+	// tx2 at the same nonce is rejected — the wedge state.
+	_, err = rpcTester.sendRawTx(signedSecond)
+	require.Error(t, err)
+	require.ErrorContains(t, err, errs.ErrInFlightNonce.Error())
+
+	// stalenessFactor is 4 (see services/requester/batch_tx_pool.go). With
+	// TxBatchInterval = 2.5s the eviction window is 10s. Add a cushion for
+	// the 1s flush ticker.
+	const stalenessFactor = 4
+	time.Sleep(cfg.TxBatchInterval*stalenessFactor + 2*time.Second)
+
+	// tx3 at the same nonce again: the queue was evicted (empty + past the
+	// window), so Add sees a fresh queue with lastSubmittedAt.IsZero(). The
+	// in-flight check short-circuits and the fast path submits.
+	_, err = rpcTester.sendRawTx(signedThird)
+	require.NoError(t, err, "wedge did not clear after staleEntry window")
+}
+
 func Test_TransactionBatchingMode(t *testing.T) {
 	_, cfg, stop := setupGatewayNode(t)
 	defer stop()

--- a/tests/tx_batching_test.go
+++ b/tests/tx_batching_test.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand/v2"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/onflow/cadence"
+	jsonCdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow-emulator/emulator"
 	"github.com/onflow/flow-go-sdk/access/grpc"
 	"github.com/onflow/flow-go/fvm/evm/types"
@@ -21,6 +24,401 @@ import (
 	"github.com/onflow/flow-evm-gateway/bootstrap"
 	"github.com/onflow/flow-evm-gateway/config"
 )
+
+// Test_BatchTxPool_OutOfOrderBurst is the DFNS regression scenario:
+// a burst of transactions from a single EOA, arriving out of nonce order,
+// must all be executed exactly once - no drops, no duplicates.
+func Test_BatchTxPool_OutOfOrderBurst(t *testing.T) {
+	emu, cfg, stop := setupGatewayNode(t)
+	defer stop()
+
+	rpcTester := &rpcTest{
+		url: fmt.Sprintf("%s:%d", cfg.RPCHost, cfg.RPCPort),
+	}
+
+	testAddr := common.HexToAddress("0x061B63D29332e4de81bD9F51A48609824CD113a8")
+	privateKey, err := crypto.HexToECDSA("ddcb1e965557474fd13de3a66a40e4bc9b759a306e5db1046bac5ca47aafd584")
+	require.NoError(t, err)
+
+	fundEOA(t, rpcTester, testAddr)
+
+	testEoaReceiver := common.HexToAddress("0x6F416dcC9BEFe43b7dDF53f2662F76dD34A9fc11")
+
+	totalTxs := 10
+	transferAmount := int64(50_000)
+
+	// Sign 10 transfers with nonces 0..9.
+	signedTxs := make([][]byte, totalTxs)
+	for nonce := range totalTxs {
+		signed, _, err := evmSign(
+			big.NewInt(transferAmount),
+			205_000,
+			privateKey,
+			uint64(nonce),
+			&testEoaReceiver,
+			nil,
+		)
+		require.NoError(t, err)
+		signedTxs[nonce] = signed
+	}
+
+	startBlock, err := emu.GetLatestBlock()
+	require.NoError(t, err)
+
+	// Send them concurrently in shuffled nonce order.
+	// All sends must be accepted by the pool without errors.
+	shuffledNonces := []int{6, 2, 8, 0, 1, 9, 3, 5, 4, 7}
+	g := errgroup.Group{}
+	for _, nonce := range shuffledNonces {
+		signed := signedTxs[nonce]
+		g.Go(func() error {
+			_, err := rpcTester.sendRawTx(signed)
+			return err
+		})
+	}
+
+	err = g.Wait()
+	require.NoError(t, err)
+
+	expectedBalance := int64(totalTxs) * transferAmount
+
+	assert.Eventually(t, func() bool {
+		balance, err := rpcTester.getBalance(testEoaReceiver)
+		require.NoError(t, err)
+
+		return balance.Cmp(big.NewInt(expectedBalance)) == 0
+	}, time.Second*30, time.Second*1, "all transactions were not executed")
+
+	endBlock, err := emu.GetLatestBlock()
+	require.NoError(t, err)
+
+	blockEvents, err := emu.GetEventsForHeightRange(
+		"A.f8d6e0586b0a20c7.EVM.TransactionExecuted",
+		startBlock.Height+1,
+		endBlock.Height,
+	)
+	require.NoError(t, err)
+
+	totalEVMEvents := 0
+	for _, blockEvent := range blockEvents {
+		totalEVMEvents += len(blockEvent.Events)
+	}
+
+	// Exactly 10 EVM transactions executed: no drops, no duplicates.
+	assert.Equal(t, totalTxs, totalEVMEvents)
+}
+
+// Test_BatchTxPool_SingleTxImmediateSubmission asserts the fast path:
+// a transaction with the expected next nonce, an empty queue and nothing
+// in flight is submitted immediately as a single-tx batch, which takes
+// the `EVM.run` path of the run.cdc script.
+func Test_BatchTxPool_SingleTxImmediateSubmission(t *testing.T) {
+	emu, cfg, stop := setupGatewayNode(t)
+	defer stop()
+
+	rpcTester := &rpcTest{
+		url: fmt.Sprintf("%s:%d", cfg.RPCHost, cfg.RPCPort),
+	}
+
+	testAddr := common.HexToAddress("0x061B63D29332e4de81bD9F51A48609824CD113a8")
+	privateKey, err := crypto.HexToECDSA("ddcb1e965557474fd13de3a66a40e4bc9b759a306e5db1046bac5ca47aafd584")
+	require.NoError(t, err)
+
+	fundEOA(t, rpcTester, testAddr)
+
+	startBlock, err := emu.GetLatestBlock()
+	require.NoError(t, err)
+
+	testEoaReceiver := common.HexToAddress("0x6F416dcC9BEFe43b7dDF53f2662F76dD34A9fc11")
+	transferAmount := int64(50_000)
+
+	signed, _, err := evmSign(
+		big.NewInt(transferAmount),
+		205_000,
+		privateKey,
+		0,
+		&testEoaReceiver,
+		nil,
+	)
+	require.NoError(t, err)
+
+	_, err = rpcTester.sendRawTx(signed)
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		balance, err := rpcTester.getBalance(testEoaReceiver)
+		require.NoError(t, err)
+
+		return balance.Cmp(big.NewInt(transferAmount)) == 0
+	}, time.Second*15, time.Second*1, "transaction was not executed")
+
+	endBlock, err := emu.GetLatestBlock()
+	require.NoError(t, err)
+
+	// Inspect the Cadence transactions submitted by the gateway between
+	// the recorded heights. The transaction mempool always uses the run.cdc
+	// script (recognizable by its `hexEncodedTxs` parameter), which uses
+	// `EVM.run` for a single-tx array and `EVM.batchRun` for more.
+	gatewayTxs := 0
+	for height := startBlock.Height + 1; height <= endBlock.Height; height++ {
+		block, err := emu.GetBlockByHeight(height)
+		require.NoError(t, err)
+
+		txResults, err := emu.GetTransactionsByBlockID(block.ID())
+		require.NoError(t, err)
+
+		for _, txResult := range txResults {
+			script := string(txResult.Script)
+			if !strings.Contains(script, "hexEncodedTxs") {
+				continue
+			}
+			gatewayTxs++
+
+			// Decode the `hexEncodedTxs` argument and assert that the
+			// submission was a single-tx array, i.e. the `EVM.run` path.
+			require.NotEmpty(t, txResult.Arguments)
+			arg, err := jsonCdc.Decode(nil, txResult.Arguments[0])
+			require.NoError(t, err)
+
+			txsArray, ok := arg.(cadence.Array)
+			require.True(t, ok)
+			assert.Len(t, txsArray.Values, 1)
+		}
+	}
+
+	// Exactly one gateway-submitted EVM transaction.
+	assert.Equal(t, 1, gatewayTxs)
+}
+
+// Test_BatchTxPool_GapHoldAndFill asserts that transactions behind a
+// nonce gap are held until the gap is filled, and that filling the gap
+// releases the whole consecutive run.
+func Test_BatchTxPool_GapHoldAndFill(t *testing.T) {
+	_, cfg, stop := setupGatewayNode(t)
+	defer stop()
+
+	rpcTester := &rpcTest{
+		url: fmt.Sprintf("%s:%d", cfg.RPCHost, cfg.RPCPort),
+	}
+
+	testAddr := common.HexToAddress("0x061B63D29332e4de81bD9F51A48609824CD113a8")
+	privateKey, err := crypto.HexToECDSA("ddcb1e965557474fd13de3a66a40e4bc9b759a306e5db1046bac5ca47aafd584")
+	require.NoError(t, err)
+
+	fundEOA(t, rpcTester, testAddr)
+
+	testEoaReceiver := common.HexToAddress("0x6F416dcC9BEFe43b7dDF53f2662F76dD34A9fc11")
+	transferAmount := int64(50_000)
+
+	// Sign 5 transfers with nonces 0..4.
+	signedTxs := make([][]byte, 5)
+	for nonce := range 5 {
+		signed, _, err := evmSign(
+			big.NewInt(transferAmount),
+			205_000,
+			privateKey,
+			uint64(nonce),
+			&testEoaReceiver,
+			nil,
+		)
+		require.NoError(t, err)
+		signedTxs[nonce] = signed
+	}
+
+	// Send nonces 0 and 1, wait until both are executed.
+	for _, nonce := range []int{0, 1} {
+		_, err := rpcTester.sendRawTx(signedTxs[nonce])
+		require.NoError(t, err)
+	}
+
+	assert.Eventually(t, func() bool {
+		balance, err := rpcTester.getBalance(testEoaReceiver)
+		require.NoError(t, err)
+
+		return balance.Cmp(big.NewInt(2*transferAmount)) == 0
+	}, time.Second*15, time.Second*1, "first two transactions were not executed")
+
+	// Send nonces 3 and 4, skipping nonce 2: they must be held behind
+	// the gap.
+	for _, nonce := range []int{3, 4} {
+		_, err := rpcTester.sendRawTx(signedTxs[nonce])
+		require.NoError(t, err)
+	}
+
+	// Sleep past the collection window (300ms) and the submission spacing
+	// (1200ms), but well within the pool TTL (5s): the held transactions
+	// must NOT have been submitted.
+	time.Sleep(2500 * time.Millisecond)
+
+	balance, err := rpcTester.getBalance(testEoaReceiver)
+	require.NoError(t, err)
+	require.Zero(
+		t,
+		balance.Cmp(big.NewInt(2*transferAmount)),
+		"transactions behind the nonce gap must be held, balance: %s", balance,
+	)
+
+	// Fill the gap with nonce 2: the whole consecutive run 2..4 is released.
+	_, err = rpcTester.sendRawTx(signedTxs[2])
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		balance, err := rpcTester.getBalance(testEoaReceiver)
+		require.NoError(t, err)
+
+		return balance.Cmp(big.NewInt(5*transferAmount)) == 0
+	}, time.Second*30, time.Second*1, "all transactions were not executed")
+}
+
+// Test_BatchTxPool_BatchSizeCap asserts that the gateway never submits a
+// Cadence transaction wrapping more EVM transactions than TxMaxBatchSize,
+// while still executing every submitted transaction exactly once.
+func Test_BatchTxPool_BatchSizeCap(t *testing.T) {
+	const maxBatchSize = 5
+	emu, cfg, stop := setupGatewayNode(t)
+	defer stop()
+
+	rpcTester := &rpcTest{
+		url: fmt.Sprintf("%s:%d", cfg.RPCHost, cfg.RPCPort),
+	}
+
+	testAddr := common.HexToAddress("0x061B63D29332e4de81bD9F51A48609824CD113a8")
+	privateKey, err := crypto.HexToECDSA("ddcb1e965557474fd13de3a66a40e4bc9b759a306e5db1046bac5ca47aafd584")
+	require.NoError(t, err)
+
+	fundEOA(t, rpcTester, testAddr)
+
+	testEoaReceiver := common.HexToAddress("0x6F416dcC9BEFe43b7dDF53f2662F76dD34A9fc11")
+
+	totalTxs := 10
+	transferAmount := int64(50_000)
+
+	// Sign 10 transfers with consecutive nonces 0..9.
+	signedTxs := make([][]byte, totalTxs)
+	for nonce := range totalTxs {
+		signed, _, err := evmSign(
+			big.NewInt(transferAmount),
+			205_000,
+			privateKey,
+			uint64(nonce),
+			&testEoaReceiver,
+			nil,
+		)
+		require.NoError(t, err)
+		signedTxs[nonce] = signed
+	}
+
+	startBlock, err := emu.GetLatestBlock()
+	require.NoError(t, err)
+
+	// Send all 10 in nonce order. The fast path may submit the first alone;
+	// the rest batch behind the collection window, capped at maxBatchSize.
+	for _, signed := range signedTxs {
+		_, err := rpcTester.sendRawTx(signed)
+		require.NoError(t, err)
+	}
+
+	expectedBalance := int64(totalTxs) * transferAmount
+	assert.Eventually(t, func() bool {
+		balance, err := rpcTester.getBalance(testEoaReceiver)
+		require.NoError(t, err)
+
+		return balance.Cmp(big.NewInt(expectedBalance)) == 0
+	}, time.Second*30, time.Second*1, "all transactions were not executed")
+
+	endBlock, err := emu.GetLatestBlock()
+	require.NoError(t, err)
+
+	// Inspect every gateway-submitted Cadence tx and count the EVM txs it
+	// wraps (the `hexEncodedTxs` array length). Assertions are intentionally
+	// robust rather than asserting an exact batch count: the fast path can
+	// submit the first tx alone and timing affects how the rest group, so the
+	// number of batches is not deterministic. What MUST hold is: every batch
+	// honors the cap, the total across batches is exactly 10 (no drops/dupes),
+	// and at least one batch carried more than one tx (proving batching via
+	// EVM.batchRun actually happened rather than 10 single submissions).
+	totalEVMTxs := 0
+	maxObservedBatch := 0
+	for height := startBlock.Height + 1; height <= endBlock.Height; height++ {
+		block, err := emu.GetBlockByHeight(height)
+		require.NoError(t, err)
+
+		txResults, err := emu.GetTransactionsByBlockID(block.ID())
+		require.NoError(t, err)
+
+		for _, txResult := range txResults {
+			if !strings.Contains(string(txResult.Script), "hexEncodedTxs") {
+				continue
+			}
+
+			require.NotEmpty(t, txResult.Arguments)
+			arg, err := jsonCdc.Decode(nil, txResult.Arguments[0])
+			require.NoError(t, err)
+
+			txsArray, ok := arg.(cadence.Array)
+			require.True(t, ok)
+
+			batchLen := len(txsArray.Values)
+			assert.LessOrEqual(t, batchLen, maxBatchSize,
+				"batch size cap of %d must be honored, got %d", maxBatchSize, batchLen)
+			totalEVMTxs += batchLen
+			if batchLen > maxObservedBatch {
+				maxObservedBatch = batchLen
+			}
+		}
+	}
+
+	assert.Equal(t, totalTxs, totalEVMTxs, "every submitted EVM tx must appear exactly once")
+	assert.Greater(t, maxObservedBatch, 1, "at least one batch must wrap more than one tx (EVM.batchRun)")
+}
+
+// Test_BatchTxPool_DuplicateTransactionRejection asserts that resending the
+// exact same raw transaction while it is still QUEUED (held behind a nonce
+// gap, not yet submitted) is rejected with ErrDuplicateTransaction.
+//
+// A fast-path-submitted tx instead becomes IN-FLIGHT, so resending it would
+// surface as ErrInFlightNonce (see Test_TxMemPool_InFlightNonceRejection).
+// To reach the duplicate path we must keep the tx queued: send an
+// out-of-order nonce so it parks behind a gap, then resend the identical
+// bytes before the gap fills.
+func Test_BatchTxPool_DuplicateTransactionRejection(t *testing.T) {
+	_, cfg, stop := setupGatewayNode(t)
+	defer stop()
+
+	rpcTester := &rpcTest{
+		url: fmt.Sprintf("%s:%d", cfg.RPCHost, cfg.RPCPort),
+	}
+
+	testAddr := common.HexToAddress("0x061B63D29332e4de81bD9F51A48609824CD113a8")
+	privateKey, err := crypto.HexToECDSA("ddcb1e965557474fd13de3a66a40e4bc9b759a306e5db1046bac5ca47aafd584")
+	require.NoError(t, err)
+
+	fundEOA(t, rpcTester, testAddr)
+
+	testEoaReceiver := common.HexToAddress("0x6F416dcC9BEFe43b7dDF53f2662F76dD34A9fc11")
+
+	// Nonce 5 while the expected nonce is 0: the tx parks behind the gap and
+	// stays queued (never fast-pathed, never in flight).
+	signed, _, err := evmSign(
+		big.NewInt(50_000),
+		205_000,
+		privateKey,
+		5,
+		&testEoaReceiver,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// First send queues the transaction.
+	_, err = rpcTester.sendRawTx(signed)
+	require.NoError(t, err)
+
+	// Resending the identical raw tx while it is still queued is rejected as
+	// a duplicate (ErrDuplicateTransaction -> "transaction already in pool").
+	_, err = rpcTester.sendRawTx(signed)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "transaction already in pool")
+}
 
 func Test_TransactionBatchingMode(t *testing.T) {
 	_, cfg, stop := setupGatewayNode(t)
@@ -514,59 +912,6 @@ func Test_MultipleTransactionSubmissionsWithinNonRecentInterval(t *testing.T) {
 	)
 }
 
-func Test_MultipleTransactionSubmissionsWithDuplicates(t *testing.T) {
-	_, cfg, stop := setupGatewayNode(t)
-	defer stop()
-
-	rpcTester := &rpcTest{
-		url: fmt.Sprintf("%s:%d", cfg.RPCHost, cfg.RPCPort),
-	}
-
-	eoaKey, err := crypto.HexToECDSA(eoaTestPrivateKey)
-	require.NoError(t, err)
-
-	testAddr := common.HexToAddress("55253ed90B70b96C73092D8680915aaF50081194")
-	nonce := uint64(0)
-	hashes := make([]common.Hash, 0)
-
-	signed, _, err := evmSign(big.NewInt(10), 205_000, eoaKey, nonce, &testAddr, nil)
-	require.NoError(t, err)
-
-	txHash, err := rpcTester.sendRawTx(signed)
-	require.NoError(t, err)
-	hashes = append(hashes, txHash)
-
-	// Increment nonce for the duplicate test transactions that follow
-	nonce += 1
-	dupSigned, _, err := evmSign(big.NewInt(10), 15_000_000, eoaKey, nonce, &testAddr, nil)
-	require.NoError(t, err)
-
-	// Submit 5 identical transactions to test duplicate detection:
-	// the first should succeed, the rest should be rejected as duplicates.
-	for i := range 5 {
-		if i == 0 {
-			txHash, err := rpcTester.sendRawTx(dupSigned)
-			require.NoError(t, err)
-			hashes = append(hashes, txHash)
-		} else {
-			_, err := rpcTester.sendRawTx(dupSigned)
-			require.Error(t, err)
-			require.ErrorContains(t, err, "invalid: transaction already in pool")
-		}
-	}
-
-	assert.Eventually(t, func() bool {
-		for _, h := range hashes {
-			rcp, err := rpcTester.getReceipt(h.String())
-			if err != nil || rcp == nil || rcp.Status != 1 {
-				return false
-			}
-		}
-
-		return true
-	}, time.Second*15, time.Second*1, "all transactions were not executed")
-}
-
 func setupGatewayNode(t *testing.T) (emulator.Emulator, config.Config, func()) {
 	srv, err := startEmulator(true)
 	require.NoError(t, err)
@@ -604,9 +949,9 @@ func setupGatewayNode(t *testing.T) (emulator.Emulator, config.Config, func()) {
 		EnforceGasPrice:   true,
 		LogLevel:          zerolog.DebugLevel,
 		LogWriter:         testLogWriter(),
-		TxStateValidation: config.TxSealValidation,
+		TxStateValidation: config.LocalIndexValidation,
 		TxBatchMode:       true,
-		TxBatchInterval:   time.Second * 2,
+		TxBatchInterval:   time.Millisecond * 2500, // 2.5 seconds, the same as mainnet,
 	}
 
 	bootstrapDone := make(chan struct{})
@@ -616,6 +961,9 @@ func setupGatewayNode(t *testing.T) (emulator.Emulator, config.Config, func()) {
 		})
 		require.NoError(t, err)
 	}()
+
+	// Allow the Gateway to catch up on indexing
+	time.Sleep(time.Second * 2)
 
 	<-bootstrapDone
 

--- a/tests/tx_batching_test.go
+++ b/tests/tx_batching_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/flow-evm-gateway/bootstrap"
 	"github.com/onflow/flow-evm-gateway/config"
+	errs "github.com/onflow/flow-evm-gateway/models/errors"
 )
 
 // Test_BatchTxPool_OutOfOrderBurst is the DFNS regression scenario:
@@ -374,12 +375,6 @@ func Test_BatchTxPool_BatchSizeCap(t *testing.T) {
 // Test_BatchTxPool_DuplicateTransactionRejection asserts that resending the
 // exact same raw transaction while it is still QUEUED (held behind a nonce
 // gap, not yet submitted) is rejected with ErrDuplicateTransaction.
-//
-// A fast-path-submitted tx instead becomes IN-FLIGHT, so resending it would
-// surface as ErrInFlightNonce (see Test_TxMemPool_InFlightNonceRejection).
-// To reach the duplicate path we must keep the tx queued: send an
-// out-of-order nonce so it parks behind a gap, then resend the identical
-// bytes before the gap fills.
 func Test_BatchTxPool_DuplicateTransactionRejection(t *testing.T) {
 	_, cfg, stop := setupGatewayNode(t)
 	defer stop()
@@ -416,7 +411,76 @@ func Test_BatchTxPool_DuplicateTransactionRejection(t *testing.T) {
 	// a duplicate (ErrDuplicateTransaction -> "transaction already in pool").
 	_, err = rpcTester.sendRawTx(signed)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "transaction already in pool")
+	require.ErrorContains(t, err, errs.ErrDuplicateTransaction.Error())
+}
+
+// Test_BatchTxPool_InFlightNonceRejection asserts that a transaction
+// carrying the same nonce as an in-flight submission is rejected, since
+// it would burn Flow fees on a guaranteed nonce-mismatch failure.
+func Test_BatchTxPool_InFlightNonceRejection(t *testing.T) {
+	emu, cfg, stop := setupGatewayNode(t)
+	defer stop()
+
+	rpcTester := &rpcTest{
+		url: fmt.Sprintf("%s:%d", cfg.RPCHost, cfg.RPCPort),
+	}
+
+	testAddr := common.HexToAddress("0x061B63D29332e4de81bD9F51A48609824CD113a8")
+	privateKey, err := crypto.HexToECDSA("ddcb1e965557474fd13de3a66a40e4bc9b759a306e5db1046bac5ca47aafd584")
+	require.NoError(t, err)
+
+	fundEOA(t, rpcTester, testAddr)
+
+	testEoaReceiver := common.HexToAddress("0x6F416dcC9BEFe43b7dDF53f2662F76dD34A9fc11")
+	transferAmount := int64(50_000)
+
+	// Sign two DIFFERENT transfers (different amounts, hence different
+	// hashes) carrying the same nonce 0.
+	signedFirst, _, err := evmSign(
+		big.NewInt(transferAmount),
+		205_000,
+		privateKey,
+		0,
+		&testEoaReceiver,
+		nil,
+	)
+	require.NoError(t, err)
+
+	signedSecond, _, err := evmSign(
+		big.NewInt(60_000),
+		23_500,
+		privateKey,
+		0,
+		&testEoaReceiver,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// disable auto-mine so we can control delays
+	emu.DisableAutoMine()
+
+	// The first transfer takes the fast path: it is submitted immediately
+	// and stays in flight until the local index confirms it.
+	_, err = rpcTester.sendRawTx(signedFirst)
+	require.NoError(t, err)
+
+	// The second transfer is sent back to back with the first one: its
+	// nonce is still in flight, so it must be rejected.
+	_, err = rpcTester.sendRawTx(signedSecond)
+	require.Error(t, err)
+	require.ErrorContains(t, err, errs.ErrInFlightNonce.Error())
+
+	// Execute and commit block, to advance EVM state
+	_, _, err = emu.ExecuteAndCommitBlock()
+	require.NoError(t, err)
+
+	// The first transfer eventually executes.
+	assert.Eventually(t, func() bool {
+		balance, err := rpcTester.getBalance(testEoaReceiver)
+		require.NoError(t, err)
+
+		return balance.Cmp(big.NewInt(transferAmount)) == 0
+	}, time.Second*15, time.Second*1, "first transaction was not executed")
 }
 
 func Test_TransactionBatchingMode(t *testing.T) {

--- a/tests/tx_batching_test.go
+++ b/tests/tx_batching_test.go
@@ -109,6 +109,95 @@ func Test_BatchTxPool_OutOfOrderBurst(t *testing.T) {
 	assert.Equal(t, totalTxs, totalEVMEvents)
 }
 
+// Test_BatchTxPool_OutOfOrderBurstSubmissionSpacingPreserved asserts that
+// a burst of out-of-order transactions with arbitrary spacing, will always
+// preserve the necessary spacing between consecutive submissions
+func Test_BatchTxPool_OutOfOrderBurstSubmissionSpacingPreserved(t *testing.T) {
+	emu, cfg, stop := setupGatewayNode(t)
+	defer stop()
+
+	rpcTester := &rpcTest{
+		url: fmt.Sprintf("%s:%d", cfg.RPCHost, cfg.RPCPort),
+	}
+
+	privateKey, err := crypto.HexToECDSA(eoaTestPrivateKey)
+	require.NoError(t, err)
+
+	testEoaReceiver := common.HexToAddress("0x6F416dcC9BEFe43b7dDF53f2662F76dD34A9fc11")
+
+	totalTxs := 10
+	transferAmount := int64(50_000)
+
+	// Sign 10 transfers with nonces 0..9.
+	signedTxs := make([][]byte, totalTxs)
+	for nonce := range totalTxs {
+		signed, _, err := evmSign(
+			big.NewInt(transferAmount),
+			205_000,
+			privateKey,
+			uint64(nonce),
+			&testEoaReceiver,
+			nil,
+		)
+		require.NoError(t, err)
+		signedTxs[nonce] = signed
+	}
+
+	startBlock, err := emu.GetLatestBlock()
+	require.NoError(t, err)
+
+	// Send them concurrently in shuffled nonce order.
+	// All sends must be accepted by the pool without errors.
+	shuffledNonces := []int{6, 2, 8, 0, 1, 9, 3, 5, 4, 7}
+	g := errgroup.Group{}
+	for _, nonce := range shuffledNonces {
+		signed := signedTxs[nonce]
+		g.Go(func() error {
+			// Add a bit of random waiting time, to simulate spacing.
+			waitTime := rand.IntN(5) * 1000
+			time.Sleep(time.Duration(waitTime) * time.Millisecond)
+			_, err := rpcTester.sendRawTx(signed)
+			return err
+		})
+	}
+
+	err = g.Wait()
+	require.NoError(t, err)
+
+	expectedBalance := int64(totalTxs) * transferAmount
+
+	assert.Eventually(t, func() bool {
+		balance, err := rpcTester.getBalance(testEoaReceiver)
+		require.NoError(t, err)
+
+		return balance.Cmp(big.NewInt(expectedBalance)) == 0
+	}, time.Second*30, time.Second*1, "all transactions were not executed")
+
+	endBlock, err := emu.GetLatestBlock()
+	require.NoError(t, err)
+
+	blockEvents, err := emu.GetEventsForHeightRange(
+		"A.f8d6e0586b0a20c7.EVM.TransactionExecuted",
+		startBlock.Height+1,
+		endBlock.Height,
+	)
+	require.NoError(t, err)
+
+	totalEVMEvents := 0
+	now := blockEvents[0].BlockTimestamp.Add(-2 * time.Second)
+	for _, blockEvent := range blockEvents {
+		totalEVMEvents += len(blockEvent.Events)
+		// Assert that each `EVM.TransactionExecuted` was included
+		// in blocks were there was enough spacing. For Emulator,
+		// blocks are created with each single Cadence transaction
+		// execution.
+		assert.GreaterOrEqual(t, blockEvent.BlockTimestamp.Sub(now), time.Second*2)
+	}
+
+	// Exactly 10 EVM transactions executed: no drops, no duplicates.
+	assert.Equal(t, totalTxs, totalEVMEvents)
+}
+
 // Test_BatchTxPool_SingleTxImmediateSubmission asserts the fast path:
 // a transaction with the expected next nonce, an empty queue and nothing
 // in flight is submitted immediately as a single-tx batch, which takes
@@ -525,7 +614,7 @@ func Test_TransactionBatchingMode(t *testing.T) {
 		}
 
 		return true
-	}, time.Second*15, time.Second*1, "all transactions were not executed")
+	}, time.Second*25, time.Second*1, "all transactions were not executed")
 }
 
 func Test_TransactionBatchingModeWithConcurrentTxSubmissions(t *testing.T) {


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-evm-gateway/issues/983

## Problem

Flow did not have a traditional EVM mempool. On standard EVM chains, when a wallet sends transactions out-of-nonce-sequence (e.g., nonces 5, 7, 6 in parallel), the mempool holds future-nonce transactions until the gap is filled. Flow EVM had no such pooling mechanism — a transaction whose nonce does not match the current account nonce is simply dropped.

The original `BatchTxPool` implementation partially addressed this by batching transactions that arrived from an EOA with "recent activity" (i.e., a prior transaction within `TxBatchInterval`, `2.5 seconds` for `mainnet`). However, it still submitted the FIRST transaction from any burst immediately — before the rest of the burst had a chance to arrive. If that first transaction happened to carry a future nonce (due to parallel dispatch), it failed, and the gap it left caused all subsequent nonces in the batch to fail as well.

## Fix

For all incoming transactions, we are now inspecting the EOA's current nonce in the local state index:
1. If it matches the transaction nonce, we submit it right away, and record this activity in the EOA's dedicated queue, for use in future submissions.
2. If the transaction nonce is higher, we check for any recent submissions to see if we can form a valid sequence. This could happen from in-flight transaction submission, that have not yet been indexed by the local state index. In this case we optimistically submit right away. and record this activity in the EOA's dedicated queue, for use in future submissions.
3. If none of the above 2 conditions are met, we enqueue the transaction in the pool. The flush timer (`TxBatchInterval`) is the sole submission trigger. This guarantees that parallel transactions from the same wallet accumulate in the pool before being sorted by nonce and submitted atomically. When we process the per-EOA pool, we read again the current nonce from the local state index, any stale transactions are pruned, we attempt to select a list of transactions with sequential nonces (up to 5 transactions max), and we submit those in a batch. On successful submission, we record this activity in the EOA's dedicated queue, for use in future submissions. When there are submission errors, e.g. due to network, we add the transactions back to the pool as a retry mechanism. This is an important part to avoid gaps, which would require users to resubmit.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved transaction batching with nonce-aware queueing.
  * Eligible transactions can be submitted immediately.
  * Out-of-order transactions are held and released when nonce gaps are filled.
  * Batches are limited to five transactions for predictable processing.
  * Duplicate and in-flight nonce transactions are rejected.
  * Submission results now include Flow transaction IDs.
  * Accounts receive a clear error when their transaction pool is full.

* **Bug Fixes**
  * Improved handling of failed submissions, stale transactions, and queue cleanup.
  * Transactions are preserved for retry when batch submission fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->