### PR TITLE
Update to Cadence v1.10.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/holiman/uint256 v1.3.2
 	github.com/onflow/atree v0.16.1
 	github.com/onflow/cadence v1.10.6
-	github.com/onflow/flow-go v0.51.0
+	github.com/onflow/flow-go v0.51.1-0.20260818190615-51d198a4e379
 	github.com/onflow/flow-go-sdk v1.10.9
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rs/cors v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.1.1 h1:BNbP3CrTIgScpx2NS9snq9XDESF
 github.com/onflow/flow-ft/lib/go/contracts v1.1.1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.1.1 h1:X+EGTWKeVlsF33JD5QBFZLr8KW2apl6Oh1AXRWHmzLI=
 github.com/onflow/flow-ft/lib/go/templates v1.1.1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.51.0 h1:fSroagQ4GGL9z4xzyCcGNtyUWjzlXPDy1HeGbCLIXAc=
-github.com/onflow/flow-go v0.51.0/go.mod h1:1PxapD+za9wUCSXg0qo+Wja4N7n5rPqnwx2Al+UovWw=
+github.com/onflow/flow-go v0.51.1-0.20260818190615-51d198a4e379 h1:bqypNhEUgaq9dNixK+m2dUXiLGN+IOteO/O1zNhAUf4=
+github.com/onflow/flow-go v0.51.1-0.20260818190615-51d198a4e379/go.mod h1:5Gjj5SIfqWCxjd82NtckWKJAJXCDni4g8flZIBCDThY=
 github.com/onflow/flow-go-sdk v1.10.9 h1:x8moEpVMy9lm35imHLM4oab4d05OZ8OxkNlz61bdl14=
 github.com/onflow/flow-go-sdk v1.10.9/go.mod h1:NfeE2ead4MKOGpr43C2JVtCIWqnJzhYiytNOsb9qmfM=
 github.com/onflow/flow-nft/lib/go/contracts v1.4.1 h1:iQ8s4W5HNWd92MVRZbKxYpQ6UJn9snHLKQ9hFFNCiys=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.10.6](https://github.com/onflow/cadence/releases/tag/v1.10.6)
- [onflow/flow-go-sdk v1.10.9](https://github.com/onflow/flow-go-sdk/releases/tag/v1.10.9)
- [onflow/flow-go 51d198a4e379](https://github.com/onflow/flow-go/commit/51d198a4e379)
- [onflow/flow-emulator v1.22.0](https://github.com/onflow/flow-emulator/releases/tag/v1.22.0)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying Flow dependency to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->